### PR TITLE
Match pulldown-cmark options with rustdoc

### DIFF
--- a/src/sync/contents/rustdoc/intra_link.rs
+++ b/src/sync/contents/rustdoc/intra_link.rs
@@ -77,16 +77,14 @@ where
 }
 
 impl LinkMapper<'_, '_> {
-    pub(super) fn build_parser(&self) -> impl Iterator<Item = Event<'_>> {
-        Parser::new_with_broken_link_callback(self.docs, Options::all(), Some(self)).map(
-            |mut event| {
-                if let Event::Start(Tag::Link { dest_url: url, .. }) = &mut event
-                    && let Some(Some(full_url)) = self.map.get(url.as_ref())
-                {
-                    *url = full_url.clone().into();
-                }
-                event
-            },
-        )
+    pub(super) fn build_parser(&self, options: Options) -> impl Iterator<Item = Event<'_>> {
+        Parser::new_with_broken_link_callback(self.docs, options, Some(self)).map(|mut event| {
+            if let Event::Start(Tag::Link { dest_url: url, .. }) = &mut event
+                && let Some(Some(full_url)) = self.map.get(url.as_ref())
+            {
+                *url = full_url.clone().into();
+            }
+            event
+        })
     }
 }

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -1,6 +1,7 @@
 use std::process::ExitStatus;
 
 use cargo_metadata::{Metadata, Package, PackageName};
+use pulldown_cmark::Options;
 
 use crate::{
     App,
@@ -69,7 +70,7 @@ pub(super) fn create(
             package_name: package.name.clone(),
         })?;
 
-    let events = mapper.build_parser();
+    let events = mapper.build_parser(main_body_opts());
     let events = heading::convert(events);
     let events = code_block::convert(events);
 
@@ -109,4 +110,14 @@ fn run_rustdoc(app: &App, package: &Package) -> CreateResult<()> {
         return Err(CreateRustdocError::Exit(status));
     }
     Ok(())
+}
+
+// Same options as rustdoc uses for the main body of the crate-level documentation.
+// <https://github.com/rust-lang/rust/blob/153ecc4f74035b709bb3e1eb9546f1d934865042/compiler/rustc_resolve/src/rustdoc.rs#L250-L257>
+fn main_body_opts() -> Options {
+    Options::ENABLE_TABLES
+        | Options::ENABLE_FOOTNOTES
+        | Options::ENABLE_STRIKETHROUGH
+        | Options::ENABLE_TASKLISTS
+        | Options::ENABLE_SMART_PUNCTUATION
 }


### PR DESCRIPTION
## Summary
- pass the same `pulldown-cmark` options that `rustdoc` uses for crate-level documentation
- change `LinkMapper::build_parser` to accept the parser options from the caller instead of hard-coding `Options::all()`
- keep the existing intra-doc link rewriting behavior while aligning markdown parsing with `rustdoc`

## Motivation
`cargo-sync-rdme` was parsing crate docs with `Options::all()`, which can enable markdown features that `rustdoc` itself does not use for the main body. This makes the generated README potentially diverge from how the original crate documentation is interpreted.

## Validation
- `cargo test`

## Impact
Generated README content should now match `rustdoc` more closely for crate-level documentation, especially for markdown extensions that are not enabled by `rustdoc`.
