### PR TITLE
(breaking change) fix typo in command line arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+* (breaking change) fix typo in command line arguments: `--allow-no-vsc` -> `--allow-no-vcs`
+
 ## [0.1.4] - 2022-09-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 dependencies = [
  "serde",
 ]
@@ -891,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2aed7a697360aae71c545044813761b33c131ba40cbbf721f87bfd86dd07a0"
+checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1221,9 +1221,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
+checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ pulldown-cmark-to-cmark = "10.0.4"
 rustdoc-types = "0.17.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
-serde_yaml = "0.9.12"
+serde_yaml = "0.9.13"
 similar = { version = "2.2.0", features = ["inline", "unicode"] }
 tempfile = "3.3.0"
 thiserror = "1.0.35"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -153,7 +153,7 @@ pub(crate) struct FixArgs {
     check: bool,
     /// Sync README even if a VCS was not detected
     #[clap(long)]
-    allow_no_vsc: bool,
+    allow_no_vcs: bool,
     /// Sync README even if the target file is dirty
     #[clap(long)]
     allow_dirty: bool,
@@ -178,7 +178,7 @@ impl FixArgs {
             );
         }
 
-        if self.allow_no_vsc {
+        if self.allow_no_vcs {
             return Ok(());
         }
 


### PR DESCRIPTION
`--allow-no-vsc` -> `--allow-no-vcs`

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cargo-sync-rdme/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cargo-sync-rdme/blob/HEAD/CHANGELOG.md
-->
