### PR TITLE
ci: add concurrency settings to cancel redundant workflow runs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,6 +9,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 jobs:
   audit:
     uses: gifnksm/rust-template/.github/workflows/reusable-audit.yml@main

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 jobs:
   cd:
     uses: gifnksm/rust-template/.github/workflows/reusable-cd.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary

Add `concurrency` settings to the CI, CD, and Security Audit workflows to automatically cancel outdated runs when new commits are pushed or a PR is updated.

## Changes

- `.github/workflows/ci.yml`: added `concurrency` block
- `.github/workflows/cd.yml`: added `concurrency` block
- `.github/workflows/audit.yml`: added `concurrency` block
- `.github/workflows/pages.yml`: left unchanged (already has dedicated concurrency control for pages deployment)

## Concurrency strategy

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
```

- **Group key**: scoped per workflow + PR number (for pull requests) or branch/tag ref (for pushes), so only runs of the same workflow on the same target are grouped together.
- **cancel-in-progress**: `true` on feature branches and PRs (cancels the previous run when a new one starts), `false` on the default branch (preserves the full run history for `main`).