### PR TITLE
Use `cargo metadata` output instead of pasring `Cargo.toml`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -61,18 +61,6 @@ pub(crate) struct Manifest {
 }
 
 impl WithSource<Manifest> {
-    pub(crate) fn try_package(
-        &self,
-    ) -> Result<WithSource<&Spanned<package::Package>>, GetConfigError> {
-        let package = self.value().package.as_ref().ok_or_else(|| KeyNotSet {
-            name: self.name().to_owned(),
-            key: "package".to_owned(),
-            span: (0..0).into(),
-            source_code: self.to_named_source(),
-        })?;
-        Ok(self.map(|_| package))
-    }
-
     pub(crate) fn try_badges(
         &self,
     ) -> Result<WithSource<&Spanned<badges::Badges>>, GetConfigError> {

--- a/src/config/package.rs
+++ b/src/config/package.rs
@@ -1,86 +1,11 @@
-use cargo_metadata::semver::VersionReq;
 use serde::Deserialize;
 use toml::Spanned;
 
-use crate::with_source::WithSource;
-
-use super::{metadata, GetConfigError, KeyNotSet};
+use super::metadata;
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct Package {
     #[serde(default)]
-    pub(crate) license: Option<Spanned<String>>,
-    #[serde(default)]
-    pub(crate) license_file: Option<Spanned<String>>,
-    #[serde(default)]
-    pub(crate) repository: Option<Spanned<String>>,
-    #[serde(default)]
-    pub(crate) rust_version: Option<Spanned<VersionReq>>,
-    #[serde(default)]
     pub(crate) metadata: Option<Spanned<metadata::Metadata>>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) enum License<'a> {
-    Name {
-        name: &'a Spanned<String>,
-        path: &'a Option<Spanned<String>>,
-    },
-    File {
-        path: &'a Spanned<String>,
-    },
-}
-
-impl<'a> WithSource<&'a Spanned<Package>> {
-    pub(crate) fn try_license(&self) -> Result<WithSource<License<'a>>, GetConfigError> {
-        if let Some(name) = &self.value().get_ref().license {
-            return Ok(self.map(|_| License::Name {
-                name,
-                path: &self.value().get_ref().license_file,
-            }));
-        }
-        if let Some(path) = &self.value().get_ref().license_file {
-            return Ok(self.map(|_| License::File { path }));
-        }
-        Err(KeyNotSet {
-            name: self.name().to_owned(),
-            key: "package.license` or `package.license-file".to_owned(),
-            span: self.span(),
-            source_code: self.to_named_source(),
-        }
-        .into())
-    }
-
-    pub(crate) fn try_repository(&self) -> Result<WithSource<&'a Spanned<String>>, GetConfigError> {
-        let repository = self
-            .value()
-            .get_ref()
-            .repository
-            .as_ref()
-            .ok_or_else(|| KeyNotSet {
-                name: self.name().to_owned(),
-                key: "package.repository".to_owned(),
-                span: self.span(),
-                source_code: self.to_named_source(),
-            })?;
-        Ok(self.map(|_| repository))
-    }
-
-    pub(crate) fn try_rust_version(
-        &self,
-    ) -> Result<WithSource<&'a Spanned<VersionReq>>, GetConfigError> {
-        let status = self
-            .value()
-            .get_ref()
-            .rust_version
-            .as_ref()
-            .ok_or_else(|| KeyNotSet {
-                name: self.name().to_owned(),
-                key: "package.rust-version".to_owned(),
-                span: self.span(),
-                source_code: self.to_named_source(),
-            })?;
-        Ok(self.map(|_| status))
-    }
 }


### PR DESCRIPTION
By this, cargo-sync-rdme supports `package.<key>.workspace = true`

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cargo-sync-rdme/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cargo-sync-rdme/blob/HEAD/CHANGELOG.md
-->
