### PR TITLE
Fix code block `#`-hiding behavior to match rustdoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+* Match code block `#` hiding behavior with rustdoc: hide lines beginning with any number of whitespace plus `# ` (or a plain `#`), and turn `##` at the beginning of lines into `#`.
+
 ## [0.4.1] - 2025-01-26
 
 ## [0.4.0] - 2024-11-30


### PR DESCRIPTION
There are a few subtleties -- in particular, it's `# ` that is hidden, not just a plain `#` without a following space (except if it's on a line by itself.)