### PR TITLE
Expand link showcase coverage

### DIFF
--- a/examples/lib/README.md
+++ b/examples/lib/README.md
@@ -27,8 +27,8 @@ Intra-doc links are also supported.
 * Reference shortcut link with backtick: [`Union`]
 
 * Link with paths: [`crate::Struct`], [`self::Struct`]
-* Link with namespace: [`Struct`](struct@Struct), [`macro_`](macro@macro_)
-* Link with disambiguators: [`function()`], [`macro_!`]
+* Link with namespace: [`Struct`](struct@Struct), [`declarative_macro`](macro@declarative_macro)
+* Link with disambiguators: [`function()`], [`declarative_macro!`]
 
 [e1]: Enum
 [e2]: `Enum`
@@ -50,35 +50,54 @@ Intra-doc links are also supported.
 
 * Link with paths: [`crate::Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html), [`self::Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)
 
-* Link with namespace: [`Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html), [`macro_`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.macro_.html)
+* Link with namespace: [`Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html), [`declarative_macro`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html)
 
-* Link with disambiguators: [`function()`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html), [`macro_!`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.macro_.html)
+* Link with disambiguators: [`function()`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html), [`declarative_macro!`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html)
 
 ### Link showcase
 
 <!-- markdownlint-disable MD060 -->
 
-|Item Kind|[`crate`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/index.html)|[`std`](https://doc.rust-lang.org/nightly/std/index.html)|External Crate|
-|---------|-------|-----|--------------|
+|Link Target|[`crate`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/index.html)|[`std`](https://doc.rust-lang.org/nightly/std/index.html)|External Crate|
+|-----------|-------|-----|--------------|
 |Module|[`module`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html)|[`std::collections`](https://doc.rust-lang.org/nightly/std/collections/index.html)|[`num::bigint`](https://docs.rs/num/0.4/num/bigint/index.html)|
-|Struct|[`Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)|[`std::collections::HashMap`](https://doc.rust-lang.org/nightly/std/collections/hash/map/struct.HashMap.html)|[`num::bigint::BigInt`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html)|
-|Struct Field|[`Struct::field`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#structfield.field)|[`std::ops::Range::start`](https://doc.rust-lang.org/nightly/core/ops/range/struct.Range.html#structfield.start)||
-|Union|[`Union`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html)|||
+|Struct|[`Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)|[`std::collections::HashMap`](https://doc.rust-lang.org/nightly/std/collections/hash/map/struct.HashMap.html)|[`num::BigInt`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html)|
+|Struct Field|[`Struct::field`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#structfield.field)|[`std::ops::Range::start`](https://doc.rust-lang.org/nightly/core/ops/range/struct.Range.html#structfield.start)|[`num::Complex::re`](https://docs.rs/num-complex/0.4/num_complex/struct.Complex.html#structfield.re)|
+|Tuple Struct Field|[`TupleStruct::0`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.TupleStruct.html#structfield.0)|[`std::cmp::Reverse::0`](https://doc.rust-lang.org/nightly/core/cmp/struct.Reverse.html#structfield.0)||
+|Union|[`Union`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html)|[`std::mem::MaybeUninit`](https://doc.rust-lang.org/nightly/core/mem/maybe_uninit/union.MaybeUninit.html)||
+|Union Field|[`Union::x`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Union.html#structfield.x)|||
 |Enum|[`Enum`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html)|[`Option`](https://doc.rust-lang.org/nightly/core/option/enum.Option.html)|[`num::traits::FloatErrorKind`](https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html)|
 |Enum Variant|[`Enum::Variant`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Variant)|[`Option::Some`](https://doc.rust-lang.org/nightly/core/option/enum.Option.html#variant.Some)|[`num::traits::FloatErrorKind::Empty`](https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html#variant.Empty)|
-|Function|[`function`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html)|[`std::iter::from_fn`](https://doc.rust-lang.org/nightly/core/iter/sources/from_fn/fn.from_fn.html)|[`num::abs`](https://docs.rs/num-traits/0.2/num_traits/sign/fn.abs.html)|
-|Typedef|[`Typedef`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.Typedef.html)|[`std::io::Result`](https://doc.rust-lang.org/nightly/core/io/error/type.Result.html)|[`num::BigRational`](https://docs.rs/num-rational/0.4/num_rational/type.BigRational.html)|
+|Variant Field|[`Enum::Struct::field`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/Enum/struct.Struct.html#structfield.field)|||
+|Tuple Variant Field|[`Enum::Tuple::0`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/Enum/struct.Tuple.html#structfield.0)|[`Option::Some::0`](https://doc.rust-lang.org/nightly/core/option/Option/struct.Some.html#structfield.0)|[`serde::de::Unexpected::Other::0`](https://docs.rs/serde_core/1.0.229/serde_core/de/Unexpected/struct.Other.html#structfield.0)|
+|Type Alias|[`TypeAlias`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html)|[`std::io::Result`](https://doc.rust-lang.org/nightly/core/io/error/type.Result.html)|[`num::BigRational`](https://docs.rs/num-rational/0.4/num_rational/type.BigRational.html)|
+|Trait|[`Trait`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html)|[`Iterator`](https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html)|[`num::Num`](https://docs.rs/num-traits/0.2/num_traits/trait.Num.html)|
+|Required Method|[`Trait::method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/Trait/fn.method.html)|[`Iterator::next`](https://doc.rust-lang.org/nightly/core/iter/traits/iterator/Iterator/fn.next.html)|[`num::Zero::is_zero`](https://docs.rs/num-traits/0.2/num_traits/identities/Zero/fn.is_zero.html)|
+|Provided Method|[`Trait::provided_method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/Trait/fn.provided_method.html)|[`Iterator::size_hint`](https://doc.rust-lang.org/nightly/core/iter/traits/iterator/Iterator/fn.size_hint.html)|[`num::Zero::set_zero`](https://docs.rs/num-traits/0.2/num_traits/identities/Zero/fn.set_zero.html)|
+|Required Associated Function|[`Trait::assoc_fn`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/Trait/fn.assoc_fn.html)|[`FromIterator::from_iter`](https://doc.rust-lang.org/nightly/core/iter/traits/collect/FromIterator/fn.from_iter.html)|[`num::Zero::zero`](https://docs.rs/num-traits/0.2/num_traits/identities/Zero/fn.zero.html)|
+|Required Associated Constant|[`Trait::CONST`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedconstant.CONST)||[`num::traits::ConstZero::ZERO`](https://docs.rs/num-traits/0.2/num_traits/identities/trait.ConstZero.html#associatedconstant.ZERO)|
+|Required Associated Type|[`Trait::Type`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedtype.Type)|[`Iterator::Item`](https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#associatedtype.Item)|[`num::Num::FromStrRadixErr`](https://docs.rs/num-traits/0.2/num_traits/trait.Num.html#associatedtype.FromStrRadixErr)|
+|Trait Implementation Method|[`Struct::method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/Struct/fn.method.html)|[`Vec::clone`](https://doc.rust-lang.org/nightly/alloc/vec/Vec/fn.clone.html)|[`num::BigInt::is_zero`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/BigInt/fn.is_zero.html)|
+|Trait Implementation Method (overrides default)|[`Struct::provided_method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/Struct/fn.provided_method.html)|[`std::slice::Iter::size_hint`](https://doc.rust-lang.org/nightly/core/slice/iter/Iter/fn.size_hint.html)|[`num::BigInt::set_zero`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/BigInt/fn.set_zero.html)|
+|Trait Implementation Associated Function|[`Struct::assoc_fn`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/Struct/fn.assoc_fn.html)|[`Vec::from_iter`](https://doc.rust-lang.org/nightly/alloc/vec/Vec/fn.from_iter.html)|[`num::BigInt::zero`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/BigInt/fn.zero.html)|
+|Trait Implementation Associated Constant|[`Struct::CONST`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Struct.html#associatedconstant.CONST)|||
+|Trait Implementation Associated Type|[`Struct::Type`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Struct.html#associatedtype.Type)|[`std::slice::Iter::Item`](https://doc.rust-lang.org/nightly/core/slice/iter/trait.Iter.html#associatedtype.Item)|[`num::BigInt::FromStrRadixErr`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/trait.BigInt.html#associatedtype.FromStrRadixErr)|
+|Inherent Method|[`Struct::inhr_method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/Struct/fn.inhr_method.html)|[`Vec::len`](https://doc.rust-lang.org/nightly/alloc/vec/Vec/fn.len.html)|[`num::BigInt::sign`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/BigInt/fn.sign.html)|
+|Inherent Associated Function|[`Struct::inhr_assoc_fn`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/Struct/fn.inhr_assoc_fn.html)|[`Vec::new`](https://doc.rust-lang.org/nightly/alloc/vec/Vec/fn.new.html)|[`num::BigInt::new`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/BigInt/fn.new.html)|
+|Inherent Associated Constant|[`Struct::INHR_CONST`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Struct.html#associatedconstant.INHR_CONST)|[`i32::MAX`](https://doc.rust-lang.org/nightly/std/trait.i32.html#associatedconstant.MAX)|[`num::BigInt::ZERO`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/trait.BigInt.html#associatedconstant.ZERO)|
 |Constant|[`CONSTANT`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html)|[`std::path::MAIN_SEPARATOR`](https://doc.rust-lang.org/nightly/std/path/constant.MAIN_SEPARATOR.html)||
-|Trait|[`Trait`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html)|[`std::clone::Clone`](https://doc.rust-lang.org/nightly/core/clone/trait.Clone.html)|[`num::Num`](https://docs.rs/num-traits/0.2/num_traits/trait.Num.html)|
-|Method (trait)|[`Trait::method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/Trait/fn.method.html)|[`std::clone::Clone::clone`](https://doc.rust-lang.org/nightly/core/clone/Clone/fn.clone.html)|[`num::Num::from_str_radix`](https://docs.rs/num-traits/0.2/num_traits/Num/fn.from_str_radix.html)|
-|Method (impl)|[`Struct::method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/Struct/fn.method.html)|[`Vec::clone`](https://doc.rust-lang.org/nightly/alloc/vec/Vec/fn.clone.html)|[`num::bigint::BigInt::from_str_radix`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/BigInt/fn.from_str_radix.html)|
 |Static|[`STATIC`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.STATIC.html)|||
-|Macro|[`macro_`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.macro_.html)|[`println`](https://doc.rust-lang.org/nightly/std/macro.println.html)||
-|Attribute Macro|||[`async_trait::async_trait`](https://docs.rs/async-trait/0.1.91/async_trait/attr.async_trait.html)|
-|Derive Macro|||[`serde::Serialize`](https://docs.rs/serde_derive/1.0.229/serde_derive/derive.Serialize.html)|
-|Associated Constant|[`Trait::CONST`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedconstant.CONST)|[`i32::MAX`](https://doc.rust-lang.org/nightly/std/trait.i32.html#associatedconstant.MAX)||
-|Associated Type|[`Trait::Type`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedtype.Type)|[`Iterator::Item`](https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#associatedtype.Item)||
-|Primitive||[`i32`](https://doc.rust-lang.org/nightly/std/primitive.i32.html)||
+|Function|[`function`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html)|[`std::iter::from_fn`](https://doc.rust-lang.org/nightly/core/iter/sources/from_fn/fn.from_fn.html)|[`num::abs`](https://docs.rs/num-traits/0.2/num_traits/sign/fn.abs.html)|
+|Primitive Type||[`i32`](https://doc.rust-lang.org/nightly/std/primitive.i32.html)||
+|Primitive Method||[`i32::count_ones`](https://doc.rust-lang.org/nightly/std/i32/fn.count_ones.html)||
+|Primitive Associated Function||[`i32::from_str_radix`](https://doc.rust-lang.org/nightly/std/i32/fn.from_str_radix.html)||
+|Primitive Associated Constant||[`i32::MAX`](https://doc.rust-lang.org/nightly/std/trait.i32.html#associatedconstant.MAX)||
+|Declarative Macro|[`declarative_macro`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html)|[`println`](https://doc.rust-lang.org/nightly/std/macro.println.html)||
+|Attribute Macro||[`derive`](https://doc.rust-lang.org/nightly/core/macros/builtin/attr.derive.html)|[`async_trait::async_trait`](https://docs.rs/async-trait/0.1.91/async_trait/attr.async_trait.html)|
+|Derive Macro||[`Clone`](https://doc.rust-lang.org/nightly/core/clone/derive.Clone.html)|[`serde::Serialize`](https://docs.rs/serde_derive/1.0.229/serde_derive/derive.Serialize.html)|
+|Re-exported from Private Module|[`ReexportedFromPrivateMod`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/private/struct.ReexportedFromPrivateMod.html)|||
+|Foreign Function|[`foreign_function`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.foreign_function.html)|||
+|Foreign Static|[`FOREIGN_STATIC`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.FOREIGN_STATIC.html)|||
 
 <!-- markdownlint-enable MD060 -->
 

--- a/examples/lib/src/lib.rs
+++ b/examples/lib/src/lib.rs
@@ -24,8 +24,8 @@
 //! * Reference shortcut link with backtick: [`Union`]
 //!
 //! * Link with paths: [`crate::Struct`], [`self::Struct`]
-//! * Link with namespace: [`Struct`](struct@Struct), [`macro_`](macro@macro_)
-//! * Link with disambiguators: [`function()`], [`macro_!`]
+//! * Link with namespace: [`Struct`](struct@Struct), [`declarative_macro`](macro@declarative_macro)
+//! * Link with disambiguators: [`function()`], [`declarative_macro!`]
 //!
 //! [e1]: Enum
 //! [e2]: `Enum`
@@ -41,8 +41,8 @@
 //! * Reference shortcut link with backtick: [`Union`]
 //!
 //! * Link with paths: [`crate::Struct`], [`self::Struct`]
-//! * Link with namespace: [`Struct`](struct@Struct), [`macro_`](macro@macro_)
-//! * Link with disambiguators: [`function()`], [`macro_!`]
+//! * Link with namespace: [`Struct`](struct@Struct), [`declarative_macro`](macro@declarative_macro)
+//! * Link with disambiguators: [`function()`], [`declarative_macro!`]
 //!
 //! [e1]: Enum
 //! [e2]: `Enum`
@@ -50,27 +50,46 @@
 //! ## Link showcase
 //!
 //! <!-- markdownlint-disable MD060 -->
-//! | Item Kind           | [`crate`]          | [`std`]                       | External Crate                               |
-//! | --------------------| ------------------ | ----------------------------- | -------------------------------------------- |
-//! | Module              | [`module`]         | [`std::collections`]          | [`num::bigint`]                              |
-//! | Struct              | [`Struct`]         | [`std::collections::HashMap`] | [`num::bigint::BigInt`]                      |
-//! | Struct Field        | [`Struct::field`]  | [`std::ops::Range::start`]    |                                              |
-//! | Union               | [`Union`]          |                               |                                              |
-//! | Enum                | [`Enum`]           | [`Option`]                    | [`num::traits::FloatErrorKind`]              |
-//! | Enum Variant        | [`Enum::Variant`]  | [`Option::Some`]              | [`num::traits::FloatErrorKind::Empty`]       |
-//! | Function            | [`function`]       | [`std::iter::from_fn`]        | [`num::abs`]                                 |
-//! | Typedef             | [`Typedef`]        | [`std::io::Result`]           | [`num::BigRational`]                         |
-//! | Constant            | [`CONSTANT`]       | [`std::path::MAIN_SEPARATOR`] |                                              |
-//! | Trait               | [`Trait`]          | [`std::clone::Clone`]         | [`num::Num`]                                 |
-//! | Method (trait)      | [`Trait::method`]  | [`std::clone::Clone::clone`]  | [`num::Num::from_str_radix`]                 |
-//! | Method (impl)       | [`Struct::method`] | [`Vec::clone`]                | [`num::bigint::BigInt::from_str_radix`]      |
-//! | Static              | [`STATIC`]         |                               |                                              |
-//! | Macro               | [`macro_`]         | [`println`]                   |                                              |
-//! | Attribute Macro     |                    |                               | [`async_trait::async_trait`]                 |
-//! | Derive Macro        |                    |                               | [`serde::Serialize`](macro@serde::Serialize) |
-//! | Associated Constant | [`Trait::CONST`]   | [`i32::MAX`]                  |                                              |
-//! | Associated Type     | [`Trait::Type`]    | [`Iterator::Item`]            |                                              |
-//! | Primitive           |                    | [`i32`]                       |                                              |
+//! | Link Target                                     | [`crate`]                     | [`std`]                         | External Crate                                |
+//! | ----------------------------------------------- | ----------------------------- | ------------------------------- | --------------------------------------------- |
+//! | Module                                          | [`module`]                    | [`std::collections`]            | [`num::bigint`]                               |
+//! | Struct                                          | [`Struct`]                    | [`std::collections::HashMap`]   | [`num::BigInt`]                               |
+//! | Struct Field                                    | [`Struct::field`]             | [`std::ops::Range::start`]      | [`num::Complex::re`]                          |
+//! | Tuple Struct Field                              | [`TupleStruct::0`]            | [`std::cmp::Reverse::0`]        |                                               |
+//! | Union                                           | [`Union`]                     | [`std::mem::MaybeUninit`]       |                                               |
+//! | Union Field                                     | [`Union::x`]                  |                                 |                                               |
+//! | Enum                                            | [`Enum`]                      | [`Option`]                      | [`num::traits::FloatErrorKind`]               |
+//! | Enum Variant                                    | [`Enum::Variant`]             | [`Option::Some`]                | [`num::traits::FloatErrorKind::Empty`]        |
+//! | Variant Field                                   | [`Enum::Struct::field`]       |                                 |                                               |
+//! | Tuple Variant Field                             | [`Enum::Tuple::0`]            | [`Option::Some::0`]             | [`serde::de::Unexpected::Other::0`]           |
+//! | Type Alias                                      | [`TypeAlias`]                 | [`std::io::Result`]             | [`num::BigRational`]                          |
+//! | Trait                                           | [`Trait`]                     | [`Iterator`]                    | [`num::Num`]                                  |
+//! | Required Method                                 | [`Trait::method`]             | [`Iterator::next`]              | [`num::Zero::is_zero`]                        |
+//! | Provided Method                                 | [`Trait::provided_method`]    | [`Iterator::size_hint`]         | [`num::Zero::set_zero`]                       |
+//! | Required Associated Function                    | [`Trait::assoc_fn`]           | [`FromIterator::from_iter`]     | [`num::Zero::zero`]                           |
+//! | Required Associated Constant                    | [`Trait::CONST`]              |                                 | [`num::traits::ConstZero::ZERO`]              |
+//! | Required Associated Type                        | [`Trait::Type`]               | [`Iterator::Item`]              | [`num::Num::FromStrRadixErr`]                 |
+//! | Trait Implementation Method                     | [`Struct::method`]            | [`Vec::clone`]                  | [`num::BigInt::is_zero`]                      |
+//! | Trait Implementation Method (overrides default) | [`Struct::provided_method`]   | [`std::slice::Iter::size_hint`] | [`num::BigInt::set_zero`]                     |
+//! | Trait Implementation Associated Function        | [`Struct::assoc_fn`]          | [`Vec::from_iter`]              | [`num::BigInt::zero`]                         |
+//! | Trait Implementation Associated Constant        | [`Struct::CONST`]             |                                 |                                               |
+//! | Trait Implementation Associated Type            | [`Struct::Type`]              | [`std::slice::Iter::Item`]      | [`num::BigInt::FromStrRadixErr`]              |
+//! | Inherent Method                                 | [`Struct::inhr_method`]       | [`Vec::len`]                    | [`num::BigInt::sign`]                         |
+//! | Inherent Associated Function                    | [`Struct::inhr_assoc_fn`]     | [`Vec::new`]                    | [`num::BigInt::new`]                          |
+//! | Inherent Associated Constant                    | [`Struct::INHR_CONST`]        | [`i32::MAX`]                    | [`num::BigInt::ZERO`]                         |
+//! | Constant                                        | [`CONSTANT`]                  | [`std::path::MAIN_SEPARATOR`]   |                                               |
+//! | Static                                          | [`STATIC`]                    |                                 |                                               |
+//! | Function                                        | [`function`]                  | [`std::iter::from_fn`]          | [`num::abs`]                                  |
+//! | Primitive Type                                  |                               | [`i32`]                         |                                               |
+//! | Primitive Method                                |                               | [`i32::count_ones`]             |                                               |
+//! | Primitive Associated Function                   |                               | [`i32::from_str_radix`]         |                                               |
+//! | Primitive Associated Constant                   |                               | [`i32::MAX`]                    |                                               |
+//! | Declarative Macro                               | [`declarative_macro`]         | [`println`]                     |                                               |
+//! | Attribute Macro                                 |                               | [`derive`]                      | [`async_trait::async_trait`]                  |
+//! | Derive Macro                                    |                               | [`Clone`](derive@Clone)         | [`serde::Serialize`](derive@serde::Serialize) |
+//! | Re-exported from Private Module                 | [`ReexportedFromPrivateMod`]  |                                 |                                               |
+//! | Foreign Function                                | [`foreign_function`]          |                                 |                                               |
+//! | Foreign Static                                  | [`FOREIGN_STATIC`]            |                                 |                                               |
 //! <!-- markdownlint-enable MD060 -->
 //!
 //! ### Code Block
@@ -97,7 +116,7 @@ use num as _;
 use serde as _;
 
 #[cfg(doc)]
-use num::Num as _;
+use num::{Num as _, traits::Zero as _};
 
 /// This is a module.
 pub mod module {}
@@ -108,11 +127,17 @@ pub struct Struct {
     pub field: usize,
 }
 
-/// This is union.
+/// This is a tuple struct.
+pub struct TupleStruct(
+    /// This is a field in a tuple struct.
+    pub usize,
+);
+
+/// This is a union.
 pub union Union {
-    /// This is a first union field.
+    /// This is the first union field.
     pub x: u32,
-    /// This is a second union field.
+    /// This is the second union field.
     pub y: i32,
 }
 
@@ -120,43 +145,103 @@ pub union Union {
 pub enum Enum {
     /// This is an enum variant.
     Variant,
+    /// This is an enum variant with a field.
+    Struct {
+        /// This is a field in an enum struct variant.
+        field: usize,
+    },
+    /// This is an enum tuple variant.
+    Tuple(
+        /// This is a field in an enum tuple variant.
+        usize,
+    ),
 }
 
 /// This is a function.
 pub fn function() {}
 
-/// This is a type definition.
-pub type Typedef = i32;
+/// This is a type alias.
+pub type TypeAlias = i32;
 
 /// This is a constant.
 pub const CONSTANT: &str = "This is a constant.";
 
 /// This is a trait.
 pub trait Trait {
-    /// This is a trait method.
+    /// This is a required method.
     fn method(&self);
 
-    /// This is an associated constant.
+    /// This is a provided method.
+    fn provided_method(&self) {}
+
+    /// This is a required associated function.
+    fn assoc_fn();
+
+    /// This is a required associated constant.
     const CONST: &'static str;
 
-    /// This is an associated type.
+    /// This is a required associated type.
     type Type: Trait;
+
+    // unstable feature `associated_type_defaults` is not yet available in stable Rust, so this part is commented out
+    // /// This is a trait associated type with a default type.
+    // type DefaultType: Trait = Struct;
 }
 
-/// This is an impl.
+/// This is a trait implementation.
 impl Trait for Struct {
+    /// This is an implementation of the method.
     fn method(&self) {}
 
+    /// This is an implementation of the provided method.
+    fn provided_method(&self) {}
+
+    /// This is an implementation of the associated function.
+    fn assoc_fn() {}
+
+    /// This is an implementation of the associated constant.
     const CONST: &'static str = "This is an associated constant.";
 
+    /// This is an implementation of the associated type.
     type Type = Struct;
+}
+
+/// This is an inherent implementation.
+impl Struct {
+    /// This is an associated function.
+    pub fn inhr_assoc_fn() {}
+
+    /// This is a method.
+    pub fn inhr_method(&self) {}
+
+    /// This is an inherent associated constant.
+    pub const INHR_CONST: &'static str = "This is an inherent associated constant.";
+
+    // unstable feature `inherent_associated_types` is not yet available in stable Rust, so this part is commented out
+    // /// This is an inherent associated type.
+    // pub type InhrType = Struct;
 }
 
 /// This is a static.
 pub static STATIC: &str = "This is a static.";
 
-/// This is a macro.
+/// This is a declarative macro.
 #[macro_export]
-macro_rules! macro_ {
+macro_rules! declarative_macro {
     () => {};
+}
+
+/// This is a public re-export of a struct from a private module.
+pub use self::private::ReexportedFromPrivateMod;
+
+mod private {
+    /// This is a struct defined in a private module and re-exported publicly.
+    pub struct ReexportedFromPrivateMod;
+}
+
+unsafe extern "C" {
+    /// This is a foreign function.
+    pub unsafe fn foreign_function();
+    /// This is a foreign static.
+    pub unsafe static FOREIGN_STATIC: i32;
 }


### PR DESCRIPTION
## Summary
- expand the link showcase in `examples/lib` to cover more intra-doc link target shapes
- distinguish trait methods, associated items, inherent items, primitive items, tuple fields, variant fields, and foreign items
- add a crate-local example of an item re-exported from a private module

## Notes
- the showcase favors short, readable link paths; the path used is not intended to distinguish direct definitions from re-exported public paths
- the synced `README.md` still contains known URL inaccuracies for some generated links; this PR does not address those

## Validation
- user confirmed `rustdoc` and `sync-rdme` emit no warnings for this change
- checked `cargo-sync-rdme/examples/lib/README.md` with diagnostics; no markdown warnings