### PR TITLE
Use minimal profile for nightly install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         with:
           tool: just,cargo-hack
       - uses: Swatinem/rust-cache@v2
-      - run: rustup install nightly
+      - run: rustup toolchain install nightly --profile minimal
         shell: bash
       - run: just ci-sync-rdme
         shell: bash


### PR DESCRIPTION
## Summary
- change the `sync-rdme` CI job to install nightly with `rustup toolchain add nightly --profile minimal`

## Motivation
The job only needs nightly available for the internal `cargo rustdoc` invocation. Using the minimal profile avoids installing unnecessary components.

## Validation
- `just ci-sync-rdme`
- confirmed `rustup toolchain add --help` supports `--profile minimal`

## Impact
- reduces the amount of toolchain content installed in the `sync-rdme` CI job
- keeps the existing behavior of running the job itself on stable while making nightly available separately
