### PR TITLE
Resolve links to exported public items defined in private modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+* Resolve links to exported public items defined in private modules
+
 ## [0.1.3] - 2022-09-14
 
 ### Fixed

--- a/src/sync/contents/rustdoc.rs
+++ b/src/sync/contents/rustdoc.rs
@@ -76,6 +76,7 @@ fn run_rustdoc(app: &App, package: &Package) -> CreateResult<()> {
         .args([
             "-Zrustdoc-map",
             "--",
+            "--document-private-items",
             "-Zunstable-options",
             "--output-format=json",
         ]);


### PR DESCRIPTION
<!-- Please explain the changes you made -->

Pass `--document-private-items` option to `rustdoc`.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cargo-sync-rdme/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cargo-sync-rdme/blob/HEAD/CHANGELOG.md
-->
