### PR TITLE
Add linting and formatting checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 [*.rs]
 indent_size = 4
 
-[*.toml]
+[*.{toml,json}]
 indent_size = 2
 
 [*.{yml,yaml}]
@@ -19,6 +19,10 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+indent_size = unset
 
 [Makefile]
 indent_style = tab
+
+[LICENSE*]
+indent_size = unset

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,20 @@ jobs:
       - run: just ci-rustfmt
         shell: bash
 
+  tombi:
+    name: Tombi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - run: just ci-tombi-format
+        shell: bash
+      - run: just ci-tombi-lint
+        shell: bash
+
   check:
     name: Check
     needs: set-matrix
@@ -240,14 +254,23 @@ jobs:
         shell: bash
 
   actionlint:
+    name: Actionlint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Check workflow files
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - name: Install actionlint
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          echo "::add-matcher::.github/actionlint-matcher.json"
-          ./actionlint -color
+          mkdir -p "$RUNNER_TEMP/tools-bin"
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) latest "$RUNNER_TEMP/tools-bin"
+          echo "$RUNNER_TEMP/tools-bin" >> "$GITHUB_PATH"
+        shell: bash
+      - name: Add actionlint problem matcher
+        run: echo "::add-matcher::.github/actionlint-matcher.json"
+        shell: bash
+      - run: just ci-actionlint
         shell: bash
 
   typos:
@@ -257,13 +280,34 @@ jobs:
       - uses: actions/checkout@v7
       - uses: taiki-e/install-action@v2
         with:
-          tool: typos
-      - name: Check spelling of entire workspace
-        run: typos
+          tool: just,typos
+      - run: just ci-typos
+
+  markdownlint:
+    name: Markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - run: just ci-markdownlint
+
+  editorconfig:
+    name: EditorConfig
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - uses: editorconfig-checker/action-editorconfig-checker@v2.2.0
+      - run: just ci-editorconfig -format github-actions
 
   ci-complete:
     needs:
       - set-matrix
+      - tombi
       - rustfmt
       - check
       - clippy
@@ -275,6 +319,8 @@ jobs:
       - release-dry-run
       - actionlint
       - typos
+      - markdownlint
+      - editorconfig
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-This project adheres to the Rust Code of Conduct, which can be found [here](https://www.rust-lang.org/conduct.html).
+This project adheres to the [Rust Code of Conduct](https://www.rust-lang.org/conduct.html).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
-[workspace]
-members = ["examples/lib"]
-
 [package]
 name = "cargo-sync-rdme"
 version = "0.5.0"
@@ -12,12 +9,6 @@ repository = "https://github.com/gifnksm/cargo-sync-rdme"
 license = "MIT OR Apache-2.0"
 keywords = []
 categories = []
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[features]
-default = ["vcs-git"]
-vcs-git = ["dep:git2"]
-vendored-libgit2 = ["git2?/vendored-libgit2"]
 
 [package.metadata.cargo-sync-rdme]
 extra-targets = "./docs/configuration.md"
@@ -36,16 +27,22 @@ codecov = true
 
 [package.metadata.cargo-sync-rdme.badge.badges-maintenance]
 maintenance = true
+
 [package.metadata.cargo-sync-rdme.badge.badges-license]
 license = true
+
 [package.metadata.cargo-sync-rdme.badge.badges-crates-io]
 crates-io = true
+
 [package.metadata.cargo-sync-rdme.badge.badges-docs-rs]
 docs-rs = true
+
 [package.metadata.cargo-sync-rdme.badge.badges-rust-version]
 rust-version = true
+
 [package.metadata.cargo-sync-rdme.badge.badges-github-actions]
 github-actions = true
+
 [package.metadata.cargo-sync-rdme.badge.badges-codecov]
 codecov = true
 
@@ -53,6 +50,9 @@ codecov = true
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }.{ archive-format }"
 bin-dir = "{ bin }{ binary-ext }"
 pkg-fmt = "tgz"
+
+[workspace]
+members = ["examples/lib"]
 
 [dependencies]
 cargo_metadata = "0.23.1"
@@ -79,15 +79,21 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 url = "2.5.8"
 void = "1.0.2"
 
+[dev-dependencies]
+indoc = "2.0.7"
+
 [build-dependencies]
+
+[badges]
+maintenance = { status = "actively-developed" }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["vcs-git"]
+vcs-git = ["dep:git2"]
+vendored-libgit2 = ["git2?/vendored-libgit2"]
 
 [profile.dev]
 
 [profile.release]
 strip = true
-
-[badges]
-maintenance = { status = "actively-developed" }
-
-[dev-dependencies]
-indoc = "2.0.7"

--- a/deny.toml
+++ b/deny.toml
@@ -23,13 +23,13 @@
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
 targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #"x86_64-unknown-linux-musl",
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+  # The triple can be any string, but only the target triples built in to
+  # rustc (as of 1.40) can be checked against actual config expressions
+  # "x86_64-unknown-linux-musl",
+  # You can also specify which target_features you promise are enabled for a
+  # particular target. target_features are currently not validated against
+  # the actual valid features supported by the target architecture.
+  # { triple = "wasm32-unknown-unknown", features = ["atomics"] },
 ]
 # When creating the dependency graph used as the source of truth when checks are
 # executed, this field can be used to prune crates from the graph, removing them
@@ -38,7 +38,7 @@ targets = [
 # they are connected to another crate in the graph that hasn't been pruned,
 # so it should be used with care. The identifiers are [Package ID Specifications]
 # (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
-#exclude = []
+# exclude = []
 # If true, metadata will be collected with `--all-features`. Note that this can't
 # be toggled off if true, if you want to conditionally enable `--all-features` it
 # is recommended to pass `--all-features` on the cmd line instead
@@ -48,7 +48,7 @@ all-features = false
 no-default-features = false
 # If set, these feature will be enabled when collecting metadata. If `--features`
 # is specified on the cmd line they will take precedence over this option.
-#features = []
+# features = []
 
 # The output table provides options for how/if diagnostics are outputted
 [output]
@@ -64,22 +64,22 @@ feature-depth = 1
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 # The path where the advisory databases are cloned/fetched into
-#db-path = "$CARGO_HOME/advisory-dbs"
+# db-path = "$CARGO_HOME/advisory-dbs"
 # The url(s) of the advisory databases to use
-#db-urls = ["https://github.com/rustsec/advisory-db"]
+# db-urls = ["https://github.com/rustsec/advisory-db"]
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
-    #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
-    #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
-    #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+  # "RUSTSEC-0000-0000",
+  # { id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
+  # "a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
+  # { crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
 # Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
 # See Git Authentication for more information about setting up git authentication.
-#git-fetch-with-cli = true
+# git-fetch-with-cli = true
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
@@ -89,11 +89,11 @@ ignore = [
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    "MIT",
-    "Apache-2.0",
-    "ISC",
-    "Unicode-3.0",
-    #"Apache-2.0 WITH LLVM-exception",
+  "MIT",
+  "Apache-2.0",
+  "ISC",
+  "Unicode-3.0",
+  # "Apache-2.0 WITH LLVM-exception",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -103,28 +103,28 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], crate = "adler32" },
+  # Each entry is the crate and version constraint, and its specific allow
+  # list
+  # { allow = ["Zlib"], crate = "adler32" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the
 # licensing information
-#[[licenses.clarify]]
+# [[licenses.clarify]]
 # The package spec the clarification applies to
-#crate = "ring"
+# crate = "ring"
 # The SPDX expression for the license requirements of the crate
-#expression = "MIT AND ISC AND OpenSSL"
+# expression = "MIT AND ISC AND OpenSSL"
 # One or more files in the crate's source used as the "source of truth" for
 # the license expression. If the contents match, the clarification will be used
 # when running the license check, otherwise the clarification will be ignored
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
-#license-files = [
+# license-files = [
 # Each entry is a crate relative path, and the (opaque) hash of its contents
-#{ path = "LICENSE", hash = 0xbd0eed23 }
-#]
+# { path = "LICENSE", hash = 0xbd0eed23 }
+# ]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
@@ -136,7 +136,7 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-    #"https://sekretz.com/registry
+  # "https://sekretz.com/registry"
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -163,27 +163,27 @@ workspace-default-features = "allow"
 external-default-features = "allow"
 # List of crates that are allowed. Use with care!
 allow = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+  # "ansi_term@0.11.0",
+  # { crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
 ]
 # List of crates to deny
 deny = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+  # "ansi_term@0.11.0",
+  # { crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+  # Wrapper crates can optionally be specified to allow the crate when it
+  # is a direct dependency of the otherwise banned crate
+  # { crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
 ]
 
 # List of features to allow/deny
 # Each entry the name of a crate and a version range. If version is
 # not specified, all versions will be matched.
-#[[bans.features]]
-#crate = "reqwest"
+# [[bans.features]]
+# crate = "reqwest"
 # Features to not allow
-#deny = ["json"]
+# deny = ["json"]
 # Features to allow
-#allow = [
+# allow = [
 #    "rustls",
 #    "__rustls",
 #    "__tls",
@@ -193,23 +193,23 @@ deny = [
 #    "rustls-tls-webpki-roots",
 #    "tokio-rustls",
 #    "webpki-roots",
-#]
+# ]
 # If true, the allowed features must exactly match the enabled feature set. If
 # this is set there is no point setting `deny`
-#exact = true
+# exact = true
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+  # "ansi_term@0.11.0",
+  # { crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite.
 skip-tree = [
-    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
-    #{ crate = "ansi_term@0.11.0", depth = 20 },
+  # "ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+  # { crate = "ansi_term@0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/examples/lib/Cargo.toml
+++ b/examples/lib/Cargo.toml
@@ -21,4 +21,3 @@ ignored = ["async-trait", "serde"]
 async-trait = "0.1.89"
 num = { version = "0.4.3", features = ["num-bigint"] }
 serde = { version = "1.0.228", features = ["derive"] }
-

--- a/examples/lib/README.md
+++ b/examples/lib/README.md
@@ -56,6 +56,8 @@ Intra-doc links are also supported.
 
 ### Link showcase
 
+<!-- markdownlint-disable MD060 -->
+
 |Item Kind|[`crate`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/index.html)|[`std`](https://doc.rust-lang.org/nightly/std/index.html)|External Crate|
 |---------|-------|-----|--------------|
 |Module|[`module`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html)|[`std::collections`](https://doc.rust-lang.org/nightly/std/collections/index.html)|[`num::bigint`](https://docs.rs/num/0.4/num/bigint/index.html)|
@@ -77,6 +79,8 @@ Intra-doc links are also supported.
 |Associated Constant [^4]|[`Trait::CONST`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedconstant.CONST)|\[`i32::MAX`\]||
 |Associated Type [^4]|[`Trait::Type`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedtype.Type)|\[`Iterator::Item`\]||
 |Primitive||[`i32`](https://doc.rust-lang.org/nightly/std/primitive.i32.html)||
+
+<!-- markdownlint-enable MD060 -->
 
 [^1]: Intra-doc links to struct fields are not supported in cargo-sync-rdme yet due to [rustdoc bug].
 
@@ -106,4 +110,3 @@ println!("Hello, world!");
 [e2]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html
 [rustdoc bug]: https://github.com/rust-lang/rust/issues/101687
 <!-- cargo-sync-rdme ]] -->
-

--- a/examples/lib/src/lib.rs
+++ b/examples/lib/src/lib.rs
@@ -49,6 +49,7 @@
 //!
 //! ## Link showcase
 //!
+//! <!-- markdownlint-disable MD060 -->
 //! | Item Kind                | [`crate`]          | [`std`]                       | External Crate                               |
 //! | ------------------------ | ------------------ | ----------------------------- | -------------------------------------------- |
 //! | Module                   | [`module`]         | [`std::collections`]          | [`num::bigint`]                              |
@@ -70,6 +71,7 @@
 //! | Associated Constant [^4] | [`Trait::CONST`]   | [`i32::MAX`]                  |                                              |
 //! | Associated Type [^4]     | [`Trait::Type`]    | [`Iterator::Item`]            |                                              |
 //! | Primitive                |                    | [`i32`]                       |                                              |
+//! <!-- markdownlint-enable MD060 -->
 //!
 //! [^1]: Intra-doc links to struct fields are not supported in cargo-sync-rdme yet due to [rustdoc bug].
 //!

--- a/justfile
+++ b/justfile
@@ -66,12 +66,47 @@ sync-rdme-all *args:
 machete *args:
     cargo machete {{ args }}
 
+# Check workflow files.
+actionlint *args:
+    actionlint {{ args }}
+
+# Check spelling of entire workspace.
+typos *args:
+    typos {{ args }}
+
+# Lint markdown files.
+markdownlint *args:
+    npx --yes markdownlint-cli {{ args }} .
+
+# Format TOML files.
+tombi-format *args:
+    uvx tombi format {{ args }}
+
+# Lint TOML files.
+tombi-lint *args:
+    uvx tombi lint {{ args }}
+
+# Check EditorConfig compliance.
+editorconfig *args:
+    editorconfig-checker {{ args }}
+
+# Run lint and static checks used for day-to-day local verification.
+ci-lint: ci-rustfmt ci-tombi-format ci-tombi-lint ci-check ci-clippy ci-machete ci-actionlint ci-typos ci-markdownlint ci-editorconfig
+
 # Run all CI-equivalent checks.
-ci: ci-rustfmt ci-check ci-clippy ci-rustdoc ci-sync-rdme ci-machete ci-test ci-coverage
+ci: ci-lint ci-rustdoc ci-sync-rdme ci-test ci-coverage
 
 # CI: formatting must be clean.
 ci-rustfmt:
     just fmt --check
+
+# CI: TOML formatting must be clean.
+ci-tombi-format:
+    just tombi-format --check
+
+# CI: TOML lint must be clean.
+ci-tombi-lint:
+    just tombi-lint --error-on-warnings
 
 # CI: compile checks.
 ci-check:
@@ -93,6 +128,22 @@ ci-sync-rdme:
 # CI: dependency hygiene.
 ci-machete:
     just machete
+
+# CI: check workflow files.
+ci-actionlint:
+    just actionlint
+
+# CI: check spelling.
+ci-typos:
+    just typos
+
+# CI: lint markdown files.
+ci-markdownlint:
+    just markdownlint
+
+# CI: check EditorConfig compliance.
+ci-editorconfig *args:
+    just editorconfig {{ args }}
 
 # CI: test suite.
 ci-test:

--- a/release.toml
+++ b/release.toml
@@ -1,9 +1,9 @@
 pre-release-replacements = [
-  {file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}"},
-  {file = "CHANGELOG.md", search = "/commits/HEAD", replace = "/commits/{{tag_name}}", min = 0, max = 1},
-  {file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", min = 0, max = 1},
-  {file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}"},
-  {file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] - ReleaseDate", exactly = 1},
-  {file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/gifnksm/cargo-sync-rdme/compare/{{tag_name}}...HEAD", exactly = 1},
+  { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+  { file = "CHANGELOG.md", search = "/commits/HEAD", replace = "/commits/{{tag_name}}", min = 0, max = 1 },
+  { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", min = 0, max = 1 },
+  { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
+  { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] - ReleaseDate", exactly = 1 },
+  { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/gifnksm/cargo-sync-rdme/compare/{{tag_name}}...HEAD", exactly = 1 },
 ]
 pre-release-hook = ["just", "pre-release"]


### PR DESCRIPTION
## Summary
- add local `just` tasks and CI jobs for Tombi, Markdownlint, and EditorConfig checks
- route typos and actionlint through `just` so local and CI entrypoints stay aligned
- apply the formatting and content adjustments needed for the new lint rules to pass

## Background
The `just` rules and CI shape are based on patterns already used in other repositories.
Rust formatting remains owned by `rustfmt`; the EditorConfig updates in this repository stay compatible with the current Rust sources while extending indentation checks for the non-Rust files that need them.

## Validation
- `just ci-tombi-format`
- `just ci-tombi-lint`
- `just ci-markdownlint`
- `just ci-editorconfig -format github-actions`
- `just ci-actionlint`
- `just ci-typos`

## Impact
This adds lint coverage for TOML, Markdown, and EditorConfig compliance, and makes the corresponding local workflows available through `just`.