### PR TITLE
Use separated target dir for xtask run

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [alias]
-xtask = "run --package xtask --"
+xtask = "run --package xtask --target-dir target/xtask/run --"


### PR DESCRIPTION
Workaround for windows build failure

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cargo-sync-rdme/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cargo-sync-rdme/blob/HEAD/CHANGELOG.md
-->
