### PR TITLE
Document rustdoc markdown extensions

### DIFF
--- a/examples/lib/README.md
+++ b/examples/lib/README.md
@@ -141,11 +141,11 @@ It will be extracted and used to generate README.md.
 
 <!-- markdownlint-enable MD060 -->
 
-### Code Blocks
+## Code Blocks
 
 All code block syntaxes in [CommonMark Spec][commonmark-spec] are supported.
 
-In rendered Rust code blocks, cargo-sync-rdme matches rustdoc’s hidden-line handling for `#`-prefixed lines.
+In rendered Rust code blocks, `cargo-sync-rdme` matches the hidden-line handling of `rustdoc` for `#`-prefixed lines.
 
 ### Fenced code block
 
@@ -181,6 +181,35 @@ println!("Hello, world!");
 println!("Hello, world!");
 
 ````
+
+## `rustdoc` Markdown Extensions
+
+`cargo-sync-rdme` preserves several Markdown extensions supported by `rustdoc`.
+
+<!-- markdownlint-disable MD060 -->
+
+|Extension|Example|
+|---------|-------|
+|Tables|This section itself starts with a table.|
+|Footnotes|Footnotes work in prose too.[^markdown-extension-footnote]|
+|Strikethrough|~~Deprecated wording~~|
+|Task lists|See the checklist below.|
+
+<!-- markdownlint-enable MD060 -->
+
+* [x] Completed task list item
+* [ ] Incomplete task list item
+
+`rustdoc` also applies smart punctuation, and `cargo-sync-rdme` preserves
+those conversions in synced Markdown so README output matches `rustdoc`
+more closely.
+
+“quoted text”… really – exactly — like this.
+
+In `rustdoc`, that text is rendered with typographic quotes, an ellipsis,
+and en/em dashes.
+
+[^markdown-extension-footnote]: In `rustdoc`, footnotes are collected at the end of the rendered Markdown block.
 
 [intra-doc-link]: https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html
 [struct-without-backtick]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html

--- a/examples/lib/src/lib.rs
+++ b/examples/lib/src/lib.rs
@@ -138,12 +138,11 @@
 //! | Foreign Function                                | [`foreign_function`]          |                                 |                                               |
 //! | Foreign Static                                  | [`FOREIGN_STATIC`]            |                                 |                                               |
 //! <!-- markdownlint-enable MD060 -->
-//!
-//! ## Code Blocks
+//! # Code Blocks
 //!
 //! All code block syntaxes in [CommonMark Spec][commonmark-spec] are supported.
 //!
-//! In rendered Rust code blocks, cargo-sync-rdme matches rustdoc's hidden-line handling for `#`-prefixed lines.
+//! In rendered Rust code blocks, `cargo-sync-rdme` matches the hidden-line handling of `rustdoc` for `#`-prefixed lines.
 //!
 //! [commonmark-spec]: https://spec.commonmark.org/0.31.2/
 //!
@@ -182,6 +181,33 @@
 //!     # fn main() {
 //!     println!("Hello, world!");
 //!     # }
+//!
+//! # `rustdoc` Markdown Extensions
+//!
+//! `cargo-sync-rdme` preserves several Markdown extensions supported by `rustdoc`.
+//!
+//! <!-- markdownlint-disable MD060 -->
+//! | Extension | Example |
+//! | --------- | ------- |
+//! | Tables | This section itself starts with a table. |
+//! | Footnotes | Footnotes work in prose too.[^markdown-extension-footnote] |
+//! | Strikethrough | ~~Deprecated wording~~ |
+//! | Task lists | See the checklist below. |
+//! <!-- markdownlint-enable MD060 -->
+//!
+//! - [x] Completed task list item
+//! - [ ] Incomplete task list item
+//!
+//! `rustdoc` also applies smart punctuation, and `cargo-sync-rdme` preserves
+//! those conversions in synced Markdown so README output matches `rustdoc`
+//! more closely.
+//!
+//! "quoted text"... really -- exactly --- like this.
+//!
+//! In `rustdoc`, that text is rendered with typographic quotes, an ellipsis,
+//! and en/em dashes.
+//!
+//! [^markdown-extension-footnote]: In `rustdoc`, footnotes are collected at the end of the rendered Markdown block.
 //!
 
 #![allow(missing_copy_implementations, missing_debug_implementations)]

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -119,5 +119,8 @@ fn main_body_opts() -> Options {
         | Options::ENABLE_FOOTNOTES
         | Options::ENABLE_STRIKETHROUGH
         | Options::ENABLE_TASKLISTS
+        // Keep smart punctuation enabled so synced Markdown matches rustdoc's
+        // rendered output more closely, including on renderers like GitHub that
+        // do not apply those substitutions themselves.
         | Options::ENABLE_SMART_PUNCTUATION
 }


### PR DESCRIPTION
## Summary

- add a `rustdoc` Markdown extensions section to the example crate docs
- show examples for tables, footnotes, strikethrough, and task lists
- document that `cargo-sync-rdme` preserves `rustdoc` smart punctuation in synced Markdown
- sync the example crate README with the updated crate-level docs

## Motivation

`rustdoc` applies smart punctuation, but GitHub's Markdown renderer does not. Preserving those conversions when reconstructing Markdown keeps the synced README closer to how the crate documentation appears in `rustdoc`, and documenting that behavior in both the implementation and the example crate makes the generated README easier to understand.

## Validation

- `cargo clippy --package cargo-sync-rdme-example-lib --all-targets`
- `cargo doc --package cargo-sync-rdme-example-lib --no-deps`
- `cargo run -- --package cargo-sync-rdme-example-lib --toolchain nightly --check`

## Impact

Docs only. No functional behavior changes.
