### PR TITLE
Use active toolchain for sync-rdme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rust: [nightly]
+        rust: [stable]
         os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -161,6 +161,8 @@ jobs:
         with:
           tool: just,cargo-hack
       - uses: Swatinem/rust-cache@v2
+      - run: rustup install nightly
+        shell: bash
       - run: just ci-sync-rdme
         shell: bash
 

--- a/justfile
+++ b/justfile
@@ -60,7 +60,7 @@ doc-all *args:
 
 # Synchronize README snippets for all packages.
 sync-rdme-all *args:
-    rustup run nightly cargo run -- --workspace {{ args }}
+    cargo run -- --workspace --toolchain nightly {{ args }}
 
 # Detect unused dependencies.
 machete *args:


### PR DESCRIPTION
## Summary
- run `cargo-sync-rdme` itself via the active toolchain in `just sync-rdme-all`
- pass `--toolchain nightly` so only the internal `cargo rustdoc` invocation uses nightly
- update the `sync-rdme` CI job to run on stable and install nightly explicitly

## Motivation
`cargo-sync-rdme` only needs nightly for unstable rustdoc features. This keeps the main binary running on the active toolchain while still ensuring nightly is available where required.

## Validation
- `just ci-sync-rdme`

## Impact
- local `just sync-rdme-all` now runs the binary with the active toolchain
- CI now verifies the same behavior by running the job on stable and installing nightly separately
