### PR TITLE
Refactor rustdoc processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+* Fix a bug that could cause `cargo sync-rdme` to panic when converting documentation containing valid intra-doc links that `cargo-sync-rdme` cannot resolve.
+
 ### Removed
 
 * Stop publishing prebuilt Linux release artifacts for `i686-unknown-linux-gnu`.

--- a/src/sync/contents/rustdoc/document.rs
+++ b/src/sync/contents/rustdoc/document.rs
@@ -1,0 +1,734 @@
+use std::{
+    borrow::Cow,
+    collections::{HashMap, hash_map},
+};
+
+use rustdoc_types::{Crate, Id, Item, ItemEnum, ItemKind, ItemSummary};
+
+type CrateId = u32;
+const LOCAL_CRATE_ID: CrateId = 0;
+
+#[derive(Debug)]
+pub(super) struct RustdocDocument {
+    doc: Crate,
+}
+
+impl RustdocDocument {
+    pub(super) fn new(doc: Crate) -> Self {
+        Self { doc }
+    }
+
+    pub(super) fn intra_link_resolver(&self) -> IntraLinkResolver<'_> {
+        IntraLinkResolver::new(&self.doc)
+    }
+
+    pub(super) fn root_item(&self) -> Option<&Item> {
+        self.doc.index.get(&self.doc.root)
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct IntraLinkResolver<'doc> {
+    doc: &'doc Crate,
+    per_crate_resolved_paths: HashMap<CrateId, HashMap<&'doc [String], (Id, &'doc ItemSummary)>>,
+    fallback_resolved_paths: HashMap<&'doc [String], (CrateId, Id, &'doc ItemSummary)>,
+}
+
+impl<'doc> IntraLinkResolver<'doc> {
+    fn new(doc: &'doc Crate) -> Self {
+        let mut per_crate_resolved_paths = HashMap::new();
+        let mut fallback_resolved_paths = HashMap::new();
+        for (id, summary) in &doc.paths {
+            let crate_id = summary.crate_id;
+            let crate_ = LinkTargetCrate::new(doc, crate_id);
+            let path = summary.path.as_slice();
+            // TODO: Handle the case where there are multiple items with the same path but different kinds.
+            //
+            // Rust has different namespaces for different kinds of items, so there can be multiple items with the same path but different kinds,
+            // such as `std::i32` (primitive type and module) or `std::clone::Clone` (trait and derive).
+            // For now, we will just use the one with smaller ID, and emit a debug log if we find another one with the same path.
+            match per_crate_resolved_paths
+                .entry(crate_id)
+                .or_insert_with(HashMap::new)
+                .entry(path)
+            {
+                hash_map::Entry::Vacant(e) => {
+                    e.insert((*id, summary));
+                }
+                hash_map::Entry::Occupied(mut e) => {
+                    let (existing_id, existing_summary) = e.get();
+                    tracing::debug!(
+                        crate = crate_.display_name().as_ref(),
+                        path = path.join("::"),
+                        existing = ?(existing_id, existing_summary.kind),
+                        new = ?(*id, summary.kind),
+                        "multiple items with the same path, using the one with smaller ID",
+                    );
+                    if *existing_id > *id {
+                        e.insert((*id, summary));
+                    }
+                }
+            }
+            match fallback_resolved_paths.entry(path) {
+                hash_map::Entry::Vacant(e) => {
+                    e.insert((crate_id, *id, summary));
+                }
+                hash_map::Entry::Occupied(mut e) => {
+                    let (existing_crate_id, existing_id, existing_summary) = e.get();
+                    let existing_crate = LinkTargetCrate::new(doc, *existing_crate_id);
+                    tracing::debug!(
+                        path = path.join("::"),
+                        existing = ?(existing_crate.display_name().as_ref(), existing_id, existing_summary.kind),
+                        new = ?(crate_.display_name().as_ref(), id.0, summary.kind),
+                        "multiple items with the same path in different crates, using the one with smaller crate ID and smaller item ID",
+                    );
+                    if *existing_crate_id > crate_id
+                        || (*existing_crate_id == crate_id && existing_id > id)
+                    {
+                        e.insert((crate_id, *id, summary));
+                    }
+                }
+            }
+        }
+        Self {
+            doc,
+            per_crate_resolved_paths,
+            fallback_resolved_paths,
+        }
+    }
+
+    pub(super) fn resolve_link(&self, id: Id) -> Option<LinkTarget<'doc>> {
+        let summary = self.doc.paths.get(&id)?;
+        let path = self.build_link_target_path(id, summary)?;
+        let crate_ = LinkTargetCrate::new(self.doc, summary.crate_id);
+        Some(LinkTarget { crate_, path })
+    }
+
+    fn build_link_target_path_from_path(
+        &self,
+        crate_id: CrateId,
+        path: &[String],
+    ) -> Option<LinkTargetPath<'doc>> {
+        let (id, summary) = self.find_path_summary(crate_id, path)?;
+        self.build_link_target_path(id, summary)
+    }
+
+    fn build_container_link_target_parts(
+        &self,
+        crate_id: CrateId,
+        path: &'doc [String],
+        kind: ItemKind,
+    ) -> Option<(LinkTargetPath<'doc>, &'doc String)> {
+        let [container_path @ .., item] = path else {
+            return warn_unexpected_path_for_kind(kind, path);
+        };
+        let Some(container) = self.build_link_target_path_from_path(crate_id, container_path)
+        else {
+            return warn_missing_container_information(kind, path);
+        };
+        Some((container, item))
+    }
+
+    fn build_link_target_path(
+        &self,
+        id: Id,
+        summary: &'doc ItemSummary,
+    ) -> Option<LinkTargetPath<'doc>> {
+        let crate_id = summary.crate_id;
+        let path = summary.path.as_slice();
+        let kind = summary.kind;
+        #[expect(clippy::match_same_arms)]
+        match kind {
+            ItemKind::Module => Some(LinkTargetPath::module(path)),
+            // References to `extern crate` items are resolved to the crate root, which is already handled by the `Module` case above.
+            ItemKind::ExternCrate => warn_not_supported_kind(kind, path),
+            // References to `use` items (re-exported items) are resolved to the target of the `use`, which is already handled by the other cases above.
+            ItemKind::Use => warn_not_supported_kind(kind, path),
+            ItemKind::Struct => LinkItemKind::Struct.with_path(path),
+            ItemKind::StructField => {
+                let [container_path @ .., field] = path else {
+                    return warn_unexpected_path_for_kind(kind, path);
+                };
+                // struct, union or enum variant field
+                if let Some(c) = self.build_link_target_path_from_path(crate_id, container_path) {
+                    return c.with_field(field);
+                }
+                // In some cases, rustdoc does not provide path information for enum variant.
+                // To work around this, we fall back to the last two segments of the path as the variant and field names when the parent of parent is an enum.
+                if let [path @ .., variant] = container_path
+                    && let Some(c) = self.build_link_target_path_from_path(crate_id, path)
+                {
+                    return c.with_variant_field(variant, field);
+                }
+                warn_missing_container_information(kind, path)
+            }
+            ItemKind::Union => LinkItemKind::Union.with_path(path),
+            ItemKind::Enum => LinkItemKind::Enum.with_path(path),
+            ItemKind::Variant => {
+                if let [module @ .., item, variant] = path {
+                    return Some(LinkTargetPath::enum_variant(module, item, variant));
+                }
+                warn_unexpected_path_for_kind(kind, path)
+            }
+            ItemKind::Function => {
+                let has_body = self.doc.index.get(&id).and_then(|item| match &item.inner {
+                    ItemEnum::Function(f) => Some(f.has_body),
+                    _ => None,
+                });
+                let [container_path @ .., function] = path else {
+                    return warn_unexpected_path_for_kind(kind, path);
+                };
+                // trait or impl method / associated function
+                if let Some(c) = self.build_link_target_path_from_path(crate_id, container_path) {
+                    return c.with_function(function, has_body);
+                }
+                tracing::warn!(
+                    path = path.join("::"),
+                    ?kind,
+                    "container information for the item is missing, falling back to free function",
+                );
+                LinkItemKind::Function.with_path(path)
+            }
+            ItemKind::TypeAlias => LinkItemKind::TypeAlias.with_path(path),
+            ItemKind::Constant => LinkItemKind::Constant.with_path(path),
+            ItemKind::Trait => LinkItemKind::Trait.with_path(path),
+            // Trait aliases are unstable features (`trait_alias`), and we don't support them yet.
+            // Tracking issue: <https://github.com/rust-lang/rust/issues/41517>
+            ItemKind::TraitAlias => warn_not_supported_kind(kind, path),
+            // Impl blocks have dedicated sections (`#implementations`), but there is no way to create an intra-doc link to it.
+            ItemKind::Impl => warn_not_supported_kind(kind, path),
+            ItemKind::Static => LinkItemKind::Static.with_path(path),
+            // Extern types are unstable features (`extern_types`), and we don't support them yet.
+            // Tracking issue: <https://github.com/rust-lang/rust/issues/43467>
+            ItemKind::ExternType => warn_not_supported_kind(kind, path),
+            ItemKind::Macro => LinkItemKind::Macro.with_path(path),
+            ItemKind::ProcAttribute => LinkItemKind::ProcAttribute.with_path(path),
+            ItemKind::ProcDerive => LinkItemKind::ProcDerive.with_path(path),
+            ItemKind::AssocConst => {
+                let (container, constant) =
+                    self.build_container_link_target_parts(crate_id, path, kind)?;
+                container.with_assoc_const(constant)
+            }
+            ItemKind::AssocType => {
+                let (container, ty) =
+                    self.build_container_link_target_parts(crate_id, path, kind)?;
+                container.with_assoc_type(ty)
+            }
+            ItemKind::Primitive => LinkItemKind::Primitive.with_path(path),
+            // Keywords have dedicated pages in `std` and `core`, but there is no way to create an intra-doc link to it.
+            ItemKind::Keyword => warn_not_supported_kind(kind, path),
+            // Attributes do not have dedicated pages, and there is no way to create an intra-doc link to it.
+            ItemKind::Attribute => warn_not_supported_kind(kind, path),
+        }
+    }
+
+    fn find_path_summary(
+        &self,
+        crate_id: CrateId,
+        path: &[String],
+    ) -> Option<(Id, &'doc ItemSummary)> {
+        let crate_ = LinkTargetCrate::new(self.doc, crate_id);
+        if let Some((id, summary)) = self
+            .per_crate_resolved_paths
+            .get(&crate_id)
+            .and_then(|crate_paths| crate_paths.get(path))
+            .copied()
+        {
+            return Some((id, summary));
+        }
+
+        // For some reason, rustdoc sometimes has inconsistent crate IDs for the ancestor paths (e.g. `std` vs `core`), which causes the path to not be found in the expected crate.
+        // To work around this, we fall back to an item with the same path in another crate, and log a warning.
+        // <https://github.com/rust-lang/rust/issues/160665>
+        if let Some((found_crate_id, id, summary)) = self.fallback_resolved_paths.get(path).copied()
+        {
+            let found_crate = LinkTargetCrate::new(self.doc, found_crate_id);
+            tracing::warn!(
+                path = path.join("::"),
+                expected = crate_.display_name().as_ref(),
+                found = found_crate.display_name().as_ref(),
+                kind = ?summary.kind,
+                "path not found in expected crate; falling back to another crate with the same path",
+            );
+            return Some((id, summary));
+        }
+
+        None
+    }
+}
+
+fn warn_not_supported_kind<T>(kind: ItemKind, path: &[String]) -> Option<T> {
+    tracing::warn!(
+        path = path.join("::"),
+        ?kind,
+        "items of this kind are not supported yet"
+    );
+    None
+}
+
+fn warn_unexpected_path_for_kind<T>(kind: ItemKind, path: &[String]) -> Option<T> {
+    tracing::warn!(
+        path = path.join("::"),
+        ?kind,
+        "unexpected path for the item"
+    );
+    None
+}
+
+fn warn_missing_container_information<T>(kind: ItemKind, path: &[String]) -> Option<T> {
+    tracing::warn!(
+        path = path.join("::"),
+        ?kind,
+        "container information for the item is missing",
+    );
+    None
+}
+
+#[derive(Debug)]
+pub(super) struct LinkTarget<'doc> {
+    crate_: LinkTargetCrate<'doc>,
+    path: LinkTargetPath<'doc>,
+}
+
+impl LinkTarget<'_> {
+    pub(super) fn build_url(&self, local_html_root_url: &str) -> Option<String> {
+        let mut url = self.crate_.html_root_url(local_html_root_url)?.to_owned();
+        if !url.ends_with('/') {
+            url.push('/');
+        }
+        let relative_path = self.path.build_relative_path();
+        url.push_str(&relative_path);
+        Some(url)
+    }
+}
+
+#[derive(Debug)]
+enum LinkTargetCrate<'doc> {
+    Local {
+        name: Option<&'doc str>,
+    },
+    External {
+        id: CrateId,
+        name: Option<&'doc str>,
+        html_root_url: Option<&'doc str>,
+    },
+}
+
+impl<'doc> LinkTargetCrate<'doc> {
+    fn new(doc: &'doc Crate, id: CrateId) -> Self {
+        if id == LOCAL_CRATE_ID {
+            let name = doc
+                .index
+                .get(&doc.root)
+                .and_then(|root| root.name.as_deref());
+            return Self::Local { name };
+        }
+        let info = doc.external_crates.get(&id);
+        let name = info.map(|info| info.name.as_ref());
+        let html_root_url = info.and_then(|info| info.html_root_url.as_deref());
+        Self::External {
+            id,
+            name,
+            html_root_url,
+        }
+    }
+
+    fn id(&self) -> CrateId {
+        match self {
+            Self::Local { .. } => LOCAL_CRATE_ID,
+            Self::External { id, .. } => *id,
+        }
+    }
+
+    fn name(&self) -> Option<&'doc str> {
+        match self {
+            Self::Local { name } | Self::External { name, .. } => *name,
+        }
+    }
+
+    fn display_name(&self) -> Cow<'_, str> {
+        self.name().map_or_else(
+            || Cow::Owned(format!("<unknown crate #{}>", self.id())),
+            Cow::Borrowed,
+        )
+    }
+
+    fn html_root_url<'a>(&self, local_html_root_url: &'a str) -> Option<&'a str>
+    where
+        'doc: 'a,
+    {
+        match self {
+            Self::Local { .. } => Some(local_html_root_url),
+            Self::External { html_root_url, .. } => *html_root_url,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LinkItemKind {
+    Struct,
+    Union,
+    Enum,
+    Function,
+    TypeAlias,
+    Constant,
+    Trait,
+    Static,
+    Macro,
+    ProcAttribute,
+    ProcDerive,
+    Primitive,
+}
+
+impl LinkItemKind {
+    fn with_path(self, path: &[String]) -> Option<LinkTargetPath<'_>> {
+        let Some((item, module)) = path.split_last() else {
+            return warn_unexpected_path_for_kind(self.as_item_kind(), path);
+        };
+        let kind = self;
+        Some(LinkTargetPath::Item { kind, item, module })
+    }
+
+    fn has_inherent_methods(self) -> bool {
+        match self {
+            LinkItemKind::Struct
+            | LinkItemKind::Union
+            | LinkItemKind::Enum
+            | LinkItemKind::Primitive => true,
+            LinkItemKind::Function
+            | LinkItemKind::TypeAlias
+            | LinkItemKind::Constant
+            | LinkItemKind::Trait
+            | LinkItemKind::Static
+            | LinkItemKind::Macro
+            | LinkItemKind::ProcAttribute
+            | LinkItemKind::ProcDerive => false,
+        }
+    }
+
+    fn has_assoc_items(self) -> bool {
+        self == LinkItemKind::Trait || self.has_inherent_methods()
+    }
+
+    fn as_item_kind(self) -> ItemKind {
+        match self {
+            LinkItemKind::Struct => ItemKind::Struct,
+            LinkItemKind::Union => ItemKind::Union,
+            LinkItemKind::Enum => ItemKind::Enum,
+            LinkItemKind::Function => ItemKind::Function,
+            LinkItemKind::TypeAlias => ItemKind::TypeAlias,
+            LinkItemKind::Constant => ItemKind::Constant,
+            LinkItemKind::Trait => ItemKind::Trait,
+            LinkItemKind::Static => ItemKind::Static,
+            LinkItemKind::Macro => ItemKind::Macro,
+            LinkItemKind::ProcAttribute => ItemKind::ProcAttribute,
+            LinkItemKind::ProcDerive => ItemKind::ProcDerive,
+            LinkItemKind::Primitive => ItemKind::Primitive,
+        }
+    }
+
+    fn namespace(self) -> &'static str {
+        match self {
+            Self::Struct => "struct",
+            Self::Union => "union",
+            Self::Enum => "enum",
+            Self::Function => "fn",
+            Self::TypeAlias => "type",
+            Self::Constant => "constant",
+            Self::Trait => "trait",
+            Self::Static => "static",
+            Self::Macro => "macro",
+            Self::ProcAttribute => "attr",
+            Self::ProcDerive => "derive",
+            Self::Primitive => "primitive",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnchorKind {
+    StructField,
+    EnumVariant,
+    EnumVariantField,
+    RequiredMethod,
+    ProvidedMethod,
+    ImplementedMethod,
+    AssocConst,
+    AssocType,
+}
+
+impl AnchorKind {
+    fn as_item_kind(self) -> ItemKind {
+        match self {
+            AnchorKind::StructField | AnchorKind::EnumVariantField => ItemKind::StructField,
+            AnchorKind::EnumVariant => ItemKind::Variant,
+            AnchorKind::RequiredMethod
+            | AnchorKind::ProvidedMethod
+            | AnchorKind::ImplementedMethod => ItemKind::Function,
+            AnchorKind::AssocConst => ItemKind::AssocConst,
+            AnchorKind::AssocType => ItemKind::AssocType,
+        }
+    }
+
+    fn namespace(self) -> &'static str {
+        match self {
+            Self::StructField => "structfield",
+            Self::EnumVariant => "variant",
+            Self::EnumVariantField => "field",
+            Self::RequiredMethod => "tymethod",
+            Self::ProvidedMethod | Self::ImplementedMethod => "method",
+            Self::AssocConst => "associatedconstant",
+            Self::AssocType => "associatedtype",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum LinkTargetPath<'doc> {
+    Module {
+        module: &'doc [String],
+    },
+    Item {
+        kind: LinkItemKind,
+        module: &'doc [String],
+        item: &'doc str,
+    },
+    AnchoredItem {
+        kind: LinkItemKind,
+        module: &'doc [String],
+        item: &'doc str,
+        anchor: [(AnchorKind, &'doc str); 1],
+    },
+    NestedAnchoredItem {
+        kind: LinkItemKind,
+        module: &'doc [String],
+        item: &'doc str,
+        anchors: [(AnchorKind, &'doc str); 2],
+    },
+}
+
+impl<'doc> LinkTargetPath<'doc> {
+    fn as_item_kind(self) -> ItemKind {
+        match self {
+            LinkTargetPath::Module { .. } => ItemKind::Module,
+            LinkTargetPath::Item { kind, .. } => kind.as_item_kind(),
+            LinkTargetPath::AnchoredItem {
+                anchor: [(kind, _)],
+                ..
+            }
+            | LinkTargetPath::NestedAnchoredItem {
+                anchors: [_, (kind, _)],
+                ..
+            } => kind.as_item_kind(),
+        }
+    }
+
+    fn display_path(self) -> String {
+        match self {
+            LinkTargetPath::Module { module } => module.join("::"),
+            LinkTargetPath::Item {
+                kind: _,
+                module,
+                item,
+            } => format!("{}::{item}", module.join("::")),
+            LinkTargetPath::AnchoredItem {
+                kind: _,
+                module,
+                item,
+                anchor: [(_, a0)],
+            } => format!("{}::{item}::{a0}", module.join("::")),
+            LinkTargetPath::NestedAnchoredItem {
+                kind: _,
+                module,
+                item,
+                anchors: [(_, a0), (_, a1)],
+            } => format!("{}::{item}::{a0}::{a1}", module.join("::")),
+        }
+    }
+
+    fn warn_unexpected_container_for_item<T>(self, kind: ItemKind, item: &str) -> Option<T> {
+        tracing::warn!(
+            path = format!("{}::{item}", self.display_path()),
+            container_kind = ?self.as_item_kind(),
+            ?kind,
+            "unexpected container kind for the item",
+        );
+        None
+    }
+
+    fn module(module: &'doc [String]) -> Self {
+        Self::Module { module }
+    }
+
+    fn enum_variant(module: &'doc [String], item: &'doc str, variant: &'doc str) -> Self {
+        Self::AnchoredItem {
+            kind: LinkItemKind::Enum,
+            module,
+            item,
+            anchor: [(AnchorKind::EnumVariant, variant)],
+        }
+    }
+
+    fn with_field(self, field: &'doc str) -> Option<Self> {
+        match self {
+            Self::Item {
+                kind: kind @ (LinkItemKind::Struct | LinkItemKind::Union),
+                module,
+                item,
+            } => Some(Self::AnchoredItem {
+                kind,
+                module,
+                item,
+                anchor: [(AnchorKind::StructField, field)],
+            }),
+            Self::AnchoredItem {
+                kind: kind @ LinkItemKind::Enum,
+                module,
+                item,
+                anchor: [(AnchorKind::EnumVariant, variant)],
+            } => Some(Self::NestedAnchoredItem {
+                kind,
+                module,
+                item,
+                anchors: [
+                    (AnchorKind::EnumVariant, variant),
+                    (AnchorKind::EnumVariantField, field),
+                ],
+            }),
+            _ => self.warn_unexpected_container_for_item(ItemKind::StructField, field),
+        }
+    }
+
+    fn with_variant_field(self, variant: &'doc str, field: &'doc str) -> Option<Self> {
+        let Self::Item {
+            kind: kind @ LinkItemKind::Enum,
+            module,
+            item,
+        } = self
+        else {
+            tracing::warn!(
+                path = format!("{}::{variant}::{field}", self.display_path()),
+                container_kind = ?self.as_item_kind(),
+                "unexpected container kind for the variant field",
+            );
+            return None;
+        };
+        Some(Self::NestedAnchoredItem {
+            kind,
+            module,
+            item,
+            anchors: [
+                (AnchorKind::EnumVariant, variant),
+                (AnchorKind::EnumVariantField, field),
+            ],
+        })
+    }
+
+    fn with_function(self, function: &'doc str, has_body: Option<bool>) -> Option<Self> {
+        let target = match self {
+            Self::Module { module } => Some(Self::Item {
+                kind: LinkItemKind::Function,
+                module,
+                item: function,
+            }),
+            Self::Item { kind, module, item } => {
+                let anchor = match (kind, has_body) {
+                    (LinkItemKind::Trait, Some(true)) => Some(AnchorKind::ProvidedMethod),
+                    (LinkItemKind::Trait, Some(false)) => Some(AnchorKind::RequiredMethod),
+                    (LinkItemKind::Trait, None) => {
+                        // In some cases, rustdoc does not provide information about whether a trait method is required or provided.
+                        // In those cases, we log a warning and default to `RequiredMethod`.
+                        // <https://github.com/rust-lang/rust/issues/160662>
+                        tracing::warn!(
+                            path = format!("{}::{item}::{function}", module.join("::")),
+                            "failed to determine if trait method is required or provided",
+                        );
+                        Some(AnchorKind::RequiredMethod)
+                    }
+                    (kind, _) if kind.has_inherent_methods() => Some(AnchorKind::ImplementedMethod),
+                    (_, _) => None,
+                };
+                anchor.map(|anchor| Self::AnchoredItem {
+                    kind,
+                    module,
+                    item,
+                    anchor: [(anchor, function)],
+                })
+            }
+            _ => None,
+        };
+        let Some(target) = target else {
+            return self.warn_unexpected_container_for_item(ItemKind::Function, function);
+        };
+        Some(target)
+    }
+
+    fn with_assoc_const(self, constant: &'doc str) -> Option<Self> {
+        match self {
+            Self::Item { kind, module, item } if kind.has_assoc_items() => {
+                Some(Self::AnchoredItem {
+                    kind,
+                    module,
+                    item,
+                    anchor: [(AnchorKind::AssocConst, constant)],
+                })
+            }
+            _ => self.warn_unexpected_container_for_item(ItemKind::AssocConst, constant),
+        }
+    }
+
+    fn with_assoc_type(self, ty: &'doc str) -> Option<Self> {
+        match self {
+            Self::Item { kind, module, item } if kind.has_assoc_items() => {
+                Some(Self::AnchoredItem {
+                    kind,
+                    module,
+                    item,
+                    anchor: [(AnchorKind::AssocType, ty)],
+                })
+            }
+            _ => self.warn_unexpected_container_for_item(ItemKind::AssocType, ty),
+        }
+    }
+}
+
+impl LinkTargetPath<'_> {
+    fn build_relative_path(&self) -> String {
+        match self {
+            LinkTargetPath::Module { module } => {
+                let module = module.join("/");
+                format!("{module}/index.html")
+            }
+            LinkTargetPath::Item { kind, module, item } => {
+                let module = module.join("/");
+                let namespace = kind.namespace();
+                format!("{module}/{namespace}.{item}.html")
+            }
+            LinkTargetPath::AnchoredItem {
+                kind,
+                module,
+                item,
+                anchor: [(a0_kind, a0_name)],
+            } => {
+                let module = module.join("/");
+                let namespace = kind.namespace();
+                let a0_namespace = a0_kind.namespace();
+                format!("{module}/{namespace}.{item}.html#{a0_namespace}.{a0_name}")
+            }
+            LinkTargetPath::NestedAnchoredItem {
+                kind,
+                module,
+                item,
+                anchors: [(a0_kind, a0_name), (a1_kind, a1_name)],
+            } => {
+                let module = module.join("/");
+                let namespace = kind.namespace();
+                let a0_namespace = a0_kind.namespace();
+                let a1_namespace = a1_kind.namespace();
+                format!(
+                    "{module}/{namespace}.{item}.html#{a0_namespace}.{a0_name}.{a1_namespace}.{a1_name}"
+                )
+            }
+        }
+    }
+}

--- a/src/sync/contents/rustdoc/intra_link.rs
+++ b/src/sync/contents/rustdoc/intra_link.rs
@@ -1,764 +1,92 @@
-use std::{
-    borrow::Cow,
-    collections::{HashMap, hash_map},
-    rc::Rc,
-};
+use std::{borrow::Cow, collections::HashMap};
 
-use pulldown_cmark::{BrokenLink, CowStr, Event, Options, Tag};
-use rustdoc_types::{Crate, Id, Item, ItemEnum, ItemKind, ItemSummary};
+use pulldown_cmark::{BrokenLink, BrokenLinkCallback, CowStr, Event, Options, Parser, Tag};
+use rustdoc_types::{Id, Item};
 
-trait CowStrExt<'a> {
-    fn as_str(&'a self) -> &'a str;
-}
-
-impl<'a> CowStrExt<'a> for CowStr<'a> {
-    fn as_str(&'a self) -> &'a str {
-        match self {
-            CowStr::Boxed(s) => s,
-            CowStr::Borrowed(s) => s,
-            CowStr::Inlined(s) => s,
-        }
-    }
-}
+use crate::sync::contents::rustdoc::document::IntraLinkResolver;
 
 #[derive(Debug)]
-pub(super) struct Parser<B, M> {
-    broken_link_callback: B,
-    iterator_map: M,
+pub(super) struct LinkMappingConfig<'map, 'url> {
+    mappings: &'map HashMap<String, String>,
+    local_html_root_url: &'url str,
 }
 
-type BrokenLinkPair<'a> = (CowStr<'a>, CowStr<'a>);
-
-impl Parser<(), ()> {
-    pub(super) fn new<'doc>(
-        doc: &'doc Crate,
-        item: &'doc Item,
-        local_html_root_url: &'doc str,
-        mappings: &'doc HashMap<String, String>,
-    ) -> Parser<
-        impl FnMut(BrokenLink<'_>) -> Option<BrokenLinkPair<'doc>>,
-        impl FnMut(Event<'doc>) -> Option<Event<'doc>>,
-    > {
-        let resolver = LinkResolver::new(doc, local_html_root_url, mappings);
-        let url_map = Rc::new(resolve_all_links(&resolver, &item.links));
-
-        let broken_link_callback = {
-            let url_map = Rc::clone(&url_map);
-            move |link: BrokenLink<'_>| {
-                let url = url_map.get(link.reference.as_str())?.as_ref()?;
-                Some((url.to_owned().into(), "".into()))
-            }
-        };
-        let iterator_map = move |event| convert_link(&url_map, event);
-
-        Parser {
-            broken_link_callback,
-            iterator_map,
-        }
-    }
-}
-
-impl<'doc, B, M> Parser<B, M>
-where
-    B: FnMut(BrokenLink<'_>) -> Option<BrokenLinkPair<'doc>> + 'doc,
-    M: FnMut(Event<'doc>) -> Option<Event<'doc>> + 'doc,
-{
-    pub(super) fn events<'b>(&'b mut self, doc: &'doc str) -> impl Iterator<Item = Event<'doc>> + 'b
-    where
-        'doc: 'b,
-    {
-        pulldown_cmark::Parser::new_with_broken_link_callback(
-            doc,
-            Options::all(),
-            Some(&mut self.broken_link_callback),
-        )
-        .filter_map(&mut self.iterator_map)
-    }
-}
-
-fn resolve_all_links<'doc>(
-    resolver: &LinkResolver<'doc>,
-    links: &'doc HashMap<String, Id>,
-) -> HashMap<&'doc str, Option<String>> {
-    links
-        .iter()
-        .map(move |(name, id)| (name.as_str(), resolver.resolve_link(name, *id)))
-        .collect()
-}
-
-fn convert_link<'a>(
-    url_map: &HashMap<&str, Option<String>>,
-    mut event: Event<'a>,
-) -> Option<Event<'a>> {
-    if let Event::Start(Tag::Link { dest_url: url, .. }) = &mut event
-        && let Some(full_url) = url_map.get(url.as_ref())
-    {
-        *url = full_url.as_ref()?.to_owned().into();
-    }
-    Some(event)
-}
-
-type CrateId = u32;
-
-#[derive(Debug)]
-struct LinkResolver<'doc> {
-    doc: &'doc Crate,
-    local_html_root_url: &'doc str,
-    mappings: &'doc HashMap<String, String>,
-    per_crate_resolved_paths: HashMap<CrateId, HashMap<&'doc [String], (Id, &'doc ItemSummary)>>,
-    fallback_resolved_path: HashMap<&'doc [String], (CrateId, Id, &'doc ItemSummary)>,
-}
-
-impl<'doc> LinkResolver<'doc> {
-    fn new(
-        doc: &'doc Crate,
-        local_html_root_url: &'doc str,
-        mappings: &'doc HashMap<String, String>,
+impl<'map, 'url> LinkMappingConfig<'map, 'url> {
+    pub(super) fn new(
+        mappings: &'map HashMap<String, String>,
+        local_html_root_url: &'url str,
     ) -> Self {
-        let mut per_crate_resolved_paths = HashMap::new();
-        let mut fallback_resolved_path = HashMap::new();
-        for (id, summary) in &doc.paths {
-            let crate_id = summary.crate_id;
-            let path = summary.path.as_slice();
-            // TODO: Handle the case where there are multiple items with the same path but different kinds.
-            //
-            // Rust has different namespaces for different kinds of items, so there can be multiple items with the same path but different kinds,
-            // such as `std::i32` (primitive type and module) or `std::clone::Clone` (trait and derive).
-            // For now, we will just use the one with smaller ID, and emit a debug log if we find another one with the same path.
-            match per_crate_resolved_paths
-                .entry(crate_id)
-                .or_insert_with(HashMap::new)
-                .entry(path)
-            {
-                hash_map::Entry::Vacant(e) => {
-                    e.insert((*id, summary));
-                }
-                hash_map::Entry::Occupied(mut e) => {
-                    let (existing_id, existing_summary) = e.get();
-                    tracing::debug!(
-                        crate = display_crate(doc, crate_id).as_ref(),
-                        path = path.join("::"),
-                        existing = ?(existing_id, existing_summary.kind),
-                        new = ?(*id, summary.kind),
-                        "multiple items with the same path, using the one with smaller ID",
-                    );
-                    if *existing_id > *id {
-                        e.insert((*id, summary));
-                    }
-                }
-            }
-            match fallback_resolved_path.entry(path) {
-                hash_map::Entry::Vacant(e) => {
-                    e.insert((crate_id, *id, summary));
-                }
-                hash_map::Entry::Occupied(mut e) => {
-                    let (existing_crate_id, existing_id, existing_summary) = e.get();
-                    tracing::debug!(
-                        path = path.join("::"),
-                        existing = ?(display_crate(doc, *existing_crate_id).as_ref(), existing_id, existing_summary.kind),
-                        new = ?(display_crate(doc, crate_id).as_ref(), id.0, summary.kind),
-                        "multiple items with the same path in different crates, using the one with smaller crate ID and smaller item ID",
-                    );
-                    if *existing_crate_id > crate_id
-                        || (*existing_crate_id == crate_id && existing_id > id)
-                    {
-                        e.insert((crate_id, *id, summary));
-                    }
-                }
-            }
-        }
         Self {
-            doc,
-            local_html_root_url,
             mappings,
-            per_crate_resolved_paths,
-            fallback_resolved_path,
+            local_html_root_url,
         }
     }
 
-    #[tracing::instrument(skip_all, fields(name = name, id = ?id))]
-    fn resolve_link(&self, name: &str, id: Id) -> Option<String> {
-        if let Some(path) = self.mappings.get(name) {
-            return Some(path.clone());
-        }
-        let Some(url) = self.build_url_for_item(id) else {
-            tracing::warn!("failed to resolve link");
-            return None;
-        };
-        Some(url)
-    }
-
-    fn build_url_for_item(&self, id: Id) -> Option<String> {
-        let summary = self.doc.paths.get(&id)?;
-        let target = self.build_link_target(id, summary)?;
-        let relative_path = target.build_relative_path();
-        let mut url = self.base_url(summary.crate_id)?.to_owned();
-        if !url.ends_with('/') {
-            url.push('/');
-        }
-        url.push_str(&relative_path);
-        Some(url)
-    }
-
-    fn build_link_target_from_path(
+    pub(super) fn build_mapper<'doc>(
         &self,
-        crate_id: CrateId,
-        path: &[String],
-    ) -> Option<LinkTarget<'doc>> {
-        let (id, summary) = self.find_path_summary(crate_id, path)?;
-        self.build_link_target(id, summary)
+        resolver: &IntraLinkResolver<'_>,
+        item: &'doc Item,
+    ) -> Option<LinkMapper<'doc, 'map>> {
+        let docs = item.docs.as_deref()?;
+        let map = item
+            .links
+            .iter()
+            .map(|(name, id)| (name.as_str(), resolve_link(resolver, self, name, *id)))
+            .collect();
+        Some(LinkMapper { docs, map })
     }
+}
 
-    fn expect_container_link_target(
-        &self,
-        crate_id: CrateId,
-        path: &'doc [String],
-        kind: ItemKind,
-    ) -> Option<(LinkTarget<'doc>, &'doc String)> {
-        let [container_path @ .., item] = path else {
-            return warn_unexpected_path_for_kind(kind, path);
-        };
-        let Some(container) = self.build_link_target_from_path(crate_id, container_path) else {
-            return warn_missing_container_information(kind, path);
-        };
-        Some((container, item))
+#[tracing::instrument(skip_all, fields(name = name, id = ?id))]
+fn resolve_link<'map>(
+    resolver: &IntraLinkResolver<'_>,
+    config: &LinkMappingConfig<'map, '_>,
+    name: &str,
+    id: Id,
+) -> Option<Cow<'map, str>> {
+    if let Some(url) = config.mappings.get(name) {
+        return Some(url.into());
     }
+    let Some(url) = resolver
+        .resolve_link(id)
+        .and_then(|target| target.build_url(config.local_html_root_url))
+    else {
+        tracing::warn!("failed to resolve link");
+        return None;
+    };
+    Some(url.into())
+}
 
-    fn build_link_target(&self, id: Id, summary: &'doc ItemSummary) -> Option<LinkTarget<'doc>> {
-        let crate_id = summary.crate_id;
-        let path = summary.path.as_slice();
-        let kind = summary.kind;
-        #[expect(clippy::match_same_arms)]
-        match kind {
-            ItemKind::Module => Some(LinkTarget::module(path)),
-            // References to `extern crate` items are resolved to the crate root, which is already handled by the `Module` case above.
-            ItemKind::ExternCrate => warn_not_supported_kind(kind, path),
-            // References to `use` items (re-exported items) are resolved to the target of the `use`, which is already handled by the other cases above.
-            ItemKind::Use => warn_not_supported_kind(kind, path),
-            ItemKind::Struct => LinkItemKind::Struct.with_path(path),
-            ItemKind::StructField => {
-                let [container_path @ .., field] = path else {
-                    return warn_unexpected_path_for_kind(kind, path);
-                };
-                // struct, union or enum variant field
-                if let Some(c) = self.build_link_target_from_path(crate_id, container_path) {
-                    return c.with_field(field);
-                }
-                // In some cases, rustdoc does not provide path information for enum variant.
-                // To work around this, we fall back to the last two segments of the path as the variant and field names when the parent of parent is an enum.
-                if let [path @ .., variant] = container_path
-                    && let Some(c) = self.build_link_target_from_path(crate_id, path)
+#[derive(Debug)]
+pub(super) struct LinkMapper<'doc, 'map> {
+    docs: &'doc str,
+    map: HashMap<&'doc str, Option<Cow<'map, str>>>,
+}
+
+impl<'url, 'input> BrokenLinkCallback<'input> for &LinkMapper<'_, 'url>
+where
+    'url: 'input,
+{
+    fn handle_broken_link(
+        &mut self,
+        link: BrokenLink<'input>,
+    ) -> Option<(CowStr<'input>, CowStr<'input>)> {
+        let target = self.map.get(&*link.reference)?.as_ref()?;
+        Some((target.clone().into(), "".into()))
+    }
+}
+
+impl LinkMapper<'_, '_> {
+    pub(super) fn build_parser(&self) -> impl Iterator<Item = Event<'_>> {
+        Parser::new_with_broken_link_callback(self.docs, Options::all(), Some(self)).map(
+            |mut event| {
+                if let Event::Start(Tag::Link { dest_url: url, .. }) = &mut event
+                    && let Some(Some(full_url)) = self.map.get(url.as_ref())
                 {
-                    return c.with_variant_field(variant, field);
+                    *url = full_url.clone().into();
                 }
-                warn_missing_container_information(kind, path)
-            }
-            ItemKind::Union => LinkItemKind::Union.with_path(path),
-            ItemKind::Enum => LinkItemKind::Enum.with_path(path),
-            ItemKind::Variant => {
-                if let [module @ .., item, variant] = path {
-                    return Some(LinkTarget::enum_variant(module, item, variant));
-                }
-                warn_unexpected_path_for_kind(kind, path)
-            }
-            ItemKind::Function => {
-                let has_body = self.doc.index.get(&id).and_then(|item| match &item.inner {
-                    ItemEnum::Function(f) => Some(f.has_body),
-                    _ => None,
-                });
-                let [container_path @ .., function] = path else {
-                    return warn_unexpected_path_for_kind(kind, path);
-                };
-                // trait or impl method / associated function
-                if let Some(c) = self.build_link_target_from_path(crate_id, container_path) {
-                    return c.with_function(function, has_body);
-                }
-                tracing::warn!(
-                    path = path.join("::"),
-                    ?kind,
-                    "container information for the item is missing, falling back to free function",
-                );
-                LinkItemKind::Function.with_path(path)
-            }
-            ItemKind::TypeAlias => LinkItemKind::TypeAlias.with_path(path),
-            ItemKind::Constant => LinkItemKind::Constant.with_path(path),
-            ItemKind::Trait => LinkItemKind::Trait.with_path(path),
-            // Trait aliases are unstable features (`trait_alias`), and we don't support them yet.
-            // Tracking issue: <https://github.com/rust-lang/rust/issues/41517>
-            ItemKind::TraitAlias => warn_not_supported_kind(kind, path),
-            // Impl blocks have dedicated sections (`#implementations`), but there is no way to create an intra-doc link to it.
-            ItemKind::Impl => warn_not_supported_kind(kind, path),
-            ItemKind::Static => LinkItemKind::Static.with_path(path),
-            // Extern types are unstable features (`extern_types`), and we don't support them yet.
-            // Tracking issue: <https://github.com/rust-lang/rust/issues/43467>
-            ItemKind::ExternType => warn_not_supported_kind(kind, path),
-            ItemKind::Macro => LinkItemKind::Macro.with_path(path),
-            ItemKind::ProcAttribute => LinkItemKind::ProcAttribute.with_path(path),
-            ItemKind::ProcDerive => LinkItemKind::ProcDerive.with_path(path),
-            ItemKind::AssocConst => {
-                let (container, constant) =
-                    self.expect_container_link_target(crate_id, path, kind)?;
-                container.with_assoc_const(constant)
-            }
-            ItemKind::AssocType => {
-                let (container, ty) = self.expect_container_link_target(crate_id, path, kind)?;
-                container.with_assoc_type(ty)
-            }
-            ItemKind::Primitive => LinkItemKind::Primitive.with_path(path),
-            // Keywords have dedicated pages in `std` and `core`, but there is no way to create an intra-doc link to it.
-            ItemKind::Keyword => warn_not_supported_kind(kind, path),
-            // Attributes do not have dedicated pages, and there is no way to create an intra-doc link to it.
-            ItemKind::Attribute => warn_not_supported_kind(kind, path),
-        }
-    }
-
-    fn find_path_summary(
-        &self,
-        crate_id: CrateId,
-        path: &[String],
-    ) -> Option<(Id, &'doc ItemSummary)> {
-        if let Some((id, summary)) = self
-            .per_crate_resolved_paths
-            .get(&crate_id)
-            .and_then(|crate_paths| crate_paths.get(path))
-            .copied()
-        {
-            return Some((id, summary));
-        }
-
-        // For some reason, rustdoc sometimes has inconsistent crate IDs for the ancestor paths (e.g. `std` vs `core`), which causes the path to not be found in the expected crate.
-        // To work around this, we fall back to an item with the same path in another crate, and log a warning.
-        // <https://github.com/rust-lang/rust/issues/160665>
-        if let Some((found_crate_id, id, summary)) = self.fallback_resolved_path.get(path).copied()
-        {
-            tracing::warn!(
-                path = path.join("::"),
-                expected = display_crate(self.doc, crate_id).as_ref(),
-                found = display_crate(self.doc, found_crate_id).as_ref(),
-                kind = ?summary.kind,
-                "path not found in expected crate; falling back to another crate with the same path",
-            );
-            return Some((id, summary));
-        }
-
-        None
-    }
-
-    fn base_url(&self, crate_id: CrateId) -> Option<&'doc str> {
-        if crate_id == 0 {
-            return Some(self.local_html_root_url);
-        }
-        let external_crate = self.doc.external_crates.get(&crate_id)?;
-        external_crate.html_root_url.as_deref()
-    }
-}
-
-fn warn_not_supported_kind<T>(kind: ItemKind, path: &[String]) -> Option<T> {
-    tracing::warn!(
-        path = path.join("::"),
-        ?kind,
-        "items of this kind are not supported yet"
-    );
-    None
-}
-
-fn warn_unexpected_path_for_kind<T>(kind: ItemKind, path: &[String]) -> Option<T> {
-    tracing::warn!(
-        path = path.join("::"),
-        ?kind,
-        "unexpected path for the item"
-    );
-    None
-}
-
-fn warn_missing_container_information<T>(kind: ItemKind, path: &[String]) -> Option<T> {
-    tracing::warn!(
-        path = path.join("::"),
-        ?kind,
-        "container information for the item is missing",
-    );
-    None
-}
-
-fn resolve_crate_name(doc: &Crate, crate_id: CrateId) -> Option<&str> {
-    if crate_id == 0 {
-        return doc.index.get(&doc.root)?.name.as_deref();
-    }
-    doc.external_crates.get(&crate_id).map(|c| c.name.as_str())
-}
-
-fn display_crate(doc: &Crate, crate_id: CrateId) -> Cow<'_, str> {
-    resolve_crate_name(doc, crate_id).map_or_else(
-        || Cow::Owned(format!("<unknown crate #{crate_id}>")),
-        Cow::Borrowed,
-    )
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LinkItemKind {
-    Struct,
-    Union,
-    Enum,
-    Function,
-    TypeAlias,
-    Constant,
-    Trait,
-    Static,
-    Macro,
-    ProcAttribute,
-    ProcDerive,
-    Primitive,
-}
-
-impl LinkItemKind {
-    fn with_path(self, path: &[String]) -> Option<LinkTarget<'_>> {
-        let Some((item, module)) = path.split_last() else {
-            return warn_unexpected_path_for_kind(self.as_item_kind(), path);
-        };
-        let kind = self;
-        Some(LinkTarget::Item { kind, item, module })
-    }
-
-    fn has_inherent_methods(self) -> bool {
-        match self {
-            LinkItemKind::Struct
-            | LinkItemKind::Union
-            | LinkItemKind::Enum
-            | LinkItemKind::Primitive => true,
-            LinkItemKind::Function
-            | LinkItemKind::TypeAlias
-            | LinkItemKind::Constant
-            | LinkItemKind::Trait
-            | LinkItemKind::Static
-            | LinkItemKind::Macro
-            | LinkItemKind::ProcAttribute
-            | LinkItemKind::ProcDerive => false,
-        }
-    }
-
-    fn has_assoc_items(self) -> bool {
-        self == LinkItemKind::Trait || self.has_inherent_methods()
-    }
-
-    fn as_item_kind(self) -> ItemKind {
-        match self {
-            LinkItemKind::Struct => ItemKind::Struct,
-            LinkItemKind::Union => ItemKind::Union,
-            LinkItemKind::Enum => ItemKind::Enum,
-            LinkItemKind::Function => ItemKind::Function,
-            LinkItemKind::TypeAlias => ItemKind::TypeAlias,
-            LinkItemKind::Constant => ItemKind::Constant,
-            LinkItemKind::Trait => ItemKind::Trait,
-            LinkItemKind::Static => ItemKind::Static,
-            LinkItemKind::Macro => ItemKind::Macro,
-            LinkItemKind::ProcAttribute => ItemKind::ProcAttribute,
-            LinkItemKind::ProcDerive => ItemKind::ProcDerive,
-            LinkItemKind::Primitive => ItemKind::Primitive,
-        }
-    }
-
-    fn namespace(self) -> &'static str {
-        match self {
-            Self::Struct => "struct",
-            Self::Union => "union",
-            Self::Enum => "enum",
-            Self::Function => "fn",
-            Self::TypeAlias => "type",
-            Self::Constant => "constant",
-            Self::Trait => "trait",
-            Self::Static => "static",
-            Self::Macro => "macro",
-            Self::ProcAttribute => "attr",
-            Self::ProcDerive => "derive",
-            Self::Primitive => "primitive",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AnchorKind {
-    StructField,
-    EnumVariant,
-    EnumVariantField,
-    RequiredMethod,
-    ProvidedMethod,
-    ImplementedMethod,
-    AssocConst,
-    AssocType,
-}
-
-impl AnchorKind {
-    fn as_item_kind(self) -> ItemKind {
-        match self {
-            AnchorKind::StructField | AnchorKind::EnumVariantField => ItemKind::StructField,
-            AnchorKind::EnumVariant => ItemKind::Variant,
-            AnchorKind::RequiredMethod
-            | AnchorKind::ProvidedMethod
-            | AnchorKind::ImplementedMethod => ItemKind::Function,
-            AnchorKind::AssocConst => ItemKind::AssocConst,
-            AnchorKind::AssocType => ItemKind::AssocType,
-        }
-    }
-
-    fn namespace(self) -> &'static str {
-        match self {
-            Self::StructField => "structfield",
-            Self::EnumVariant => "variant",
-            Self::EnumVariantField => "field",
-            Self::RequiredMethod => "tymethod",
-            Self::ProvidedMethod | Self::ImplementedMethod => "method",
-            Self::AssocConst => "associatedconstant",
-            Self::AssocType => "associatedtype",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum LinkTarget<'doc> {
-    Module {
-        module: &'doc [String],
-    },
-    Item {
-        kind: LinkItemKind,
-        module: &'doc [String],
-        item: &'doc str,
-    },
-    AnchoredItem {
-        kind: LinkItemKind,
-        module: &'doc [String],
-        item: &'doc str,
-        anchor: [(AnchorKind, &'doc str); 1],
-    },
-    NestedAnchoredItem {
-        kind: LinkItemKind,
-        module: &'doc [String],
-        item: &'doc str,
-        anchors: [(AnchorKind, &'doc str); 2],
-    },
-}
-
-impl<'doc> LinkTarget<'doc> {
-    fn as_item_kind(self) -> ItemKind {
-        match self {
-            LinkTarget::Module { .. } => ItemKind::Module,
-            LinkTarget::Item { kind, .. } => kind.as_item_kind(),
-            LinkTarget::AnchoredItem {
-                anchor: [(kind, _)],
-                ..
-            }
-            | LinkTarget::NestedAnchoredItem {
-                anchors: [_, (kind, _)],
-                ..
-            } => kind.as_item_kind(),
-        }
-    }
-
-    fn display_path(self) -> String {
-        match self {
-            LinkTarget::Module { module } => module.join("::"),
-            LinkTarget::Item {
-                kind: _,
-                module,
-                item,
-            } => format!("{}::{item}", module.join("::")),
-            LinkTarget::AnchoredItem {
-                kind: _,
-                module,
-                item,
-                anchor: [(_, a0)],
-            } => format!("{}::{item}::{a0}", module.join("::")),
-            LinkTarget::NestedAnchoredItem {
-                kind: _,
-                module,
-                item,
-                anchors: [(_, a0), (_, a1)],
-            } => format!("{}::{item}::{a0}::{a1}", module.join("::")),
-        }
-    }
-
-    fn warn_unexpected_container_for_item<T>(self, kind: ItemKind, item: &str) -> Option<T> {
-        tracing::warn!(
-            path = format!("{}::{item}", self.display_path()),
-            container_kind = ?self.as_item_kind(),
-            ?kind,
-            "unexpected container kind for the item",
-        );
-        None
-    }
-
-    fn module(module: &'doc [String]) -> Self {
-        Self::Module { module }
-    }
-
-    fn enum_variant(module: &'doc [String], item: &'doc str, variant: &'doc str) -> Self {
-        Self::AnchoredItem {
-            kind: LinkItemKind::Enum,
-            module,
-            item,
-            anchor: [(AnchorKind::EnumVariant, variant)],
-        }
-    }
-
-    fn with_field(self, field: &'doc str) -> Option<Self> {
-        match self {
-            Self::Item {
-                kind: kind @ (LinkItemKind::Struct | LinkItemKind::Union),
-                module,
-                item,
-            } => Some(Self::AnchoredItem {
-                kind,
-                module,
-                item,
-                anchor: [(AnchorKind::StructField, field)],
-            }),
-            Self::AnchoredItem {
-                kind: kind @ LinkItemKind::Enum,
-                module,
-                item,
-                anchor: [(AnchorKind::EnumVariant, variant)],
-            } => Some(Self::NestedAnchoredItem {
-                kind,
-                module,
-                item,
-                anchors: [
-                    (AnchorKind::EnumVariant, variant),
-                    (AnchorKind::EnumVariantField, field),
-                ],
-            }),
-            _ => self.warn_unexpected_container_for_item(ItemKind::StructField, field),
-        }
-    }
-
-    fn with_variant_field(self, variant: &'doc str, field: &'doc str) -> Option<Self> {
-        let Self::Item {
-            kind: kind @ LinkItemKind::Enum,
-            module,
-            item,
-        } = self
-        else {
-            tracing::warn!(
-                path = format!("{}::{variant}::{field}", self.display_path()),
-                container_kind = ?self.as_item_kind(),
-                "unexpected container kind for the variant field",
-            );
-            return None;
-        };
-        Some(Self::NestedAnchoredItem {
-            kind,
-            module,
-            item,
-            anchors: [
-                (AnchorKind::EnumVariant, variant),
-                (AnchorKind::EnumVariantField, field),
-            ],
-        })
-    }
-
-    fn with_function(self, function: &'doc str, has_body: Option<bool>) -> Option<Self> {
-        let target = match self {
-            Self::Module { module } => Some(Self::Item {
-                kind: LinkItemKind::Function,
-                module,
-                item: function,
-            }),
-            Self::Item { kind, module, item } => {
-                let anchor = match (kind, has_body) {
-                    (LinkItemKind::Trait, Some(true)) => Some(AnchorKind::ProvidedMethod),
-                    (LinkItemKind::Trait, Some(false)) => Some(AnchorKind::RequiredMethod),
-                    (LinkItemKind::Trait, None) => {
-                        // In some cases, rustdoc does not provide information about whether a trait method is required or provided.
-                        // In those cases, we log a warning and default to `RequiredMethod`.
-                        // <https://github.com/rust-lang/rust/issues/160662>
-                        tracing::warn!(
-                            path = format!("{}::{item}::{function}", module.join("::")),
-                            "failed to determine if trait method is required or provided",
-                        );
-                        Some(AnchorKind::RequiredMethod)
-                    }
-                    (kind, _) if kind.has_inherent_methods() => Some(AnchorKind::ImplementedMethod),
-                    (_, _) => None,
-                };
-                anchor.map(|anchor| Self::AnchoredItem {
-                    kind,
-                    module,
-                    item,
-                    anchor: [(anchor, function)],
-                })
-            }
-            _ => None,
-        };
-        let Some(target) = target else {
-            return self.warn_unexpected_container_for_item(ItemKind::Function, function);
-        };
-        Some(target)
-    }
-
-    fn with_assoc_const(self, constant: &'doc str) -> Option<Self> {
-        match self {
-            Self::Item { kind, module, item } if kind.has_assoc_items() => {
-                Some(Self::AnchoredItem {
-                    kind,
-                    module,
-                    item,
-                    anchor: [(AnchorKind::AssocConst, constant)],
-                })
-            }
-            _ => self.warn_unexpected_container_for_item(ItemKind::AssocConst, constant),
-        }
-    }
-
-    fn with_assoc_type(self, ty: &'doc str) -> Option<Self> {
-        match self {
-            Self::Item { kind, module, item } if kind.has_assoc_items() => {
-                Some(Self::AnchoredItem {
-                    kind,
-                    module,
-                    item,
-                    anchor: [(AnchorKind::AssocType, ty)],
-                })
-            }
-            _ => self.warn_unexpected_container_for_item(ItemKind::AssocType, ty),
-        }
-    }
-}
-
-impl LinkTarget<'_> {
-    fn build_relative_path(&self) -> String {
-        match self {
-            LinkTarget::Module { module } => {
-                let module = module.join("/");
-                format!("{module}/index.html")
-            }
-            LinkTarget::Item { kind, module, item } => {
-                let module = module.join("/");
-                let namespace = kind.namespace();
-                format!("{module}/{namespace}.{item}.html")
-            }
-            LinkTarget::AnchoredItem {
-                kind,
-                module,
-                item,
-                anchor: [(a0_kind, a0_name)],
-            } => {
-                let module = module.join("/");
-                let namespace = kind.namespace();
-                let a0_namespace = a0_kind.namespace();
-                format!("{module}/{namespace}.{item}.html#{a0_namespace}.{a0_name}")
-            }
-            LinkTarget::NestedAnchoredItem {
-                kind,
-                module,
-                item,
-                anchors: [(a0_kind, a0_name), (a1_kind, a1_name)],
-            } => {
-                let module = module.join("/");
-                let namespace = kind.namespace();
-                let a0_namespace = a0_kind.namespace();
-                let a1_namespace = a1_kind.namespace();
-                format!(
-                    "{module}/{namespace}.{item}.html#{a0_namespace}.{a0_name}.{a1_namespace}.{a1_name}"
-                )
-            }
-        }
+                event
+            },
+        )
     }
 }

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -1,15 +1,18 @@
 use std::process::ExitStatus;
 
-use cargo_metadata::{Metadata, Package};
-use rustdoc_types::{Crate, Item};
+use cargo_metadata::{Metadata, Package, PackageName};
 
 use crate::{
     App,
-    sync::ManifestFile,
+    sync::{
+        ManifestFile,
+        contents::rustdoc::{document::RustdocDocument, intra_link::LinkMappingConfig},
+    },
     with_source::{ReadFileError, WithSource},
 };
 
 mod code_block;
+mod document;
 mod heading;
 mod intra_link;
 
@@ -24,8 +27,10 @@ pub(in super::super) enum CreateRustdocError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     ReadFileError(#[from] ReadFileError),
-    #[error("crate {crate_name} does not have a crate-level documentation")]
-    RootDocNotFound { crate_name: String },
+    #[error("package {package_name} does not have a root item")]
+    RootNotFound { package_name: PackageName },
+    #[error("package {package_name} does not have a crate-level documentation")]
+    RootDocNotFound { package_name: PackageName },
 }
 
 pub(super) fn create(
@@ -35,6 +40,12 @@ pub(super) fn create(
     package: &Package,
 ) -> CreateResult<String> {
     let config = manifest.value().config();
+    let local_html_root_url = config
+        .rustdoc
+        .html_root_url
+        .clone()
+        .unwrap_or_else(|| format!("https://docs.rs/{}/{}", package.name, package.version));
+    let mapping_config = LinkMappingConfig::new(&config.rustdoc.mappings, &local_html_root_url);
 
     run_rustdoc(app, package)?;
 
@@ -43,25 +54,26 @@ pub(super) fn create(
         .join("doc")
         .join(format!("{}.json", package.name.replace('-', "_")));
 
-    let doc_with_source: WithSource<Crate> = WithSource::from_json("rustdoc output", output_file)?;
-    let doc = doc_with_source.value();
-    let root = &doc.index[&doc.root];
-    let local_html_root_url = config.rustdoc.html_root_url.clone().unwrap_or_else(|| {
-        format!(
-            "https://docs.rs/{}/{}",
-            package.name,
-            doc.crate_version.as_deref().unwrap_or("latest")
-        )
-    });
+    let doc = WithSource::from_json("rustdoc output", output_file)?.into_value();
+    let doc = RustdocDocument::new(doc);
+    let root = doc
+        .root_item()
+        .ok_or_else(|| CreateRustdocError::RootNotFound {
+            package_name: package.name.clone(),
+        })?;
 
-    let root_doc = extract_doc(root)?;
-    let mut parser =
-        intra_link::Parser::new(doc, root, &local_html_root_url, &config.rustdoc.mappings);
-    let events = parser.events(&root_doc);
+    let resolver = doc.intra_link_resolver();
+    let mapper = mapping_config
+        .build_mapper(&resolver, root)
+        .ok_or_else(|| CreateRustdocError::RootDocNotFound {
+            package_name: package.name.clone(),
+        })?;
+
+    let events = mapper.build_parser();
     let events = heading::convert(events);
     let events = code_block::convert(events);
 
-    let mut buf = String::with_capacity(root_doc.len());
+    let mut buf = String::new();
     pulldown_cmark_to_cmark::cmark(events, &mut buf).unwrap();
     if !buf.is_empty() && !buf.ends_with('\n') {
         buf.push('\n');
@@ -97,12 +109,4 @@ fn run_rustdoc(app: &App, package: &Package) -> CreateResult<()> {
         return Err(CreateRustdocError::Exit(status));
     }
     Ok(())
-}
-
-fn extract_doc(item: &Item) -> CreateResult<String> {
-    item.docs
-        .clone()
-        .ok_or_else(|| CreateRustdocError::RootDocNotFound {
-            crate_name: item.name.clone().unwrap(),
-        })
 }

--- a/src/with_source.rs
+++ b/src/with_source.rs
@@ -129,6 +129,10 @@ impl<T> WithSource<T> {
         &self.value
     }
 
+    pub(crate) fn into_value(self) -> T {
+        self.value
+    }
+
     pub(crate) fn to_named_source(&self) -> NamedSource<Arc<str>> {
         self.source_info.to_named_source()
     }


### PR DESCRIPTION
## Summary
- extract rustdoc JSON traversal and link-target construction into a dedicated `document` module
- keep Markdown link rewriting focused in `intra_link` with a smaller `LinkMappingConfig`/`LinkMapper` API
- add `WithSource::into_value()` and tighten root-item/root-doc error handling in rustdoc generation
- avoid a panic when `cargo-sync-rdme` cannot resolve some valid intra-doc links from rustdoc output

## Motivation
This refactors the rustdoc-related processing to separate rustdoc document interpretation from Markdown link mapping, making the code easier to follow and evolve.

It also fixes a bug where `cargo-sync-rdme` could panic while converting documentation that contains valid intra-doc links recognized by rustdoc but not resolvable by `cargo-sync-rdme`.

## Validation
- `cargo test`
- `cargo clippy`
- verified the converted documentation output matches the previous result
- confirmed the panic case is fixed

## Impact
No intended user-visible behavior change for successfully resolved links.

When `cargo-sync-rdme` cannot resolve a valid intra-doc link from rustdoc output, it now preserves conversion instead of panicking.

## Risks / follow-up
- no known functional regressions are intended
- warning-based helper paths may be revisited later if they are converted to `Result`-based error handling