### PR TITLE
Consolidate lints and tighten warning checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,6 @@ dependencies = [
  "git2",
  "indoc",
  "miette",
- "once_cell",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "rustdoc-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "cargo-sync-rdme"
 version = "0.5.0"
-edition = "2024"
-rust-version = "1.88.0"
+edition.workspace = true
+rust-version.workspace = true
 description = "Cargo subcommand to synchronize README with crate documentation"
 readme = "README.md"
-repository = "https://github.com/gifnksm/cargo-sync-rdme"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 keywords = []
 categories = []
 
@@ -54,6 +54,54 @@ pkg-fmt = "tgz"
 [workspace]
 members = ["examples/lib"]
 
+[workspace.package]
+edition = "2024"
+rust-version = "1.88.0"
+repository = "https://github.com/gifnksm/cargo-sync-rdme"
+license = "MIT OR Apache-2.0"
+
+[workspace.lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+
+# Restriction group
+allow_attributes = "warn"
+assertions_on_result_states = "warn"
+clone_on_ref_ptr = "warn"
+doc_paragraphs_missing_punctuation = "warn"
+error_impl_error = "warn"
+filetype_is_file = "warn"
+get_unwrap = "warn"
+if_then_some_else_none = "warn"
+impl_trait_in_params = "warn"
+map_err_ignore = "warn"
+undocumented_unsafe_blocks = "warn"
+unnecessary_self_imports = "warn"
+unused_trait_names = "warn"
+verbose_file_reads = "warn"
+
+[workspace.lints.rust]
+elided_lifetimes_in_paths = "warn"
+explicit_outlives_requirements = "warn"
+keyword_idents = "warn"
+missing_copy_implementations = "warn"
+missing_debug_implementations = "warn"
+missing_docs = "warn"
+missing_unsafe_on_extern = "warn"
+redundant_imports = "warn"
+single_use_lifetimes = "warn"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
+unreachable_pub = "warn"
+unsafe_attr_outside_unsafe = "warn"
+unused_crate_dependencies = "warn"
+unused_lifetimes = "warn"
+unused_qualifications = "warn"
+
+[workspace.lints.rustdoc]
+missing_crate_level_docs = "warn"
+private_doc_tests = "warn"
+unescaped_backticks = "warn"
+
 [dependencies]
 cargo_metadata = "0.23.1"
 clap = { version = "4.6.1", features = ["derive"] }
@@ -63,7 +111,6 @@ clap_mangen = "0.3.0"
 console = "0.16.4"
 git2 = { version = "0.21.0", default-features = false, optional = true }
 miette = { version = "7.6.0", features = ["fancy"] }
-once_cell = "1.21.4"
 pulldown-cmark = "0.13.4"
 pulldown-cmark-to-cmark = "22.0.0"
 rustdoc-types = "0.60.0"
@@ -93,7 +140,8 @@ default = ["vcs-git"]
 vcs-git = ["dep:git2"]
 vendored-libgit2 = ["git2?/vendored-libgit2"]
 
-[profile.dev]
+[lints]
+workspace = true
 
 [profile.release]
 strip = true

--- a/examples/lib/Cargo.toml
+++ b/examples/lib/Cargo.toml
@@ -1,23 +1,22 @@
 [package]
 name = "cargo-sync-rdme-example-lib"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+rust-version.workspace = true
 readme = "README.md"
+repository.workspace = true
+license.workspace = true
 publish = false
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[package.metadata.cargo-udeps.ignore]
-normal = ["async-trait", "serde", "num"]
 
 [package.metadata.cargo-sync-rdme.badge.badges]
 
 [package.metadata.cargo-sync-rdme.rustdoc]
 html-root-url = "https://gifnksm.github.io/cargo-sync-rdme/"
 
-[package.metadata.cargo-machete]
-ignored = ["async-trait", "serde"]
-
 [dependencies]
 async-trait = "0.1.89"
 num = { version = "0.4.3", features = ["num-bigint"] }
 serde = { version = "1.0.228", features = ["derive"] }
+
+[lints]
+workspace = true

--- a/examples/lib/README.md
+++ b/examples/lib/README.md
@@ -3,7 +3,7 @@
 <!-- cargo-sync-rdme ]] -->
 <!-- cargo-sync-rdme badge -->
 <!-- cargo-sync-rdme rustdoc [[ -->
-Example library of `cargo-sync-rdme`
+Example library of `cargo-sync-rdme`.
 
 This is document comments embedded in the source code.
 It will be extracted and used to generate README.md.

--- a/examples/lib/src/lib.rs
+++ b/examples/lib/src/lib.rs
@@ -1,4 +1,4 @@
-//! Example library of `cargo-sync-rdme`
+//! Example library of `cargo-sync-rdme`.
 //!
 //! This is document comments embedded in the source code.
 //! It will be extracted and used to generate README.md.
@@ -99,6 +99,13 @@
 //!     println!("Hello, world!");
 //!     # }
 
+#![allow(missing_copy_implementations, missing_debug_implementations)]
+
+// import unused external crates to demonstrate intra-doc links to external crates
+use async_trait as _;
+use num as _;
+use serde as _;
+
 #[cfg(doc)]
 use num::Num as _;
 
@@ -113,7 +120,9 @@ pub struct Struct {
 
 /// This is union.
 pub union Union {
+    /// This is a first union field.
     pub x: u32,
+    /// This is a second union field.
     pub y: i32,
 }
 

--- a/justfile
+++ b/justfile
@@ -113,11 +113,12 @@ ci-check:
     just check-all
 
 # CI: clippy warnings are treated as errors.
+[env("CARGO_BUILD_WARNINGS", "deny")]
 ci-clippy:
-    just clippy-all -- -D warnings
+    just clippy-all
 
 # CI: rustdoc warnings are treated as errors.
-[env("RUSTDOCFLAGS", x'${RUSTDOCFLAGS:-} -D warnings')]
+[env("CARGO_BUILD_WARNINGS", "deny")]
 ci-rustdoc:
     just doc-all --no-deps
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ mod args;
     version,
     about = "Cargo subcommand to synchronize README with crate documentation."
 )]
-pub struct App {
+pub(crate) struct App {
     #[clap(flatten)]
     pub(crate) verbosity: args::Verbosity,
     #[clap(flatten)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, process::Command};
 
 use cargo_metadata::{Metadata, Package, camino::Utf8Path};
 use clap::ArgAction;
-use miette::{IntoDiagnostic, WrapErr};
+use miette::{IntoDiagnostic as _, WrapErr as _};
 use tracing::Level;
 
 use crate::{
@@ -12,10 +12,10 @@ use crate::{
 
 #[derive(Debug, Clone, Copy, Default, clap::Args)]
 pub(crate) struct Verbosity {
-    /// More output per occurrence
+    /// More output per occurrence.
     #[clap(long, short = 'v', action = ArgAction::Count, global = true)]
     verbose: u8,
-    /// Less output per occurrence
+    /// Less output per occurrence.
     #[clap(
         long,
         short = 'q',
@@ -43,7 +43,7 @@ impl From<Verbosity> for Option<Level> {
 
 #[derive(Debug, Clone, Default, clap::Args)]
 pub(crate) struct WorkspaceArgs {
-    /// Path to Cargo.toml
+    /// Path to Cargo.toml.
     #[clap(long, value_name = "PATH")]
     manifest_path: Option<PathBuf>,
 }
@@ -64,11 +64,11 @@ impl WorkspaceArgs {
 
 #[derive(Debug, Clone, Default, clap::Args)]
 pub(crate) struct PackageArgs {
-    /// Sync READMEs for all packages in the workspace
+    /// Sync READMEs for all packages in the workspace.
     #[clap(long)]
     workspace: bool,
 
-    /// Package to sync README
+    /// Package to sync README.
     #[clap(long, short, value_name = "SPEC")]
     package: Option<Vec<String>>,
 }
@@ -102,15 +102,15 @@ impl PackageArgs {
 
 #[derive(Debug, Clone, Default, clap::Args)]
 pub(crate) struct FeatureArgs {
-    /// Space or comma separated list of features to activate
+    /// Space or comma separated list of features to activate.
     #[clap(long, short = 'F', value_name = "FEATURES")]
     features: Vec<String>,
 
-    /// Activate all available features
+    /// Activate all available features.
     #[clap(long)]
     all_features: bool,
 
-    /// Do not activate the `default` feature
+    /// Do not activate the `default` feature.
     #[clap(long)]
     no_default_features: bool,
 }
@@ -127,7 +127,7 @@ impl FeatureArgs {
 
 #[derive(Debug, Clone, Default, clap::Args)]
 pub(crate) struct ToolchainArgs {
-    /// Toolchain name to run `cargo rustdoc` with
+    /// Toolchain name to run `cargo rustdoc` with.
     #[clap(long)]
     toolchain: Option<String>,
 }
@@ -147,18 +147,19 @@ impl ToolchainArgs {
     }
 }
 
+#[expect(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Default, clap::Args)]
 pub(crate) struct FixArgs {
-    /// Check if READMEs are synced
+    /// Check if READMEs are synced.
     #[clap(long)]
     check: bool,
-    /// Sync README even if a VCS was not detected
+    /// Sync README even if a VCS was not detected.
     #[clap(long)]
     allow_no_vcs: bool,
-    /// Sync README even if the target file is dirty
+    /// Sync README even if the target file is dirty.
     #[clap(long)]
     allow_dirty: bool,
-    /// Sync README even if the target file has staged changes
+    /// Sync README even if the target file has staged changes.
     #[clap(long)]
     allow_staged: bool,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use miette::{NamedSource, SourceSpan};
-use once_cell::sync::Lazy;
 use serde::Deserialize;
 use toml::Spanned;
 
@@ -76,7 +75,7 @@ impl WithSource<Manifest> {
 
 impl Manifest {
     pub(crate) fn config(&self) -> &metadata::CargoSyncRdme {
-        static DEFAULT: Lazy<metadata::CargoSyncRdme> = Lazy::new(Default::default);
+        static DEFAULT: LazyLock<metadata::CargoSyncRdme> = LazyLock::new(Default::default);
         (|| {
             Some(
                 &self

--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -70,7 +70,7 @@ pub(crate) enum MaintenanceStatus {
 }
 
 impl MaintenanceStatus {
-    pub(crate) fn as_str(&self) -> &'static str {
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::ActivelyDeveloped => "actively-developed",
             Self::PassivelyMaintained => "passively-maintained",

--- a/src/config/de.rs
+++ b/src/config/de.rs
@@ -1,7 +1,7 @@
 use std::{fmt, marker::PhantomData, str::FromStr};
 
 use serde::{Deserialize, Deserializer, de::Visitor};
-use void::{ResultVoidExt, Void};
+use void::{ResultVoidExt as _, Void};
 
 pub(super) fn bool_or_map<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
 where

--- a/src/config/metadata.rs
+++ b/src/config/metadata.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fmt, str::FromStr, sync::Arc};
 
 use serde::{
     Deserialize,
-    de::{Error, Visitor},
+    de::{Error as _, Visitor},
 };
 use void::Void;
 
@@ -134,89 +134,84 @@ impl BadgeKind {
     }
 }
 
+fn deserialize_badge_list<'de, D>(deserializer: D) -> Result<Arc<[BadgeItem]>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct BadgeList;
+
+    impl<'de> Visitor<'de> for BadgeList {
+        type Value = Arc<[BadgeItem]>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("map")
+        }
+
+        fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+        where
+            M: serde::de::MapAccess<'de>,
+        {
+            let mut data = vec![];
+            while let Some(key) = map.next_key::<&str>()? {
+                #[derive(Deserialize)]
+                #[serde(bound = "T: Default + Deserialize<'de>")]
+                struct BoolOrMap<T>(#[serde(deserialize_with = "de::bool_or_map")] Option<T>);
+
+                let kind = BadgeKind::from_str(key)
+                    .map_err(|()| M::Error::unknown_variant(key, BadgeKind::expecting()))?;
+
+                match kind {
+                    BadgeKind::Maintenance => {
+                        if map.next_value::<bool>()? {
+                            data.push(BadgeItem::Maintenance);
+                        }
+                    }
+                    BadgeKind::License => {
+                        if let BoolOrMap(Some(license)) = map.next_value::<BoolOrMap<License>>()? {
+                            data.push(BadgeItem::License(license));
+                        }
+                    }
+                    BadgeKind::CratesIo => {
+                        if map.next_value::<bool>()? {
+                            data.push(BadgeItem::CratesIo);
+                        }
+                    }
+                    BadgeKind::DocsRs => {
+                        if map.next_value::<bool>()? {
+                            data.push(BadgeItem::DocsRs);
+                        }
+                    }
+                    BadgeKind::RustVersion => {
+                        if map.next_value::<bool>()? {
+                            data.push(BadgeItem::RustVersion);
+                        }
+                    }
+                    BadgeKind::GithubActions => {
+                        if let BoolOrMap(Some(github_actions)) =
+                            map.next_value::<BoolOrMap<GithubActions>>()?
+                        {
+                            data.push(BadgeItem::GithubActions(github_actions));
+                        }
+                    }
+                    BadgeKind::Codecov => {
+                        if let BoolOrMap(Some(codecov)) = map.next_value::<BoolOrMap<Codecov>>()? {
+                            data.push(BadgeItem::Codecov(codecov));
+                        }
+                    }
+                }
+            }
+            Ok(data.into())
+        }
+    }
+
+    deserializer.deserialize_any(BadgeList)
+}
+
 impl<'de> Deserialize<'de> for Badge {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        fn deserialize_badge_list<'de, D>(deserializer: D) -> Result<Arc<[BadgeItem]>, D::Error>
-        where
-            D: serde::Deserializer<'de>,
-        {
-            struct BadgeList;
-
-            impl<'de> Visitor<'de> for BadgeList {
-                type Value = Arc<[BadgeItem]>;
-
-                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    formatter.write_str("map")
-                }
-
-                fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
-                where
-                    M: serde::de::MapAccess<'de>,
-                {
-                    let mut data = vec![];
-                    while let Some(key) = map.next_key::<&str>()? {
-                        let kind = BadgeKind::from_str(key)
-                            .map_err(|_| M::Error::unknown_variant(key, BadgeKind::expecting()))?;
-                        #[derive(Deserialize)]
-                        #[serde(bound = "T: Default + Deserialize<'de>")]
-                        struct BoolOrMap<T>(
-                            #[serde(deserialize_with = "de::bool_or_map")] Option<T>,
-                        );
-
-                        match kind {
-                            BadgeKind::Maintenance => {
-                                if map.next_value::<bool>()? {
-                                    data.push(BadgeItem::Maintenance);
-                                }
-                            }
-                            BadgeKind::License => {
-                                if let BoolOrMap(Some(license)) =
-                                    map.next_value::<BoolOrMap<License>>()?
-                                {
-                                    data.push(BadgeItem::License(license));
-                                }
-                            }
-                            BadgeKind::CratesIo => {
-                                if map.next_value::<bool>()? {
-                                    data.push(BadgeItem::CratesIo);
-                                }
-                            }
-                            BadgeKind::DocsRs => {
-                                if map.next_value::<bool>()? {
-                                    data.push(BadgeItem::DocsRs);
-                                }
-                            }
-                            BadgeKind::RustVersion => {
-                                if map.next_value::<bool>()? {
-                                    data.push(BadgeItem::RustVersion);
-                                }
-                            }
-                            BadgeKind::GithubActions => {
-                                if let BoolOrMap(Some(github_actions)) =
-                                    map.next_value::<BoolOrMap<GithubActions>>()?
-                                {
-                                    data.push(BadgeItem::GithubActions(github_actions));
-                                }
-                            }
-                            BadgeKind::Codecov => {
-                                if let BoolOrMap(Some(codecov)) =
-                                    map.next_value::<BoolOrMap<Codecov>>()?
-                                {
-                                    data.push(BadgeItem::Codecov(codecov));
-                                }
-                            }
-                        }
-                    }
-                    Ok(data.into())
-                }
-            }
-
-            deserializer.deserialize_any(BadgeList)
-        }
-
         struct Badges;
         impl<'de> Visitor<'de> for Badges {
             type Value = Badge;
@@ -238,21 +233,18 @@ impl<'de> Deserialize<'de> for Badge {
 
                 while let Some(key) = map.next_key::<String>()? {
                     let expected = &["badges", "badges-*", "style"];
-                    match key.as_str() {
-                        "style" => {
-                            data.style = map.next_value()?;
-                        }
-                        _ => {
-                            let key = if key == "badges" {
-                                String::new()
-                            } else if let Some(rest) = key.strip_prefix("badges-") {
-                                rest.to_owned()
-                            } else {
-                                return Err(M::Error::unknown_field(&key, expected));
-                            };
-                            let value = map.next_value::<BadgeList>()?;
-                            data.badges.entry(key.into()).or_insert(value.0);
-                        }
+                    if key.as_str() == "style" {
+                        data.style = map.next_value()?;
+                    } else {
+                        let key = if key == "badges" {
+                            String::new()
+                        } else if let Some(rest) = key.strip_prefix("badges-") {
+                            rest.to_owned()
+                        } else {
+                            return Err(M::Error::unknown_field(&key, expected));
+                        };
+                        let value = map.next_value::<BadgeList>()?;
+                        data.badges.entry(key.into()).or_insert(value.0);
                     }
                 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use indoc::indoc;
 
 use crate::config::metadata::{BadgeItem, Codecov, GithubActions, GithubActionsWorkflow, License};
@@ -22,7 +20,7 @@ fn get_badges(manifest: Manifest) -> Arc<[BadgeItem]> {
 
 #[test]
 fn test_badges_order() {
-    let input = indoc! {r#"
+    let input = indoc! {r"
             [package.metadata.cargo-sync-rdme.badge.badges]
             license = true
             maintenance = true
@@ -31,7 +29,7 @@ fn test_badges_order() {
             codecov = true
             docs-rs = false
             rust-version = true
-        "#};
+        "};
     let badges = get_badges(toml::from_str(input).unwrap());
     assert!(matches!(
         *badges,
@@ -47,13 +45,13 @@ fn test_badges_order() {
 
 #[test]
 fn test_duplicated_badges() {
-    let input = indoc! {r#"
+    let input = indoc! {r"
             [package.metadata.cargo-sync-rdme.badge.badges]
             license = true
             license-x = true
             maintenance = true
             license-z = true
-        "#};
+        "};
     let badges = get_badges(toml::from_str(input).unwrap());
     assert!(matches!(
         *badges,
@@ -68,27 +66,27 @@ fn test_duplicated_badges() {
 
 #[test]
 fn test_license() {
-    let input = indoc! {r#"
+    let input = indoc! {r"
             [package.metadata.cargo-sync-rdme.badge.badges]
             license = true
-        "#};
+        "};
     let badges = get_badges(toml::from_str(input).unwrap());
     assert!(matches!(
         &*badges,
         [BadgeItem::License(License { link: None })]
     ));
 
-    let input = indoc! {r#"
+    let input = indoc! {r"
             [package.metadata.cargo-sync-rdme.badge.badges]
             license = false
-        "#};
+        "};
     let badges = get_badges(toml::from_str(input).unwrap());
     assert!(matches!(&*badges, []));
 
-    let input = indoc! {r#"
+    let input = indoc! {r"
             [package.metadata.cargo-sync-rdme.badge.badges]
             license = {}
-        "#};
+        "};
     let badges = get_badges(toml::from_str(input).unwrap());
     assert!(matches!(
         &*badges,
@@ -108,27 +106,27 @@ fn test_license() {
 
 #[test]
 fn test_github_actions() {
-    let input = indoc! {r#"
+    let input = indoc! {r"
             [package.metadata.cargo-sync-rdme.badge.badges]
             github-actions = true
-        "#};
+        "};
     let badges = get_badges(toml::from_str(input).unwrap());
     assert!(matches!(
         &*badges,
         [BadgeItem::GithubActions(GithubActions { workflows })] if matches!(workflows.as_slice(), &[])
     ));
 
-    let input = indoc! {r#"
+    let input = indoc! {r"
             [package.metadata.cargo-sync-rdme.badge.badges]
             github-actions = false
-        "#};
+        "};
     let badges = get_badges(toml::from_str(input).unwrap());
     assert!(matches!(*badges, []));
 
-    let input = indoc! {r#"
+    let input = indoc! {r"
             [package.metadata.cargo-sync-rdme.badge.badges]
             github-actions = {}
-        "#};
+        "};
     let badges = get_badges(toml::from_str(input).unwrap());
     assert!(matches!(
         &*badges,
@@ -185,10 +183,10 @@ fn test_github_actions() {
 
 #[test]
 fn test_codecov() {
-    let input = indoc! {r#"
+    let input = indoc! {r"
             [package.metadata.cargo-sync-rdme.badge.badges]
             codecov = true
-        "#};
+        "};
     let badges = get_badges(toml::from_str(input).unwrap());
     assert!(matches!(
         &*badges,
@@ -198,17 +196,17 @@ fn test_codecov() {
         })]
     ));
 
-    let input = indoc! {r#"
+    let input = indoc! {r"
             [package.metadata.cargo-sync-rdme.badge.badges]
             codecov = false
-        "#};
+        "};
     let badges = get_badges(toml::from_str(input).unwrap());
     assert!(matches!(*badges, []));
 
-    let input = indoc! {r#"
+    let input = indoc! {r"
             [package.metadata.cargo-sync-rdme.badge.badges]
             codecov = {}
-        "#};
+        "};
     let badges = get_badges(toml::from_str(input).unwrap());
     assert!(matches!(
         &*badges,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Write};
+use std::fmt::{self, Write as _};
 
 use console::{Style, style};
 use similar::{ChangeTag, TextDiff};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -53,7 +53,7 @@ macro_rules! miette {
     };
 }
 
-/// try for iterator implementation
+/// try for iterator implementation.
 macro_rules! itry {
     ($e:expr) => {
         match $e {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,24 +5,19 @@
 //!
 //! [repository's README]: https://github.com/gifnksm/cargo-sync-rdme/blob/main/README.md
 
-#![warn(
-    elided_lifetimes_in_paths,
-    explicit_outlives_requirements,
-    keyword_idents,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    single_use_lifetimes,
-    unreachable_pub,
-    unused
-)]
+// Keep this lint local to the binary crate as a workaround for rust-lang/rust#159078,
+// where enabling it workspace-wide produces false positives for library test targets.
+// <https://github.com/rust-lang/rust/issues/159078>
+#![warn(dead_code_pub_in_binary)]
 
 use std::{env, io, process};
 
-use clap::{CommandFactory as _, Parser};
+use clap::{CommandFactory as _, Parser as _};
 use clap_complete::{Generator, Shell};
 use tracing::Level;
 use tracing_subscriber::{EnvFilter, filter::LevelFilter};
+
+use crate::cli::App;
 
 #[macro_use]
 mod macros;
@@ -35,18 +30,13 @@ mod traits;
 mod vcs;
 mod with_source;
 
-pub use self::cli::App;
-
-/// Error type for `cargo-sync-rdme` command.
-pub type Error = miette::Error;
-
 /// Result type for `cargo-sync-rdme` command.
-pub type Result<T> = miette::Result<T>;
+type Result<T> = miette::Result<T>;
 
 /// Entry point of `cargo-sync-rdme` command.
 fn main() -> Result<()> {
     let bin_name = env!("CARGO_BIN_NAME");
-    let env_prefix = bin_name.to_uppercase().replace("-", "_");
+    let env_prefix = bin_name.to_uppercase().replace('-', "_");
     if let Ok(shell) = env::var(format!("{env_prefix}_COMPLETE")) {
         print_completion(bin_name, &shell);
         process::exit(0);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,6 +1,6 @@
 use std::{
     fs,
-    io::{self, Write},
+    io::{self, Write as _},
     sync::Arc,
 };
 
@@ -8,11 +8,11 @@ use cargo_metadata::{
     Metadata, Package,
     camino::{Utf8Path, Utf8PathBuf},
 };
-use miette::{IntoDiagnostic, NamedSource, WrapErr};
+use miette::{IntoDiagnostic as _, NamedSource, WrapErr as _};
 use pulldown_cmark::{Options, Parser};
 use tempfile::NamedTempFile;
 
-use crate::{Result, cli::App, config::Manifest, traits::PackageExt, with_source::WithSource};
+use crate::{Result, cli::App, config::Manifest, traits::PackageExt as _, with_source::WithSource};
 
 mod contents;
 mod marker;

--- a/src/sync/contents.rs
+++ b/src/sync/contents.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use cargo_metadata::{Metadata, Package};
 
-use crate::App;
+use crate::cli::App;
 
 use super::{ManifestFile, marker::Replace};
 
@@ -67,7 +67,7 @@ impl Replace {
         let text = match self {
             Replace::Title => title::create(package),
             Replace::Badge { name: _, badges } => {
-                badge::create_all(badges, manifest, workspace, package)?
+                badge::create_all(&badges, manifest, workspace, package)?
             }
             Replace::Rustdoc => rustdoc::create(app, manifest, workspace, package)?,
         };

--- a/src/sync/contents/badge.rs
+++ b/src/sync/contents/badge.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, cmp::Ordering, fmt, fmt::Write, fs, io, sync::Arc};
+use std::{borrow::Cow, cmp::Ordering, fmt, fmt::Write as _, fs, io, sync::Arc};
 
 use cargo_metadata::{
     Metadata, Package,
@@ -19,10 +19,10 @@ use crate::{
     sync::ManifestFile,
 };
 
-type CreateResult<T> = std::result::Result<T, Box<CreateBadgeError>>;
+type CreateResult<T> = Result<T, Box<CreateBadgeError>>;
 
 pub(super) fn create_all(
-    badges: Arc<[metadata::BadgeItem]>,
+    badges: &[metadata::BadgeItem],
     manifest: &ManifestFile,
     workspace: &Metadata,
     package: &Package,
@@ -31,7 +31,7 @@ pub(super) fn create_all(
 
     let mut errors = vec![];
 
-    for badge in &*badges {
+    for badge in badges {
         match BadgeLinkSet::from_config(badge, manifest, workspace, package) {
             Ok(BadgeLinkSet::None) => {}
             Ok(BadgeLinkSet::One(badge)) => writeln!(&mut output, "{badge}").unwrap(),
@@ -182,7 +182,7 @@ impl<'a> ShieldsIo<'a> {
         Self::with_path(format!("badge/{label}-{message}-{color}.svg"))
     }
 
-    fn new_maintenance(status: &MaintenanceStatus) -> Option<Self> {
+    fn new_maintenance(status: MaintenanceStatus) -> Option<Self> {
         use MaintenanceStatus as Ms;
         // image url borrowed from https://gist.github.com/taiki-e/ad73eaea17e2e0372efb76ef6b38f17b
         let color = match status {
@@ -293,7 +293,7 @@ impl BadgeLink {
     fn maintenance(manifest: &ManifestFile) -> CreateResult<Option<Self>> {
         let status_with_source = (|| manifest.try_badges()?.try_maintenance()?.try_status())()
             .map_err(|err| CreateBadgeError::from(err.with_key("badges.maintenance.status")))?;
-        let status = status_with_source.value().get_ref();
+        let status = *status_with_source.value().get_ref();
 
         let image = match ShieldsIo::new_maintenance(status) {
             Some(shields_io) => shields_io.build(manifest).to_string(),
@@ -331,7 +331,7 @@ impl BadgeLink {
         let link = license
             .link
             .clone()
-            .or_else(|| license_path.map(|p| p.to_string()));
+            .or_else(|| license_path.map(ToString::to_string));
         let image = ShieldsIo::new_license(&package.name)
             .build(manifest)
             .to_string();
@@ -410,7 +410,7 @@ impl BadgeLink {
         let results = if github_actions.workflows.is_empty() {
             Self::github_actions_from_directory(workspace)?
         } else {
-            Self::github_actions_from_config(&github_actions.workflows, workspace)?
+            Self::github_actions_from_config(&github_actions.workflows, workspace)
         };
 
         let results = results
@@ -543,7 +543,7 @@ impl BadgeLink {
     fn github_actions_from_config(
         workflows: &[metadata::GithubActionsWorkflow],
         workspace: &Metadata,
-    ) -> CreateResult<Vec<CreateResult<(String, String)>>> {
+    ) -> Vec<CreateResult<(String, String)>> {
         let workflows_dir_path = workspace.workspace_root.join(".github/workflows");
 
         let mut badges = vec![];
@@ -562,7 +562,7 @@ impl BadgeLink {
             badges.push(Ok((name, workflow.file.clone())));
         }
 
-        Ok(badges)
+        badges
     }
 }
 

--- a/src/sync/contents/rustdoc.rs
+++ b/src/sync/contents/rustdoc.rs
@@ -45,7 +45,7 @@ pub(super) fn create(
 
     let doc_with_source: WithSource<Crate> = WithSource::from_json("rustdoc output", output_file)?;
     let doc = doc_with_source.value();
-    let root = doc.index.get(&doc.root).unwrap();
+    let root = &doc.index[&doc.root];
     let local_html_root_url = config.rustdoc.html_root_url.clone().unwrap_or_else(|| {
         format!(
             "https://docs.rs/{}/{}",

--- a/src/sync/contents/rustdoc/code_block.rs
+++ b/src/sync/contents/rustdoc/code_block.rs
@@ -83,8 +83,7 @@ fn is_attribute_tag(tag: &str) -> bool {
         "" | "ignore" | "should_panic" | "no_run" | "compile_fail"
     ) || tag
         .strip_prefix("edition")
-        .map(|x| x.len() == 4 && x.chars().all(|ch| ch.is_ascii_digit()))
-        .unwrap_or_default()
+        .is_some_and(|x| x.len() == 4 && x.chars().all(|ch| ch.is_ascii_digit()))
 }
 
 fn update_codeblock_tag(tag: &mut CowStr<'_>) -> bool {
@@ -108,13 +107,15 @@ fn update_codeblock_tag(tag: &mut CowStr<'_>) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
+
     #[test]
     fn update_codeblock_tag() {
         fn check(tag: &str, expected_tag: &str, expected_is_rust: bool) {
             let mut tag = tag.into();
             let is_rust = super::update_codeblock_tag(&mut tag);
             assert_eq!(tag.as_ref(), expected_tag);
-            assert_eq!(is_rust, expected_is_rust)
+            assert_eq!(is_rust, expected_is_rust);
         }
         check("", "rust", true);
         check("typescript", "typescript", false);
@@ -135,45 +136,46 @@ mod tests {
 
     #[test]
     fn hide_codeblock_line() {
-        let input = r#"
-Lorem ipsum
+        let input = indoc! {r"
+            Lorem ipsum
 
-```rust
-# This line and the next should be hidden, but the following should not.
-#
-#[derive(Debug)]
-struct Foo;
+            ```rust
+            # This line and the next should be hidden, but the following should not.
+            #
+            #[derive(Debug)]
+            struct Foo;
 
-fn main() {
-    # As should this and the next line.
-    #
-    #But not this.
-    ## This should become a single #.
-    ##And this.
-}
-```
+            fn main() {
+                # As should this and the next line.
+                #
+                #But not this.
+                ## This should become a single #.
+                ##And this.
+            }
+            ```
 
-```toml
-# This is not Rust so it should not be hidden.
-```
-"#;
+            ```toml
+            # This is not Rust so it should not be hidden.
+            ```
+        "};
 
-        let expected = r#"Lorem ipsum
+        let expected = indoc! {r"
+            Lorem ipsum
 
-````rust
-#[derive(Debug)]
-struct Foo;
+            ````rust
+            #[derive(Debug)]
+            struct Foo;
 
-fn main() {
-    #But not this.
-    # This should become a single #.
-    #And this.
-}
-````
+            fn main() {
+                #But not this.
+                # This should become a single #.
+                #And this.
+            }
+            ````
 
-````toml
-# This is not Rust so it should not be hidden.
-````"#;
+            ````toml
+            # This is not Rust so it should not be hidden.
+            ````"};
 
         let events: Vec<_> = pulldown_cmark::Parser::new(input).collect();
         let events: Vec<_> = super::convert(events).collect();

--- a/src/sync/contents/rustdoc/heading.rs
+++ b/src/sync/contents/rustdoc/heading.rs
@@ -3,7 +3,7 @@ use pulldown_cmark::{Event, Tag, TagEnd};
 pub(super) fn convert<'a, 'b>(
     events: impl IntoIterator<Item = Event<'a>> + 'b,
 ) -> impl Iterator<Item = Event<'a>> + 'b {
-    use pulldown_cmark::HeadingLevel::*;
+    use pulldown_cmark::HeadingLevel::{H1, H2, H3, H4, H5, H6};
     events.into_iter().map(|mut event| {
         match &mut event {
             Event::Start(Tag::Heading { level, .. }) | Event::End(TagEnd::Heading(level)) => {
@@ -12,8 +12,7 @@ pub(super) fn convert<'a, 'b>(
                     H2 => H3,
                     H3 => H4,
                     H4 => H5,
-                    H5 => H6,
-                    H6 => H6,
+                    H5 | H6 => H6,
                 }
             }
             _ => {}

--- a/src/sync/contents/rustdoc/intra_link.rs
+++ b/src/sync/contents/rustdoc/intra_link.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     cmp::Reverse,
     collections::{BinaryHeap, HashMap},
-    fmt::Write,
+    fmt::Write as _,
     rc::Rc,
 };
 
@@ -92,7 +92,7 @@ fn resolve_links<'doc>(
             if let Some(path) = mappings.get(name) {
                 (name.as_str(), Some(path.clone()))
             } else {
-                let url = id_to_url(doc, &extra_paths, local_html_root_url, id).or_else(|| {
+                let url = id_to_url(doc, &extra_paths, local_html_root_url, *id).or_else(|| {
                     tracing::warn!(?id, "failed to resolve link to `{name}`");
                     None
                 });
@@ -114,21 +114,6 @@ fn extra_paths<'doc>(
     index: &'doc HashMap<Id, Item>,
     paths: &'doc HashMap<Id, ItemSummary>,
 ) -> HashMap<&'doc Id, Node<'doc>> {
-    let mut map: HashMap<&Id, Node<'_>> = index
-        .iter()
-        .map(|(id, item)| {
-            (
-                id,
-                Node {
-                    depth: usize::MAX,
-                    kind: item_kind(item),
-                    name: item.name.as_deref(),
-                    parent: None,
-                },
-            )
-        })
-        .collect();
-
     #[derive(Debug)]
     struct HeapItem<'doc> {
         depth: Reverse<usize>,
@@ -153,6 +138,21 @@ fn extra_paths<'doc>(
         }
     }
     impl Eq for HeapItem<'_> {}
+
+    let mut map: HashMap<&Id, Node<'_>> = index
+        .iter()
+        .map(|(id, item)| {
+            (
+                id,
+                Node {
+                    depth: usize::MAX,
+                    kind: item_kind(item),
+                    name: item.name.as_deref(),
+                    parent: None,
+                },
+            )
+        })
+        .collect();
 
     let mut heap: BinaryHeap<HeapItem<'_>> = index
         .iter()
@@ -187,12 +187,9 @@ fn extra_paths<'doc>(
         map.get_mut(id).unwrap().depth = depth;
 
         for child in item_children(item).into_iter().flatten() {
-            let child = match index.get(child) {
-                Some(child) => child,
-                None => {
-                    tracing::trace!(?item, ?child, "child item missing");
-                    continue;
-                }
+            let Some(child) = index.get(child) else {
+                tracing::trace!(?item, ?child, "child item missing");
+                continue;
             };
             let child_depth = depth + 1;
             heap.push(HeapItem {
@@ -240,8 +237,6 @@ fn item_kind(item: &Item) -> ItemKind {
 fn item_children<'doc>(parent: &'doc Item) -> Option<Box<dyn Iterator<Item = &'doc Id> + 'doc>> {
     match &parent.inner {
         ItemEnum::Module(m) => Some(Box::new(m.items.iter())),
-        ItemEnum::ExternCrate { .. } => None,
-        ItemEnum::Use(_) => None,
         ItemEnum::Union(u) => Some(Box::new(u.fields.iter())),
         ItemEnum::Struct(s) => match &s.kind {
             StructKind::Unit => None,
@@ -251,7 +246,6 @@ fn item_children<'doc>(parent: &'doc Item) -> Option<Box<dyn Iterator<Item = &'d
                 has_stripped_fields: _,
             } => Some(Box::new(fields.iter())),
         },
-        ItemEnum::StructField(_) => None,
         ItemEnum::Enum(e) => Some(Box::new(e.variants.iter())),
         ItemEnum::Variant(v) => match &v.kind {
             VariantKind::Plain => None,
@@ -261,19 +255,22 @@ fn item_children<'doc>(parent: &'doc Item) -> Option<Box<dyn Iterator<Item = &'d
                 has_stripped_fields: _,
             } => Some(Box::new(fields.iter())),
         },
-        ItemEnum::Function(_) => None,
         ItemEnum::Trait(t) => Some(Box::new(t.items.iter())),
-        ItemEnum::TraitAlias(_) => None,
         ItemEnum::Impl(i) => Some(Box::new(i.items.iter())),
-        ItemEnum::TypeAlias(_) => None,
-        ItemEnum::Constant { .. } => None,
-        ItemEnum::Static(_) => None,
-        ItemEnum::ExternType => None,
-        ItemEnum::Macro(_) => None,
-        ItemEnum::ProcMacro(_) => None,
-        ItemEnum::Primitive(_) => None,
-        ItemEnum::AssocConst { .. } => None,
-        ItemEnum::AssocType { .. } => None,
+        ItemEnum::ExternCrate { .. }
+        | ItemEnum::Use(_)
+        | ItemEnum::StructField(_)
+        | ItemEnum::Function(_)
+        | ItemEnum::TraitAlias(_)
+        | ItemEnum::TypeAlias(_)
+        | ItemEnum::Constant { .. }
+        | ItemEnum::Static(_)
+        | ItemEnum::ExternType
+        | ItemEnum::Macro(_)
+        | ItemEnum::ProcMacro(_)
+        | ItemEnum::Primitive(_)
+        | ItemEnum::AssocConst { .. }
+        | ItemEnum::AssocType { .. } => None,
     }
 }
 
@@ -284,7 +281,7 @@ fn convert_link<'a>(
     if let Event::Start(Tag::Link { dest_url: url, .. }) = &mut event
         && let Some(full_url) = url_map.get(url.as_ref())
     {
-        *url = full_url.as_ref()?.to_owned().into()
+        *url = full_url.as_ref()?.to_owned().into();
     }
     Some(event)
 }
@@ -293,9 +290,9 @@ fn id_to_url(
     doc: &Crate,
     extra_paths: &HashMap<&Id, Node<'_>>,
     local_html_root_url: &str,
-    id: &Id,
+    id: Id,
 ) -> Option<String> {
-    let item = item_summary(doc, extra_paths, id)?;
+    let item = item_summary(doc, extra_paths, &id)?;
     let html_root_url = if item.crate_id == 0 {
         // local item
         local_html_root_url

--- a/src/sync/marker.rs
+++ b/src/sync/marker.rs
@@ -3,7 +3,7 @@ use std::{fmt, sync::Arc};
 use miette::SourceSpan;
 
 pub(super) use self::{find::*, replace::*};
-use crate::{config::metadata::BadgeItem, traits::StrSpanExt};
+use crate::{config::metadata::BadgeItem, traits::StrSpanExt as _};
 
 use super::ManifestFile;
 
@@ -194,7 +194,7 @@ mod tests {
             let span = SourceSpan::from(0..s.len());
             match Marker::matches((s, span), &manifest).unwrap_err() {
                 ParseMarkerError::NoReplace { .. } => {}
-                e => panic!("unexpected: {e}"),
+                e @ ParseMarkerError::ParseReplace { .. } => panic!("unexpected: {e}"),
             }
         }
 

--- a/src/sync/marker/find.rs
+++ b/src/sync/marker/find.rs
@@ -121,6 +121,8 @@ where
 mod tests {
     use pulldown_cmark::Parser;
 
+    use crate::config::Manifest;
+
     use super::*;
 
     fn line_ranges(lines: &[impl AsRef<str>]) -> Vec<Range<usize>> {
@@ -139,7 +141,7 @@ mod tests {
     fn no_markers() {
         let input = "Hello, world!";
         let mut markers = Iter {
-            manifest: &ManifestFile::dummy(Default::default()),
+            manifest: &ManifestFile::dummy(Manifest::default()),
             events: Parser::new(input).into_offset_iter(),
         };
         assert!(markers.next().is_none());

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -26,7 +26,7 @@ pub(crate) trait StrSpanExt: Sized {
 }
 
 mod imp {
-    use super::*;
+    use super::{SourceSpan, StrSpanExt};
 
     fn new(s: &str, offset: usize) -> (&str, SourceSpan) {
         (s, (offset, s.len()).into())

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -5,6 +5,7 @@ use crate::Result;
 #[cfg(feature = "vcs-git")]
 mod git;
 
+#[cfg_attr(not(feature = "vcs-git"), expect(clippy::unnecessary_wraps))]
 pub(crate) fn discover(path: impl AsRef<Utf8Path>) -> Result<Option<Box<dyn Vcs>>> {
     let path = path.as_ref();
 
@@ -24,8 +25,8 @@ pub(crate) trait Vcs {
     fn status_file(&self, path: &Utf8Path) -> Result<Status>;
 }
 
+#[cfg_attr(not(feature = "vcs-git"), expect(dead_code))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) enum Status {
     Dirty,
     Staged,


### PR DESCRIPTION
## Summary
- consolidate Rust, Clippy, and rustdoc lint configuration at the workspace level and opt member crates into inheriting it
- fix the resulting warnings across the codebase and example crate, including generated example README text
- keep `dead_code_pub_in_binary` local to `src/main.rs` as a workaround for rust-lang/rust#159078 instead of enabling it workspace-wide
- replace `once_cell::sync::Lazy` with `std::sync::LazyLock` and drop the unused dependency
- switch CI warning denial from ad-hoc `-D warnings` / `RUSTDOCFLAGS` wiring to `CARGO_BUILD_WARNINGS=deny`

## Motivation
This centralizes lint policy, keeps the workspace clean under the configured lint set, and makes warning handling consistent across `clippy` and `doc` runs. It also avoids relying on `cargo machete` ignore metadata by expressing the example crate's dependency usage directly in code.

## Validation
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `CARGO_BUILD_WARNINGS=deny cargo doc --workspace --all-features --no-deps`
- `just ci-clippy`
- `just ci-rustdoc`
- `cargo run -- --workspace --check --allow-no-vcs --allow-dirty --allow-staged --toolchain nightly`

## Behavior
No functional behavior changes are intended. The user-visible content updates are limited to documentation and README output produced to satisfy the tightened lint configuration.
