### PR TITLE
ci: add typos check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,17 @@ jobs:
           ./actionlint -color
         shell: bash
 
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: typos
+      - name: Check spelling of entire workspace
+        run: typos
+
   ci-complete:
     needs:
       - set-matrix
@@ -283,6 +294,7 @@ jobs:
       - coverage
       - release-dry-run
       - actionlint
+      - typos
     runs-on: ubuntu-latest
     if: ${{ always() }}
     permissions: {}

--- a/examples/lib/README.md
+++ b/examples/lib/README.md
@@ -94,7 +94,7 @@ Fenced code block:
 println!("Hello, world!");
 ````
 
-Indented code blcok:
+Indented code block:
 
 ````rust
 println!("Hello, world!");

--- a/examples/lib/src/lib.rs
+++ b/examples/lib/src/lib.rs
@@ -91,7 +91,7 @@
 //! # }
 //! ```
 //!
-//! Indented code blcok:
+//! Indented code block:
 //!
 //!     # fn main() {
 //!     println!("Hello, world!");

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -199,7 +199,7 @@ impl FixArgs {
         match status {
             Status::Dirty => {
                 if !self.allow_dirty {
-                    bail!("README has uncomitted changes: {readme_path}");
+                    bail!("README has uncommitted changes: {readme_path}");
                 }
             }
             Status::Staged => {


### PR DESCRIPTION
Add a `typos` job to CI workflows to check spelling across the workspace.
