### PR TITLE
Resolve more links if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+* Resolve more links in the documentation if possible (workaround for [rust-lang/rust#101687](https://github.com/rust-lang/rust/issues/101687)]
+
 ## [0.1.0] - 2022-09-11
 
 * First release

--- a/examples/lib/README.md
+++ b/examples/lib/README.md
@@ -60,7 +60,7 @@ Intra-doc links are also supported.
 |---------|-------|-----|--------------|
 |Module|[`module`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html)|[`std::collections`](https://doc.rust-lang.org/nightly/std/collections/index.html)|[`num::bigint`](https://docs.rs/num/0.4/num/bigint/index.html)|
 |Struct|[`Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)|[`std::collections::HashMap`](https://doc.rust-lang.org/nightly/std/collections/hash/map/struct.HashMap.html)|[`num::bigint::BigInt`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html)|
-|Struct Field [^1]|\[`Struct::field`\]|\[`std::ops::Range::start`\]||
+|Struct Field [^1]|[`Struct::field`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#structfield.field)|\[`std::ops::Range::start`\]||
 |Union|[`Union`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html)|||
 |Enum|[`Enum`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html)|[`Option`](https://doc.rust-lang.org/nightly/core/option/enum.Option.html)|[`num::traits::FloatErrorKind`](https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html)|
 |Enum Variant [^2]|[`Enum::Variant`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Variant)|\[`Option::Some`\]|\[`num::traits::FloatErrorKind::Empty`\]|
@@ -68,14 +68,14 @@ Intra-doc links are also supported.
 |Typedef|[`Typedef`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.Typedef.html)|[`std::io::Result`](https://doc.rust-lang.org/nightly/std/io/error/type.Result.html)|[`num::BigRational`](https://docs.rs/num-rational/0.4/num_rational/type.BigRational.html)|
 |Constant|[`CONSTANT`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html)|[`std::path::MAIN_SEPARATOR`](https://doc.rust-lang.org/nightly/std/path/constant.MAIN_SEPARATOR.html)||
 |Trait|[`Trait`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html)|[`std::clone::Clone`](https://doc.rust-lang.org/nightly/core/clone/trait.Clone.html)|[`num::Num`](https://docs.rs/num-traits/0.2/num_traits/trait.Num.html)|
-|Method (trait) [^3]|\[`Trait::method`\]|\[`std::clone::Clone::clone`\]|\[`num::Num::from_str_radix`\]|
+|Method (trait) [^3]|[`Trait::method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.method)|\[`std::clone::Clone::clone`\]|\[`num::Num::from_str_radix`\]|
 |Method (impl) [^3]|\[`Struct::method`\]|\[`Vec::clone`\]|\[`num::bigint::BigInt::from_str_radix`\]|
 |Static|[`STATIC`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.STATIC.html)|||
 |Macro|[`macro_`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.macro_.html)|[`println`](https://doc.rust-lang.org/nightly/std/macro.println.html)||
 |Attribute Macro|||[`async_trait::async_trait`](https://docs.rs/async-trait/0.1.57/async_trait/attr.async_trait.html)|
 |Derive Macro|||[`serde::Serialize`](https://docs.rs/serde_derive/1.0.144/serde_derive/derive.Serialize.html)|
-|Associated Constant [^4]|\[`Trait::CONST`\]|\[`i32::MAX`\]||
-|Associated Type [^4]|\[`Trait::Type`\]|\[`Iterator::Item`\]||
+|Associated Constant [^4]|[`Trait::CONST`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedconstant.CONST)|\[`i32::MAX`\]||
+|Associated Type [^4]|[`Trait::Type`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedtype.Type)|\[`Iterator::Item`\]||
 |Primitive||[`i32`](https://doc.rust-lang.org/nightly/std/primitive.i32.html)||
 
 [^1]: Intra-doc links to struct fields are not supported in cargo-sync-rdme yet due to [rustdoc bug].

--- a/src/sync/contents/rustdoc/intra_link.rs
+++ b/src/sync/contents/rustdoc/intra_link.rs
@@ -1,7 +1,15 @@
-use std::{collections::HashMap, fmt::Write, rc::Rc};
+use std::{
+    borrow::Cow,
+    cmp::Reverse,
+    collections::{BinaryHeap, HashMap},
+    fmt::Write,
+    rc::Rc,
+};
 
 use pulldown_cmark::{BrokenLink, CowStr, Event, Options, Tag};
-use rustdoc_types::{Crate, Id, Item, ItemKind};
+use rustdoc_types::{
+    Crate, Id, Item, ItemEnum, ItemKind, ItemSummary, MacroKind, StructKind, Variant,
+};
 
 trait CowStrExt<'a> {
     fn as_str(&'a self) -> &'a str;
@@ -68,21 +76,201 @@ where
     }
 }
 
-fn resolve_links<'a>(
-    doc: &Crate,
-    item: &'a Item,
+fn resolve_links<'doc>(
+    doc: &'doc Crate,
+    item: &'doc Item,
     local_html_root_url: &str,
-) -> HashMap<&'a str, String> {
+) -> HashMap<&'doc str, String> {
+    let extra_paths = extra_paths(&doc.index, &doc.paths);
     item.links
         .iter()
-        .filter_map(|(name, id)| {
-            let url = id_to_url(doc, local_html_root_url, id).or_else(|| {
+        .filter_map(move |(name, id)| {
+            let url = id_to_url(doc, &extra_paths, local_html_root_url, id).or_else(|| {
                 tracing::warn!("failed to resolve link to `{}`", name);
                 None
             })?;
             Some((name.as_str(), url))
         })
         .collect()
+}
+
+#[derive(Debug)]
+struct Node<'a> {
+    depth: usize,
+    kind: ItemKind,
+    name: Option<&'a str>,
+    parent: Option<&'a Id>,
+}
+
+fn extra_paths<'doc>(
+    index: &'doc HashMap<Id, Item>,
+    paths: &'doc HashMap<Id, ItemSummary>,
+) -> HashMap<&'doc Id, Node<'doc>> {
+    let mut map: HashMap<&Id, Node<'_>> = index
+        .iter()
+        .map(|(id, item)| {
+            (
+                id,
+                Node {
+                    depth: usize::MAX,
+                    kind: item_kind(item),
+                    name: item.name.as_deref(),
+                    parent: None,
+                },
+            )
+        })
+        .collect();
+
+    #[derive(Debug)]
+    struct HeapItem<'doc> {
+        depth: Reverse<usize>,
+        id: &'doc Id,
+        parent: Option<&'doc Id>,
+        item: &'doc Item,
+    }
+
+    impl PartialOrd for HeapItem<'_> {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+    impl Ord for HeapItem<'_> {
+        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            self.depth.cmp(&other.depth)
+        }
+    }
+    impl PartialEq for HeapItem<'_> {
+        fn eq(&self, other: &Self) -> bool {
+            self.depth == other.depth
+        }
+    }
+    impl Eq for HeapItem<'_> {}
+
+    let mut heap: BinaryHeap<HeapItem<'_>> = index
+        .iter()
+        .map(|(id, item)| {
+            let depth = if paths.contains_key(id) {
+                0
+            } else {
+                usize::MAX
+            };
+            HeapItem {
+                depth: Reverse(depth),
+                id,
+                item,
+                parent: None,
+            }
+        })
+        .collect();
+
+    while let Some(HeapItem {
+        depth: Reverse(depth),
+        id,
+        parent,
+        item,
+    }) = heap.pop()
+    {
+        let node = map.get_mut(id).unwrap();
+        if depth >= node.depth {
+            continue;
+        }
+        node.parent = parent;
+
+        map.get_mut(id).unwrap().depth = depth;
+
+        for child in item_children(item).into_iter().flatten() {
+            let child = match index.get(child) {
+                Some(child) => child,
+                None => {
+                    tracing::trace!(?item, ?child, "child item missing");
+                    continue;
+                }
+            };
+            let child_depth = depth + 1;
+            heap.push(HeapItem {
+                depth: Reverse(child_depth),
+                id: &child.id,
+                item: child,
+                parent: Some(id),
+            });
+        }
+    }
+
+    map
+}
+
+fn item_kind(item: &Item) -> ItemKind {
+    match &item.inner {
+        ItemEnum::Module(_) => ItemKind::Module,
+        ItemEnum::ExternCrate { .. } => ItemKind::ExternCrate,
+        ItemEnum::Import(_) => ItemKind::Import,
+        ItemEnum::Union(_) => ItemKind::Union,
+        ItemEnum::Struct(_) => ItemKind::Struct,
+        ItemEnum::StructField(_) => ItemKind::StructField,
+        ItemEnum::Enum(_) => ItemKind::Enum,
+        ItemEnum::Variant(_) => ItemKind::Variant,
+        ItemEnum::Function(_) => ItemKind::Function,
+        ItemEnum::Trait(_) => ItemKind::Trait,
+        ItemEnum::TraitAlias(_) => ItemKind::TraitAlias,
+        ItemEnum::Method(_) => ItemKind::Method,
+        ItemEnum::Impl(_) => ItemKind::Impl,
+        ItemEnum::Typedef(_) => ItemKind::Typedef,
+        ItemEnum::OpaqueTy(_) => ItemKind::OpaqueTy,
+        ItemEnum::Constant(_) => ItemKind::Constant,
+        ItemEnum::Static(_) => ItemKind::Static,
+        ItemEnum::ForeignType => ItemKind::ForeignType,
+        ItemEnum::Macro(_) => ItemKind::Macro,
+        ItemEnum::ProcMacro(pm) => match pm.kind {
+            MacroKind::Bang => ItemKind::Macro,
+            MacroKind::Attr => ItemKind::ProcAttribute,
+            MacroKind::Derive => ItemKind::ProcDerive,
+        },
+        ItemEnum::PrimitiveType(_) => ItemKind::Primitive,
+        ItemEnum::AssocConst { .. } => ItemKind::AssocConst,
+        ItemEnum::AssocType { .. } => ItemKind::AssocType,
+    }
+}
+
+fn item_children<'doc>(parent: &'doc Item) -> Option<Box<dyn Iterator<Item = &'doc Id> + 'doc>> {
+    match &parent.inner {
+        ItemEnum::Module(m) => Some(Box::new(m.items.iter())),
+        ItemEnum::ExternCrate { .. } => None,
+        ItemEnum::Import(_) => None,
+        ItemEnum::Union(u) => Some(Box::new(u.fields.iter())),
+        ItemEnum::Struct(s) => match &s.kind {
+            StructKind::Unit => None,
+            StructKind::Tuple(t) => Some(Box::new(t.iter().flatten())),
+            StructKind::Plain {
+                fields,
+                fields_stripped: _,
+            } => Some(Box::new(fields.iter())),
+        },
+        ItemEnum::StructField(_) => None,
+        ItemEnum::Enum(e) => Some(Box::new(e.variants.iter())),
+        ItemEnum::Variant(v) => match v {
+            Variant::Plain(_) => None,
+            Variant::Tuple(t) => Some(Box::new(t.iter().flatten())),
+            Variant::Struct {
+                fields,
+                fields_stripped: _,
+            } => Some(Box::new(fields.iter())),
+        },
+        ItemEnum::Function(_) => None,
+        ItemEnum::Trait(t) => Some(Box::new(t.items.iter())),
+        ItemEnum::TraitAlias(_) => None,
+        ItemEnum::Method(_) => None,
+        ItemEnum::Impl(i) => Some(Box::new(i.items.iter())),
+        ItemEnum::Typedef(_) => None,
+        ItemEnum::OpaqueTy(_) => None,
+        ItemEnum::Constant(_) => None,
+        ItemEnum::Static(_) => None,
+        ItemEnum::ForeignType => None,
+        ItemEnum::Macro(_) => None,
+        ItemEnum::ProcMacro(_) => None,
+        ItemEnum::PrimitiveType(_) => None,
+        ItemEnum::AssocConst { .. } => None,
+        ItemEnum::AssocType { .. } => None,
+    }
 }
 
 fn convert_link<'a>(url_map: &HashMap<&str, String>, mut event: Event<'a>) -> Event<'a> {
@@ -98,8 +286,13 @@ fn convert_link<'a>(url_map: &HashMap<&str, String>, mut event: Event<'a>) -> Ev
     event
 }
 
-fn id_to_url(doc: &Crate, local_html_root_url: &str, id: &Id) -> Option<String> {
-    let item = doc.paths.get(id)?;
+fn id_to_url(
+    doc: &Crate,
+    extra_paths: &HashMap<&Id, Node<'_>>,
+    local_html_root_url: &str,
+    id: &Id,
+) -> Option<String> {
+    let item = item_summary(doc, extra_paths, id)?;
     let html_root_url = if item.crate_id == 0 {
         // local item
         local_html_root_url
@@ -121,30 +314,79 @@ fn id_to_url(doc: &Crate, local_html_root_url: &str, id: &Id) -> Option<String> 
         // (ItemKind::ExternCrate, [..]) => todo!(),
         // (ItemKind::Import, [..]) => todo!(),
         (ItemKind::Struct, [ps @ .., name]) => join(ps, format_args!("struct.{name}.html")),
-        // (ItemKind::StructField, [..]) => todo!(),
+        (ItemKind::StructField, [ps @ .., struct_name, field]) => join(
+            ps,
+            format_args!("struct.{struct_name}.html#structfield.{field}"),
+        ),
         (ItemKind::Union, [ps @ .., name]) => join(ps, format_args!("union.{name}.html")),
         (ItemKind::Enum, [ps @ .., name]) => join(ps, format_args!("enum.{name}.html")),
-        (ItemKind::Variant, [ps @ .., name, variant]) => {
-            join(ps, format_args!("enum.{name}.html#variant.{variant}"))
-        }
+        (ItemKind::Variant, [ps @ .., enum_name, variant_name]) => join(
+            ps,
+            format_args!("enum.{enum_name}.html#variant.{variant_name}"),
+        ),
         (ItemKind::Function, [ps @ .., name]) => join(ps, format_args!("fn.{name}.html")),
         (ItemKind::Typedef, [ps @ .., name]) => join(ps, format_args!("type.{name}.html")),
         // (ItemKind::OpaqueTy, [..]) => todo!(),
         (ItemKind::Constant, [ps @ .., name]) => join(ps, format_args!("constant.{name}.html")),
         (ItemKind::Trait, [ps @ .., name]) => join(ps, format_args!("trait.{name}.html")),
         // (ItemKind::TraitAlias, [..]) => todo!(),
-        // (ItemKind::Method, [..]) => todo!(),
+        (ItemKind::Method, [ps @ .., trait_name, method_name]) => join(
+            ps,
+            format_args!("trait.{trait_name}.html#tymethod.{method_name}"),
+        ),
         // (ItemKind::Impl, [..]) => todo!(),
         (ItemKind::Static, [ps @ .., name]) => join(ps, format_args!("static.{name}.html")),
         // (ItemKind::ForeignType, [..]) => todo!(),
         (ItemKind::Macro, [ps @ .., name]) => join(ps, format_args!("macro.{name}.html")),
         (ItemKind::ProcAttribute, [ps @ .., name]) => join(ps, format_args!("attr.{name}.html")),
         (ItemKind::ProcDerive, [ps @ .., name]) => join(ps, format_args!("derive.{name}.html")),
-        // (ItemKind::AssocConst, [..]) => todo!(),
-        // (ItemKind::AssocType, [..]) => todo!(),
+        (ItemKind::AssocConst, [ps @ .., trait_name, const_name]) => join(
+            ps,
+            format_args!("trait.{trait_name}.html#associatedconstant.{const_name}"),
+        ),
+        (ItemKind::AssocType, [ps @ .., trait_name, type_name]) => join(
+            ps,
+            format_args!("trait.{trait_name}.html#associatedtype.{type_name}"),
+        ),
         (ItemKind::Primitive, [ps @ .., name]) => join(ps, format_args!("primitive.{name}.html")),
         // (ItemKind::Keyword, [..]) => todo!(),
-        (item, path) => tracing::warn!(?item, ?path, "unexpected intra-doc link item & path found"),
+        (item, path) => {
+            tracing::warn!(?item, ?path, "unexpected intra-doc link item & path found");
+            return None;
+        }
     }
     Some(url)
+}
+
+fn item_summary<'doc>(
+    doc: &'doc Crate,
+    extra_paths: &'doc HashMap<&'doc Id, Node<'doc>>,
+    id: &'doc Id,
+) -> Option<Cow<'doc, ItemSummary>> {
+    if let Some(summary) = doc.paths.get(id) {
+        return Some(Cow::Borrowed(summary));
+    }
+    // workaround for https://github.com/rust-lang/rust/issues/101687
+    // if the item is not found in the paths, try to find it in the extra_paths
+
+    let node = extra_paths.get(id)?;
+    let mut stack = vec![node];
+    let mut current = node;
+    while let Some(parent) = current.parent {
+        if let Some(summary) = doc.paths.get(parent) {
+            let mut path = summary.path.clone();
+            while let Some(node) = stack.pop() {
+                let name = node.name?;
+                path.push(name.to_string());
+            }
+            return Some(Cow::Owned(ItemSummary {
+                crate_id: summary.crate_id,
+                kind: node.kind.clone(),
+                path,
+            }));
+        }
+        current = extra_paths.get(&parent)?;
+        stack.push(current);
+    }
+    None
 }


### PR DESCRIPTION
Search item paths from `.index` if the item ID was not found in `paths`.

workaround for rust-lang/rust#101687

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cargo-sync-rdme/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cargo-sync-rdme/blob/HEAD/CHANGELOG.md
-->
