### PR TITLE
Drop i686 Linux release artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,8 +31,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: i686-unknown-linux-gnu
           - os: macos-latest
             target: aarch64-apple-darwin
           - os: windows-latest
@@ -44,9 +42,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cross
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.job.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Removed
+
+* Stop publishing prebuilt Linux release artifacts for `i686-unknown-linux-gnu`.
+
 ## [0.6.0] - 2026-08-07
 
 ### Fixed


### PR DESCRIPTION
## Summary
- remove `i686-unknown-linux-gnu` from the CD release target matrix
- remove the now-unused `cross` installation step from the CD workflow
- add an `Unreleased` changelog entry for dropping the prebuilt `i686-unknown-linux-gnu` artifact

## Why
- `cross` does not currently support TOML 1.1 in `Cargo.toml`
- this repository no longer needs `i686-unknown-linux-gnu` release builds
- `scripts/build-dist` is intentionally left unchanged because it is shared with other repositories and still allows local cross-target builds when `cross` is available

## Validation
- verified the working branch is based on the current `origin/main` (`behind 0`, `ahead 1`)
- ran `diagnostics` for `CHANGELOG.md` (no warnings or errors)
- did not run a local build or test suite
