### PR TITLE
Migrate workspace to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["xtask", "examples/lib"]
 [package]
 name = "cargo-sync-rdme"
 version = "0.4.3"
-edition = "2021"
+edition = "2024"
 rust-version = "1.88.0"
 description = "Cargo subcommand to synchronize README with crate documentation"
 readme = "README.md"

--- a/examples/lib/Cargo.toml
+++ b/examples/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-sync-rdme-example-lib"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 readme = "README.md"
 publish = false
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,14 +1,13 @@
 use std::{path::PathBuf, process::Command};
 
-use cargo_metadata::{camino::Utf8Path, Metadata, Package};
+use cargo_metadata::{Metadata, Package, camino::Utf8Path};
 use clap::ArgAction;
 use miette::{IntoDiagnostic, WrapErr};
 use tracing::Level;
 
 use crate::{
-    diff,
+    Result, diff,
     vcs::{self, Status},
-    Result,
 };
 
 #[derive(Debug, Clone, Copy, Default, clap::Args)]

--- a/src/config/de.rs
+++ b/src/config/de.rs
@@ -1,6 +1,6 @@
 use std::{fmt, marker::PhantomData, str::FromStr};
 
-use serde::{de::Visitor, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, de::Visitor};
 use void::{ResultVoidExt, Void};
 
 pub(super) fn bool_or_map<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>

--- a/src/config/metadata.rs
+++ b/src/config/metadata.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, fmt, str::FromStr, sync::Arc};
 
 use serde::{
-    de::{Error, Visitor},
     Deserialize,
+    de::{Error, Visitor},
 };
 use void::Void;
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Write};
 
-use console::{style, Style};
+use console::{Style, style};
 use similar::{ChangeTag, TextDiff};
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use std::{env, io};
 
 use clap::Parser;
 use tracing::Level;
-use tracing_subscriber::EnvFilter;
+use tracing_subscriber::{EnvFilter, filter::LevelFilter};
 
 #[macro_use]
 mod macros;
@@ -74,19 +74,24 @@ pub fn main() -> Result<()> {
 }
 
 fn install_logger(verbosity: Option<Level>) -> Result<()> {
-    if env::var_os("RUST_LOG").is_none() {
-        match verbosity {
-            Some(Level::ERROR) => env::set_var("RUST_LOG", "error"),
-            Some(Level::WARN) => env::set_var("RUST_LOG", "warn"),
-            Some(Level::INFO) => env::set_var("RUST_LOG", "info"),
-            Some(Level::DEBUG) => env::set_var("RUST_LOG", "debug"),
-            Some(Level::TRACE) => env::set_var("RUST_LOG", "trace"),
-            None => env::set_var("RUST_LOG", "off"),
-        }
-    }
+    let env_filter = if env::var_os("RUST_LOG").is_some() {
+        EnvFilter::from_default_env()
+    } else {
+        let default_level = match verbosity {
+            Some(Level::ERROR) => LevelFilter::ERROR,
+            Some(Level::WARN) => LevelFilter::WARN,
+            Some(Level::INFO) => LevelFilter::INFO,
+            Some(Level::DEBUG) => LevelFilter::DEBUG,
+            Some(Level::TRACE) => LevelFilter::TRACE,
+            None => LevelFilter::OFF,
+        };
+        EnvFilter::builder()
+            .with_default_directive(default_level.into())
+            .from_env_lossy()
+    };
 
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(env_filter)
         .with_writer(io::stderr)
         .with_target(false)
         .try_init()

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -5,14 +5,14 @@ use std::{
 };
 
 use cargo_metadata::{
-    camino::{Utf8Path, Utf8PathBuf},
     Metadata, Package,
+    camino::{Utf8Path, Utf8PathBuf},
 };
 use miette::{IntoDiagnostic, NamedSource, WrapErr};
 use pulldown_cmark::{Options, Parser};
 use tempfile::NamedTempFile;
 
-use crate::{cli::App, config::Manifest, traits::PackageExt, with_source::WithSource, Result};
+use crate::{Result, cli::App, config::Manifest, traits::PackageExt, with_source::WithSource};
 
 mod contents;
 mod marker;
@@ -64,7 +64,9 @@ pub(crate) fn sync_all(app: &App, workspace: &Metadata, package: &Package) -> Re
         .collect::<Vec<_>>();
 
     if paths.is_empty() {
-        bail!("no target files found. Please specify `package.readme` or `package.metadata.cargo-sync-rdme.extra-targets`");
+        bail!(
+            "no target files found. Please specify `package.readme` or `package.metadata.cargo-sync-rdme.extra-targets`"
+        );
     }
 
     for path in paths {

--- a/src/sync/contents.rs
+++ b/src/sync/contents.rs
@@ -4,7 +4,7 @@ use cargo_metadata::{Metadata, Package};
 
 use crate::App;
 
-use super::{marker::Replace, ManifestFile};
+use super::{ManifestFile, marker::Replace};
 
 mod badge;
 mod rustdoc;

--- a/src/sync/contents/badge.rs
+++ b/src/sync/contents/badge.rs
@@ -1,9 +1,9 @@
 use std::{borrow::Cow, cmp::Ordering, fmt, fmt::Write, fs, io, sync::Arc};
 
 use cargo_metadata::{
+    Metadata, Package,
     camino::{Utf8Path, Utf8PathBuf},
     semver::{Comparator, Op, VersionReq},
-    Metadata, Package,
 };
 use miette::{NamedSource, SourceSpan};
 use serde::Deserialize;
@@ -11,7 +11,7 @@ use url::Url;
 
 use super::Escape;
 use crate::{
-    config::{badges::MaintenanceStatus, metadata, GetConfigError},
+    config::{GetConfigError, badges::MaintenanceStatus, metadata},
     sync::ManifestFile,
 };
 
@@ -465,7 +465,7 @@ impl BadgeLink {
                     source: err,
                     path: workflows_dir_path.clone(),
                 }
-                .into())
+                .into());
             }
         };
 

--- a/src/sync/contents/rustdoc.rs
+++ b/src/sync/contents/rustdoc.rs
@@ -4,9 +4,9 @@ use cargo_metadata::{Metadata, Package};
 use rustdoc_types::{Crate, Item};
 
 use crate::{
+    App,
     sync::ManifestFile,
     with_source::{ReadFileError, WithSource},
-    App,
 };
 
 mod code_block;

--- a/src/sync/contents/rustdoc/intra_link.rs
+++ b/src/sync/contents/rustdoc/intra_link.rs
@@ -281,12 +281,12 @@ fn convert_link<'a>(
     url_map: &HashMap<&str, Option<String>>,
     mut event: Event<'a>,
 ) -> Option<Event<'a>> {
-    if let Event::Start(Tag::Link { dest_url: url, .. }) = &mut event {
-        if let Some(full_url) = url_map.get(url.as_ref()) {
-            match full_url {
-                Some(full_url) => *url = full_url.to_owned().into(),
-                None => return None,
-            }
+    if let Event::Start(Tag::Link { dest_url: url, .. }) = &mut event
+        && let Some(full_url) = url_map.get(url.as_ref())
+    {
+        match full_url {
+            Some(full_url) => *url = full_url.to_owned().into(),
+            None => return None,
         }
     }
     Some(event)

--- a/src/sync/marker/find.rs
+++ b/src/sync/marker/find.rs
@@ -107,11 +107,10 @@ where
 {
     fn next_marker(&mut self) -> Result<Option<(Marker, Range<usize>)>, FindError> {
         for (event, range) in self.events.by_ref() {
-            if let Event::Html(html) = &event {
-                if let Some(marker) = Marker::matches((html, range.clone().into()), self.manifest)?
-                {
-                    return Ok(Some((marker, range)));
-                }
+            if let Event::Html(html) = &event
+                && let Some(marker) = Marker::matches((html, range.clone().into()), self.manifest)?
+            {
+                return Ok(Some((marker, range)));
             }
         }
         Ok(None)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-use cargo_metadata::{camino::Utf8Path, Package};
+use cargo_metadata::{Package, camino::Utf8Path};
 use miette::SourceSpan;
 
 /// Extension methods for [`cargo_metadata::Package`].

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 readme = "README.md"
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,22 +1,33 @@
 use std::env;
 
 use cli_xtask::{
+    Result, Xtask,
     camino::Utf8PathBuf,
     cargo_metadata::TargetKind,
     clap::CommandFactory,
     color_eyre::eyre::{ensure, eyre},
     config::{ConfigBuilder, DistConfigBuilder},
-    workspace, Result, Xtask,
+    workspace,
 };
 
 fn main() -> Result<()> {
     let bin_path = build_sync_rdme()?;
     let path = env::var("PATH").unwrap_or_default();
     let sep = if cfg!(windows) { ";" } else { ":" };
-    env::set_var(
-        "PATH",
-        format!("{}{}{}", bin_path.parent().unwrap(), sep, path),
-    );
+
+    // Put the freshly built `cargo-sync-rdme` binary directory at the front of
+    // PATH so the generated xtask command resolves to that binary.
+    //
+    // SAFETY:
+    // This program is single-threaded at this point and does not read or write
+    // environment variables from other threads while mutating the process
+    // environment here, satisfying `std::env::set_var` safety requirements.
+    unsafe {
+        env::set_var(
+            "PATH",
+            format!("{}{}{}", bin_path.parent().unwrap(), sep, path),
+        );
+    }
 
     <Xtask>::main_with_config(|| {
         let workspace = workspace::current();


### PR DESCRIPTION
Migrate all workspace crates to `edition = "2024"`.
Refactor logger initialization to configure tracing defaults without mutating `RUST_LOG`.
Keep xtask PATH bootstrapping Edition 2024-compatible with a minimal documented unsafe `env::set_var` call.
Validate changes with `cargo check --workspace`.
Include rustfmt formatting and clippy-driven collapsible-if cleanups in related files.