### PR TITLE
ci: inline reusable workflows from rust-template

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,20 +13,50 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  audit:
-    uses: gifnksm/rust-template/.github/workflows/reusable-audit.yml@main
+  security_audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rust-lang/audit@v1
+
+  cargo-deny:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check ${{ matrix.checks }}
 
   audit-complete:
-    needs: audit
+    needs:
+      - security_audit
+      - cargo-deny
     runs-on: ubuntu-latest
     if: ${{ always() }}
+    permissions: {}
     steps:
-      - run: |
-          if ${{ needs.audit.result == 'success' }}; then
+      - name: Audit complete
+        run: |
+          if ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}; then
             echo "Audit succeeded"
-            exit 0
           else
             echo "Audit failed"
             exit 1
           fi
+        shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,22 +12,77 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  cd:
-    uses: gifnksm/rust-template/.github/workflows/reusable-cd.yml@main
-    with:
-      upload-dist-archive: true
+  release:
+    name: Publishing for ${{ matrix.job.target }}
+    runs-on: ${{ matrix.job.os }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: true
+      matrix:
+        rust: [stable]
+        job:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: i686-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.job.target }}
+      - name: Install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: cargo xtask dist
+        run: cargo xtask dist --use-cross-if-needed --target ${{ matrix.job.target }}
+        shell: bash
+
+      - name: Upload binaries as artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: artifact-${{ matrix.job.target }}
+          path: target/dist/*
+
+      - name: Releasing assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/dist/*
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
 
   cd-complete:
-    needs: cd
+    needs:
+      - release
     runs-on: ubuntu-latest
     if: ${{ always() }}
+    permissions: {}
     steps:
-      - run: |
-          if ${{ needs.cd.result == 'success' }}; then
+      - name: CD complete
+        run: |
+          if ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}; then
             echo "CD succeeded"
-            exit 0
           else
             echo "CD failed"
             exit 1
           fi
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,162 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  ci:
-    uses: gifnksm/rust-template/.github/workflows/reusable-ci.yml@main
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.set-values.outputs.rust }}
+      os: ${{ steps.set-values.outputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Set matrix values
+        id: set-values
+        run: |
+          root_package_id="$(cargo metadata --format-version 1 | jq -cr '.resolve.root')"
+          root_package="$(cargo metadata --format-version 1 | jq -c --arg pkgid "${root_package_id}" '.packages[] | select(.id == $pkgid)')"
+          echo "${root_package}" | jq -c '{ root_package: .name }'
+
+          msrv="$(echo "${root_package}" | jq '.rust_version')"
+          rust="$(echo "[\"stable\", ${msrv}]" | jq -c)"
+          echo "rust=${rust}" >> "$GITHUB_OUTPUT"
+
+          os="$(echo '["ubuntu-latest", "macos-latest", "windows-latest"]' | jq -c)"
+          echo "os=${os}" >> "$GITHUB_OUTPUT"
+
+          jq -n --argjson rust "${rust}" --argjson os "${os}" '{ rust: $rust, os: $os }'
+        shell: bash
+
+  test:
+    name: Test
+    needs: set-matrix
+    strategy:
+      fail-fast: true
+      matrix:
+        rust: ${{ fromJSON(needs.set-matrix.outputs.rust) }}
+        os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo xtask test --exhaustive
+        shell: bash
+
+  coverage:
+    name: Coverage (test)
+    needs: set-matrix
+    strategy:
+      fail-fast: true
+      matrix:
+        rust: [stable]
+        os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - run: cargo llvm-cov --workspace --all-features --codecov --output-path codecov.json
+        shell: bash
+      - uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov.json
+          fail_ci_if_error: false
+
+  build:
+    name: Build
+    needs: set-matrix
+    strategy:
+      fail-fast: true
+      matrix:
+        rust: ${{ fromJSON(needs.set-matrix.outputs.rust) }}
+        os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo xtask build --exhaustive -- --all-targets
+        shell: bash
+
+  lint:
+    name: Lint
+    needs: set-matrix
+    strategy:
+      fail-fast: true
+      matrix:
+        os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt,clippy
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-udeps,cargo-sync-rdme
+      - run: rustup toolchain add nightly --profile minimal
+        shell: bash
+      - run: cargo xtask lint --exhaustive
+        shell: bash
+
+  release-dry-run:
+    name: Release dry run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-udeps,cargo-sync-rdme,cargo-release
+      - run: rustup toolchain add nightly --profile minimal
+        shell: bash
+      - run: cargo release patch -vv --allow-branch '*'
+        shell: bash
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check workflow files
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          echo "::add-matcher::.github/actionlint-matcher.json"
+          ./actionlint -color
+        shell: bash
 
   ci-complete:
-    needs: ci
+    needs:
+      - set-matrix
+      - test
+      - coverage
+      - build
+      - lint
+      - release-dry-run
+      - actionlint
     runs-on: ubuntu-latest
     if: ${{ always() }}
+    permissions: {}
     steps:
-      - run: |
-          if ${{ needs.ci.result == 'success' }}; then
+      - name: CI complete
+        run: |
+          if ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}; then
             echo "CI succeeded"
-            exit 0
           else
             echo "CI failed"
             exit 1
           fi
+        shell: bash


### PR DESCRIPTION
## Summary

Replace uses of `gifnksm/rust-template` reusable workflows with their inlined equivalents so the CI/CD configuration no longer depends on an external repository.

## Changes

### `ci.yml`
- Expand `reusable-ci.yml` jobs inline: `set-matrix`, `test`, `coverage`, `build`, `lint`, `release-dry-run`, `actionlint`
- `ci-complete` now depends on all individual jobs instead of a single reusable workflow job
- Add `permissions: {}` and a step name to `ci-complete`

### `audit.yml`
- Expand `reusable-audit.yml` jobs inline: `security_audit`, `cargo-deny`
- Add `env: CARGO_TERM_COLOR: always`
- `audit-complete` now depends on `security_audit` and `cargo-deny` directly
- Apply the same `*-complete` job pattern

### `cd.yml`
- Expand `reusable-cd.yml` `release` job inline with `upload-dist-archive` hardcoded to `true` (removing per-step conditional guards)
- `cd-complete` now depends on `release` directly
- Apply the same `*-complete` job pattern