### PR TITLE
Run cargo-deny with install-action

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,20 +35,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: Swatinem/rust-cache@v2
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          command: check advisories
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - run: cargo deny check advisories
+        shell: bash
 
   cargo-deny-policy:
     name: cargo-deny / bans licenses sources
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: Swatinem/rust-cache@v2
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          command: check bans licenses sources
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - run: cargo deny check bans licenses sources
+        shell: bash
 
   audit-complete:
     # Wait for cargo-audit and cargo-deny advisories to finish so issue reporting


### PR DESCRIPTION
## Summary
- replace `EmbarkStudios/cargo-deny-action` in the audit workflow with explicit Rust toolchain setup plus `taiki-e/install-action`
- run both cargo-deny jobs on the latest `stable` toolchain used elsewhere in CI
- avoid depending on the Docker action's older default Rust, which does not support TOML 1.1

## Validation
- `just ci-actionlint`

## Impact
- keeps the audit workflow aligned with the rest of CI while still checking that `cargo-deny` works on current stable Rust
