### PR TITLE
chore: add .editorconfig and update dependabot config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rs]
+indent_size = 4
+
+[*.toml]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "cargo"
     directory: "/"
+    allow:
+      - dependency-type: "all"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      patch-only:
+        update-types:
+          - "patch"


### PR DESCRIPTION
## Summary

### Add `.editorconfig`
Define consistent editor settings across the project.

- Charset: UTF-8
- End of line: LF
- Indent style: spaces (default 4; 2 for TOML, YAML, and Markdown)
- Insert final newline
- Trim trailing whitespace (except Markdown)
- Makefile uses tab indentation

### Update `.github/dependabot.yml`
Optimize Dependabot configuration.

- Change update interval from `daily` to `weekly` for both github-actions and cargo
- Allow all dependency types for cargo (`dependency-type: all`)
- Group cargo patch updates into a single PR via `patch-only` group to reduce PR noise