### PR TITLE
release.toml: remove dev-version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-sync-rdme"
-version = "0.2.1-alpha.0"
+version = "0.2.0"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xtask", "examples/lib"]
 
 [package]
 name = "cargo-sync-rdme"
-version = "0.2.1-alpha.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.62.1"
 description = "Cargo subcommand to synchronize README with crate documentation"

--- a/release.toml
+++ b/release.toml
@@ -9,4 +9,3 @@ pre-release-replacements = [
   {file = "src/lib.rs", search = "^#!\\[doc\\(html_root_url = \"https://docs.rs/cargo-sync-rdme/.*\"\\)\\]$", replace = "#![doc(html_root_url = \"https://docs.rs/cargo-sync-rdme/{{version}}\")]", exactly = 1},
 ]
 pre-release-hook = ["cargo", "xtask", "pre-release"]
-dev-version = true


### PR DESCRIPTION
cargo-release removed dev-version support

https://github.com/crate-ci/cargo-release/releases/tag/v0.22.0

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cargo-sync-rdme/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cargo-sync-rdme/blob/HEAD/CHANGELOG.md
-->
