### PR TITLE
Preserve intra-doc links as references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fix a bug that could cause `cargo sync-rdme` to panic when converting documentation containing valid intra-doc links that `cargo-sync-rdme` cannot resolve.
 
+### Changed
+
+* Emit resolved intra-doc links as reference-style Markdown links instead of expanding them to inline links with resolved URLs.
+
+  Inline intra-doc links are converted to generated reference-style links. Existing intra-doc reference links keep their labels and reference form when possible, and `cargo-sync-rdme` adds or adjusts reference definitions as needed to keep the output valid. Non-intra-doc links are left unchanged.
+
 ### Removed
 
 * Stop publishing prebuilt Linux release artifacts for `i686-unknown-linux-gnu`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "unicase",
  "url",
  "vcs-modify-guard",
  "void",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ thiserror = "2.0.20"
 toml = { version = "1.1.4", features = ["preserve_order"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+unicase = "2.9.0"
 url = "2.5.8"
 vcs-modify-guard = { version = "0.1.0", default-features = false }
 void = "1.0.2"

--- a/examples/lib/README.md
+++ b/examples/lib/README.md
@@ -16,10 +16,14 @@ It will be extracted and used to generate README.md.
 
 * Inline links:
   * `[the struct](Struct)`
-    → [the struct](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)
+    → [the struct][Struct]
   * ``[the struct](`Struct`)``
-    → [the struct](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)
+    → [the struct][`Struct`]
 * Full reference links:
+  * `[the struct][Struct]`
+    → [the struct][Struct]
+  * ``[the struct][`Struct`]``
+    → [the struct][`Struct`]
   * `[the struct][struct-without-backtick]`
     → [the struct][struct-without-backtick]
   * `[the struct][struct-with-backtick]`
@@ -30,114 +34,114 @@ It will be extracted and used to generate README.md.
   * `[struct-with-backtick][]`
     → [struct-with-backtick][]
   * `[Struct][]`
-    → [Struct](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)
+    → [Struct][]
   * ``[`Struct`][]``
-    → [`Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)
+    → [`Struct`][]
 * Shortcut reference links:
   * `[struct-without-backtick]`
     → [struct-without-backtick]
   * `[struct-with-backtick]`
     → [struct-with-backtick]
   * `[Struct]`
-    → [Struct](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)
+    → [Struct]
   * ``[`Struct`]``
-    → [`Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)
+    → [`Struct`]
 
 ### Intra-doc Link Syntaxes
 
 * Links with paths:
   * ``[`crate::Struct`]``
-    → [`crate::Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)
+    → [`crate::Struct`]
   * ``[`self::Struct`]``
-    → [`self::Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)
+    → [`self::Struct`]
 * Links with namespaces:
   * ``[`struct@Struct`]``
-    → [`struct@Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)
+    → [`struct@Struct`]
   * ``[`enum@Enum`]``
-    → [`enum@Enum`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html)
+    → [`enum@Enum`]
   * ``[`trait@Trait`]``
-    → [`trait@Trait`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html)
+    → [`trait@Trait`]
   * ``[`union@Union`]``
-    → [`union@Union`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html)
+    → [`union@Union`]
   * ``[`mod@module`], [`module@module`]``
-    → [`mod@module`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html), [`module@module`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html)
+    → [`mod@module`], [`module@module`]
   * ``[`const@CONSTANT`], [`constant@CONSTANT`]``
-    → [`const@CONSTANT`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html), [`constant@CONSTANT`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html)
+    → [`const@CONSTANT`], [`constant@CONSTANT`]
   * ``[`fn@function`], [`function@function`]``
-    → [`fn@function`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html), [`function@function`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html)
+    → [`fn@function`], [`function@function`]
   * ``[`field@Struct::field`]``
-    → [`field@Struct::field`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#structfield.field)
+    → [`field@Struct::field`]
   * ``[`variant@Enum::Variant`]``
-    → [`variant@Enum::Variant`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Variant)
+    → [`variant@Enum::Variant`]
   * ``[`method@Trait::method`]``
-    → [`method@Trait::method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.method)
+    → [`method@Trait::method`]
   * ``[`derive@Clone`]``
-    → [`derive@Clone`](https://doc.rust-lang.org/nightly/core/clone/derive.Clone.html)
+    → [`derive@Clone`]
   * ``[`type@Struct`]``
-    → [`type@Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)
+    → [`type@Struct`]
   * ``[`value@STATIC`]``
-    → [`value@STATIC`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.STATIC.html)
-  * ``[`macro@declarative_macro`]`` → [`macro@declarative_macro`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html)
+    → [`value@STATIC`]
+  * ``[`macro@declarative_macro`]`` → [`macro@declarative_macro`]
   * ``[`tyalias@TypeAlias`], [`typealias@TypeAlias`]``
-    → [`tyalias@TypeAlias`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html), [`typealias@TypeAlias`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html)
+    → [`tyalias@TypeAlias`], [`typealias@TypeAlias`]
   * ``[`prim@i32`], [`primitive@i32`]``
-    → [`prim@i32`](https://doc.rust-lang.org/nightly/std/primitive.i32.html), [`primitive@i32`](https://doc.rust-lang.org/nightly/std/primitive.i32.html)
+    → [`prim@i32`], [`primitive@i32`]
 * Links with disambiguators:
   * ``[`function()`]``
-    → [`function()`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html)
+    → [`function()`]
   * ``[`declarative_macro!`]``
-    → [`declarative_macro!`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html)
+    → [`declarative_macro!`]
   * ``[`declarative_macro!()`]``
-    → [`declarative_macro!()`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html)
+    → [`declarative_macro!()`]
   * ``[`declarative_macro![]`](declarative_macro![])``
-    → [`declarative_macro![]`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html)
+    → [`declarative_macro![]`][declarative_macro!()]
   * ``[`declarative_macro!{}`]``
-    → [`declarative_macro!{}`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html)
+    → [`declarative_macro!{}`]
 
 ### Link showcase
 
 <!-- markdownlint-disable MD060 -->
 
-|Link Target|[`crate`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/index.html)|[`std`](https://doc.rust-lang.org/nightly/std/index.html)|External Crate|
+|Link Target|[`crate`]|[`std`]|External Crate|
 |-----------|-------|-----|--------------|
-|Module|[`module`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html)|[`std::collections`](https://doc.rust-lang.org/nightly/std/collections/index.html)|[`num::bigint`](https://docs.rs/num/0.4/num/bigint/index.html)|
-|Struct|[`Struct`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html)|[`std::collections::HashMap`](https://doc.rust-lang.org/nightly/std/collections/hash/map/struct.HashMap.html)|[`num::BigInt`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html)|
-|Struct Field|[`Struct::field`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#structfield.field)|[`std::ops::Range::start`](https://doc.rust-lang.org/nightly/core/ops/range/struct.Range.html#structfield.start)|[`num::Complex::re`](https://docs.rs/num-complex/0.4/num_complex/struct.Complex.html#structfield.re)|
-|Tuple Struct Field|[`TupleStruct::0`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.TupleStruct.html#structfield.0)|[`std::cmp::Reverse::0`](https://doc.rust-lang.org/nightly/core/cmp/struct.Reverse.html#structfield.0)||
-|Union|[`Union`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html)|[`std::mem::MaybeUninit`](https://doc.rust-lang.org/nightly/core/mem/maybe_uninit/union.MaybeUninit.html)||
-|Union Field|[`Union::x`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html#structfield.x)|||
-|Enum|[`Enum`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html)|[`Option`](https://doc.rust-lang.org/nightly/core/option/enum.Option.html)|[`num::traits::FloatErrorKind`](https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html)|
-|Enum Variant|[`Enum::Variant`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Variant)|[`Option::Some`](https://doc.rust-lang.org/nightly/core/option/enum.Option.html#variant.Some)|[`num::traits::FloatErrorKind::Empty`](https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html#variant.Empty)|
-|Variant Field|[`Enum::Struct::field`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Struct.field.field)|||
-|Tuple Variant Field|[`Enum::Tuple::0`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Tuple.field.0)|[`Option::Some::0`](https://doc.rust-lang.org/nightly/core/option/enum.Option.html#variant.Some.field.0)|[`serde::de::Unexpected::Other::0`](https://docs.rs/serde_core/1.0.229/serde_core/de/enum.Unexpected.html#variant.Other.field.0)|
-|Type Alias|[`TypeAlias`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html)|[`std::io::Result`](https://doc.rust-lang.org/nightly/core/io/error/type.Result.html)|[`num::BigRational`](https://docs.rs/num-rational/0.4/num_rational/type.BigRational.html)|
-|Trait|[`Trait`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html)|[`Iterator`](https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html)|[`num::Num`](https://docs.rs/num-traits/0.2/num_traits/trait.Num.html)|
-|Required Method|[`Trait::method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.method)|[`Iterator::next`](https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#tymethod.next)|[`num::Zero::is_zero`](https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.is_zero)|
-|Provided Method|[`Trait::provided_method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#method.provided_method)|[`Iterator::size_hint`](https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#tymethod.size_hint)|[`num::Zero::set_zero`](https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.set_zero)|
-|Required Associated Function|[`Trait::assoc_fn`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.assoc_fn)|[`FromIterator::from_iter`](https://doc.rust-lang.org/nightly/core/iter/traits/collect/trait.FromIterator.html#tymethod.from_iter)|[`num::Zero::zero`](https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.zero)|
-|Required Associated Constant|[`Trait::CONST`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedconstant.CONST)||[`num::traits::ConstZero::ZERO`](https://docs.rs/num-traits/0.2/num_traits/identities/trait.ConstZero.html#associatedconstant.ZERO)|
-|Required Associated Type|[`Trait::Type`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedtype.Type)|[`Iterator::Item`](https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#associatedtype.Item)|[`num::Num::FromStrRadixErr`](https://docs.rs/num-traits/0.2/num_traits/trait.Num.html#associatedtype.FromStrRadixErr)|
-|Trait Implementation Method|[`Struct::method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.method)|[`Vec::clone`](https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.clone)|[`num::BigInt::is_zero`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.is_zero)|
-|Trait Implementation Method (overrides default)|[`Struct::provided_method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.provided_method)|[`std::slice::Iter::size_hint`](https://doc.rust-lang.org/nightly/core/slice/iter/struct.Iter.html#method.size_hint)|[`num::BigInt::set_zero`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.set_zero)|
-|Trait Implementation Associated Function|[`Struct::assoc_fn`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.assoc_fn)|[`Vec::from_iter`](https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.from_iter)|[`num::BigInt::zero`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.zero)|
-|Trait Implementation Associated Constant|[`Struct::CONST`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedconstant.CONST)|||
-|Trait Implementation Associated Type|[`Struct::Type`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedtype.Type)|[`std::slice::Iter::Item`](https://doc.rust-lang.org/nightly/core/slice/iter/struct.Iter.html#associatedtype.Item)|[`num::BigInt::FromStrRadixErr`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#associatedtype.FromStrRadixErr)|
-|Inherent Method|[`Struct::inhr_method`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.inhr_method)|[`Vec::len`](https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.len)|[`num::BigInt::sign`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.sign)|
-|Inherent Associated Function|[`Struct::inhr_assoc_fn`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.inhr_assoc_fn)|[`Vec::new`](https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.new)|[`num::BigInt::new`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.new)|
-|Inherent Associated Constant|[`Struct::INHR_CONST`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedconstant.INHR_CONST)|[`i32::MAX`](https://doc.rust-lang.org/nightly/std/primitive.i32.html#associatedconstant.MAX)|[`num::BigInt::ZERO`](https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#associatedconstant.ZERO)|
-|Constant|[`CONSTANT`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html)|[`std::path::MAIN_SEPARATOR`](https://doc.rust-lang.org/nightly/std/path/constant.MAIN_SEPARATOR.html)||
-|Static|[`STATIC`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.STATIC.html)|||
-|Function|[`function`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html)|[`std::iter::from_fn`](https://doc.rust-lang.org/nightly/core/iter/sources/from_fn/fn.from_fn.html)|[`num::abs`](https://docs.rs/num-traits/0.2/num_traits/sign/fn.abs.html)|
-|Primitive Type||[`i32`](https://doc.rust-lang.org/nightly/std/primitive.i32.html)||
-|Primitive Method||[`i32::count_ones`](https://doc.rust-lang.org/nightly/std/primitive.i32.html#method.count_ones)||
-|Primitive Associated Function||[`i32::from_str_radix`](https://doc.rust-lang.org/nightly/std/primitive.i32.html#method.from_str_radix)||
-|Primitive Associated Constant||[`i32::MAX`](https://doc.rust-lang.org/nightly/std/primitive.i32.html#associatedconstant.MAX)||
-|Declarative Macro|[`declarative_macro`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html)|[`println`](https://doc.rust-lang.org/nightly/std/macro.println.html)||
-|Attribute Macro||[`derive`](https://doc.rust-lang.org/nightly/core/macros/builtin/attr.derive.html)|[`async_trait::async_trait`](https://docs.rs/async-trait/0.1.92/async_trait/attr.async_trait.html)|
-|Derive Macro||[`Clone`](https://doc.rust-lang.org/nightly/core/clone/derive.Clone.html)|[`serde::Serialize`](https://docs.rs/serde_derive/1.0.229/serde_derive/derive.Serialize.html)|
-|Re-exported from Private Module|[`ReexportedFromPrivateMod`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/private/struct.ReexportedFromPrivateMod.html)|||
-|Foreign Function|[`foreign_function`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.foreign_function.html)|||
-|Foreign Static|[`FOREIGN_STATIC`](https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.FOREIGN_STATIC.html)|||
+|Module|[`module`]|[`std::collections`]|[`num::bigint`]|
+|Struct|[`Struct`]|[`std::collections::HashMap`]|[`num::BigInt`][num::BigInt@1]|
+|Struct Field|[`Struct::field`]|[`std::ops::Range::start`]|[`num::Complex::re`]|
+|Tuple Struct Field|[`TupleStruct::0`]|[`std::cmp::Reverse::0`]||
+|Union|[`Union`]|[`std::mem::MaybeUninit`]||
+|Union Field|[`Union::x`]|||
+|Enum|[`Enum`]|[`Option`]|[`num::traits::FloatErrorKind`]|
+|Enum Variant|[`Enum::Variant`]|[`Option::Some`]|[`num::traits::FloatErrorKind::Empty`]|
+|Variant Field|[`Enum::Struct::field`]|||
+|Tuple Variant Field|[`Enum::Tuple::0`]|[`Option::Some::0`]|[`serde::de::Unexpected::Other::0`]|
+|Type Alias|[`TypeAlias`]|[`std::io::Result`]|[`num::BigRational`]|
+|Trait|[`Trait`]|[`Iterator`]|[`num::Num`]|
+|Required Method|[`Trait::method`]|[`Iterator::next`]|[`num::Zero::is_zero`]|
+|Provided Method|[`Trait::provided_method`]|[`Iterator::size_hint`]|[`num::Zero::set_zero`]|
+|Required Associated Function|[`Trait::assoc_fn`]|[`FromIterator::from_iter`]|[`num::Zero::zero`]|
+|Required Associated Constant|[`Trait::CONST`]||[`num::traits::ConstZero::ZERO`]|
+|Required Associated Type|[`Trait::Type`]|[`Iterator::Item`]|[`num::Num::FromStrRadixErr`]|
+|Trait Implementation Method|[`Struct::method`]|[`Vec::clone`]|[`num::BigInt::is_zero`]|
+|Trait Implementation Method (overrides default)|[`Struct::provided_method`]|[`std::slice::Iter::size_hint`]|[`num::BigInt::set_zero`]|
+|Trait Implementation Associated Function|[`Struct::assoc_fn`]|[`Vec::from_iter`]|[`num::BigInt::zero`]|
+|Trait Implementation Associated Constant|[`Struct::CONST`]|||
+|Trait Implementation Associated Type|[`Struct::Type`]|[`std::slice::Iter::Item`]|[`num::BigInt::FromStrRadixErr`]|
+|Inherent Method|[`Struct::inhr_method`]|[`Vec::len`]|[`num::BigInt::sign`]|
+|Inherent Associated Function|[`Struct::inhr_assoc_fn`]|[`Vec::new`]|[`num::BigInt::new`]|
+|Inherent Associated Constant|[`Struct::INHR_CONST`]|[`i32::MAX`]|[`num::BigInt::ZERO`][num::BigInt::ZERO@1]|
+|Constant|[`CONSTANT`]|[`std::path::MAIN_SEPARATOR`]||
+|Static|[`STATIC`]|||
+|Function|[`function`]|[`std::iter::from_fn`]|[`num::abs`]|
+|Primitive Type||[`i32`]||
+|Primitive Method||[`i32::count_ones`]||
+|Primitive Associated Function||[`i32::from_str_radix`]||
+|Primitive Associated Constant||[`i32::MAX`]||
+|Declarative Macro|[`declarative_macro`]|[`println`]||
+|Attribute Macro||[`derive`]|[`async_trait::async_trait`]|
+|Derive Macro||[`Clone`][derive@Clone]|[`serde::Serialize`][derive@serde::Serialize]|
+|Re-exported from Private Module|[`ReexportedFromPrivateMod`]|||
+|Foreign Function|[`foreign_function`]|||
+|Foreign Static|[`FOREIGN_STATIC`]|||
 
 <!-- markdownlint-enable MD060 -->
 
@@ -212,7 +216,122 @@ and en/em dashes.
 [^markdown-extension-footnote]: In `rustdoc`, footnotes are collected at the end of the rendered Markdown block.
 
 [intra-doc-link]: https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html
+[Struct]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
+[`Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
 [struct-without-backtick]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
 [struct-with-backtick]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
+[`crate::Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
+[`self::Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
+[`struct@Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
+[`enum@Enum`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html
+[`trait@Trait`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html
+[`union@Union`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html
+[`mod@module`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html
+[`module@module`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html
+[`const@CONSTANT`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html
+[`constant@CONSTANT`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html
+[`fn@function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html
+[`function@function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html
+[`field@Struct::field`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#structfield.field
+[`variant@Enum::Variant`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Variant
+[`method@Trait::method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.method
+[`derive@Clone`]: https://doc.rust-lang.org/nightly/core/clone/derive.Clone.html
+[`type@Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
+[`value@STATIC`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.STATIC.html
+[`macro@declarative_macro`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
+[`tyalias@TypeAlias`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html
+[`typealias@TypeAlias`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html
+[`prim@i32`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html
+[`primitive@i32`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html
+[`function()`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html
+[`declarative_macro!`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
+[`declarative_macro!()`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
+[declarative_macro!()]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
+[`declarative_macro!{}`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
+[`crate`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/index.html
+[`std`]: https://doc.rust-lang.org/nightly/std/index.html
+[`module`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html
+[`std::collections`]: https://doc.rust-lang.org/nightly/std/collections/index.html
+[`num::bigint`]: https://docs.rs/num/0.4/num/bigint/index.html
+[`std::collections::HashMap`]: https://doc.rust-lang.org/nightly/std/collections/hash/map/struct.HashMap.html
+[num::BigInt@1]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html
+[`Struct::field`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#structfield.field
+[`std::ops::Range::start`]: https://doc.rust-lang.org/nightly/core/ops/range/struct.Range.html#structfield.start
+[`num::Complex::re`]: https://docs.rs/num-complex/0.4/num_complex/struct.Complex.html#structfield.re
+[`TupleStruct::0`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.TupleStruct.html#structfield.0
+[`std::cmp::Reverse::0`]: https://doc.rust-lang.org/nightly/core/cmp/struct.Reverse.html#structfield.0
+[`Union`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html
+[`std::mem::MaybeUninit`]: https://doc.rust-lang.org/nightly/core/mem/maybe_uninit/union.MaybeUninit.html
+[`Union::x`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html#structfield.x
+[`Enum`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html
+[`Option`]: https://doc.rust-lang.org/nightly/core/option/enum.Option.html
+[`num::traits::FloatErrorKind`]: https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html
+[`Enum::Variant`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Variant
+[`Option::Some`]: https://doc.rust-lang.org/nightly/core/option/enum.Option.html#variant.Some
+[`num::traits::FloatErrorKind::Empty`]: https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html#variant.Empty
+[`Enum::Struct::field`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Struct.field.field
+[`Enum::Tuple::0`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Tuple.field.0
+[`Option::Some::0`]: https://doc.rust-lang.org/nightly/core/option/enum.Option.html#variant.Some.field.0
+[`serde::de::Unexpected::Other::0`]: https://docs.rs/serde_core/1.0.229/serde_core/de/enum.Unexpected.html#variant.Other.field.0
+[`TypeAlias`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html
+[`std::io::Result`]: https://doc.rust-lang.org/nightly/core/io/error/type.Result.html
+[`num::BigRational`]: https://docs.rs/num-rational/0.4/num_rational/type.BigRational.html
+[`Trait`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html
+[`Iterator`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html
+[`num::Num`]: https://docs.rs/num-traits/0.2/num_traits/trait.Num.html
+[`Trait::method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.method
+[`Iterator::next`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#tymethod.next
+[`num::Zero::is_zero`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.is_zero
+[`Trait::provided_method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#method.provided_method
+[`Iterator::size_hint`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#tymethod.size_hint
+[`num::Zero::set_zero`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.set_zero
+[`Trait::assoc_fn`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.assoc_fn
+[`FromIterator::from_iter`]: https://doc.rust-lang.org/nightly/core/iter/traits/collect/trait.FromIterator.html#tymethod.from_iter
+[`num::Zero::zero`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.zero
+[`Trait::CONST`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedconstant.CONST
+[`num::traits::ConstZero::ZERO`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.ConstZero.html#associatedconstant.ZERO
+[`Trait::Type`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedtype.Type
+[`Iterator::Item`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#associatedtype.Item
+[`num::Num::FromStrRadixErr`]: https://docs.rs/num-traits/0.2/num_traits/trait.Num.html#associatedtype.FromStrRadixErr
+[`Struct::method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.method
+[`Vec::clone`]: https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.clone
+[`num::BigInt::is_zero`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.is_zero
+[`Struct::provided_method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.provided_method
+[`std::slice::Iter::size_hint`]: https://doc.rust-lang.org/nightly/core/slice/iter/struct.Iter.html#method.size_hint
+[`num::BigInt::set_zero`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.set_zero
+[`Struct::assoc_fn`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.assoc_fn
+[`Vec::from_iter`]: https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.from_iter
+[`num::BigInt::zero`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.zero
+[`Struct::CONST`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedconstant.CONST
+[`Struct::Type`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedtype.Type
+[`std::slice::Iter::Item`]: https://doc.rust-lang.org/nightly/core/slice/iter/struct.Iter.html#associatedtype.Item
+[`num::BigInt::FromStrRadixErr`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#associatedtype.FromStrRadixErr
+[`Struct::inhr_method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.inhr_method
+[`Vec::len`]: https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.len
+[`num::BigInt::sign`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.sign
+[`Struct::inhr_assoc_fn`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.inhr_assoc_fn
+[`Vec::new`]: https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.new
+[`num::BigInt::new`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.new
+[`Struct::INHR_CONST`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedconstant.INHR_CONST
+[`i32::MAX`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html#associatedconstant.MAX
+[num::BigInt::ZERO@1]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#associatedconstant.ZERO
+[`CONSTANT`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html
+[`std::path::MAIN_SEPARATOR`]: https://doc.rust-lang.org/nightly/std/path/constant.MAIN_SEPARATOR.html
+[`STATIC`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.STATIC.html
+[`function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html
+[`std::iter::from_fn`]: https://doc.rust-lang.org/nightly/core/iter/sources/from_fn/fn.from_fn.html
+[`num::abs`]: https://docs.rs/num-traits/0.2/num_traits/sign/fn.abs.html
+[`i32`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html
+[`i32::count_ones`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html#method.count_ones
+[`i32::from_str_radix`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html#method.from_str_radix
+[`declarative_macro`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
+[`println`]: https://doc.rust-lang.org/nightly/std/macro.println.html
+[`derive`]: https://doc.rust-lang.org/nightly/core/macros/builtin/attr.derive.html
+[`async_trait::async_trait`]: https://docs.rs/async-trait/0.1.92/async_trait/attr.async_trait.html
+[derive@Clone]: https://doc.rust-lang.org/nightly/core/clone/derive.Clone.html
+[derive@serde::Serialize]: https://docs.rs/serde_derive/1.0.229/serde_derive/derive.Serialize.html
+[`ReexportedFromPrivateMod`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/private/struct.ReexportedFromPrivateMod.html
+[`foreign_function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.foreign_function.html
+[`FOREIGN_STATIC`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.FOREIGN_STATIC.html
 [commonmark-spec]: https://spec.commonmark.org/0.31.2/
 <!-- cargo-sync-rdme ]] -->

--- a/examples/lib/src/lib.rs
+++ b/examples/lib/src/lib.rs
@@ -17,6 +17,10 @@
 //!   * ``[the struct](`Struct`)``
 //!     → [the struct](`Struct`)
 //! * Full reference links:
+//!   * `[the struct][Struct]`
+//!     → [the struct][Struct]
+//!   * ``[the struct][`Struct`]``
+//!     → [the struct][`Struct`]
 //!   * `[the struct][struct-without-backtick]`
 //!     → [the struct][struct-without-backtick]
 //!   * `[the struct][struct-with-backtick]`

--- a/src/sync/contents/rustdoc/intra_link.rs
+++ b/src/sync/contents/rustdoc/intra_link.rs
@@ -1,7 +1,10 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::HashMap, fmt::Debug};
 
-use pulldown_cmark::{BrokenLink, BrokenLinkCallback, CowStr, Event, Options, Parser, Tag};
+use pulldown_cmark::{
+    BrokenLink, BrokenLinkCallback, CowStr, Event, LinkType, Options, Parser, RefDefs, Tag,
+};
 use rustdoc_types::{Id, Item};
+use unicase::UniCase;
 
 use crate::sync::contents::rustdoc::document::IntraLinkResolver;
 
@@ -78,13 +81,253 @@ where
 
 impl LinkMapper<'_, '_> {
     pub(super) fn build_parser(&self, options: Options) -> impl Iterator<Item = Event<'_>> {
-        Parser::new_with_broken_link_callback(self.docs, options, Some(self)).map(|mut event| {
-            if let Event::Start(Tag::Link { dest_url: url, .. }) = &mut event
-                && let Some(Some(full_url)) = self.map.get(url.as_ref())
+        let parser = Parser::new_with_broken_link_callback(self.docs, options, Some(self));
+        let mut refs =
+            LabelRegistry::from_reference_definitions(parser.reference_definitions(), &self.map);
+        parser.map(move |mut event| {
+            if let Event::Start(Tag::Link {
+                link_type,
+                dest_url,
+                title,
+                id,
+            }) = &mut event
             {
-                *url = full_url.clone().into();
+                match link_type {
+                    LinkType::ReferenceUnknown => {
+                        *link_type = LinkType::Reference;
+                        let updated_id = refs.allocate_label(id, dest_url, title).0.into_inner();
+                        if *id != updated_id {
+                            *id = updated_id.into_static();
+                        }
+                    }
+                    LinkType::CollapsedUnknown => {
+                        *link_type = LinkType::Collapsed;
+                        let updated_id = refs.allocate_label(id, dest_url, title).0.into_inner();
+                        if *id != updated_id {
+                            *id = updated_id.into_static();
+                            *link_type = LinkType::Reference;
+                        }
+                    }
+                    LinkType::ShortcutUnknown => {
+                        *link_type = LinkType::Shortcut;
+                        let updated_id = refs.allocate_label(id, dest_url, title).0.into_inner();
+                        if *id != updated_id {
+                            *id = updated_id.into_static();
+                            *link_type = LinkType::Reference;
+                        }
+                    }
+                    LinkType::Inline => {
+                        if let Some(Some(new_dest_url)) = self.map.get(dest_url.as_ref()) {
+                            *link_type = LinkType::Reference;
+                            *id = refs
+                                .allocate_label(dest_url, new_dest_url, title)
+                                .0
+                                .into_inner()
+                                .into_static();
+                            *dest_url = new_dest_url.clone().into();
+                        }
+                    }
+                    LinkType::Reference | LinkType::Collapsed | LinkType::Shortcut => {
+                        if let Some(Some(new_dest_url)) = self.map.get(dest_url.as_ref()) {
+                            *dest_url = new_dest_url.clone().into();
+                        }
+                    }
+                    LinkType::Autolink | LinkType::Email => {}
+                    LinkType::WikiLink { .. } => unreachable!(),
+                }
             }
             event
         })
     }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct LinkLabel<'a>(UniCase<CowStr<'a>>);
+
+impl Debug for LinkLabel<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.0.as_ref(), f)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct LinkTarget<'a> {
+    url: CowStr<'a>,
+    title: CowStr<'a>,
+}
+
+impl Debug for LinkTarget<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LinkTarget")
+            .field("url", &self.url.as_ref())
+            .field("title", &self.title.as_ref())
+            .finish()
+    }
+}
+
+#[derive(Debug, Default)]
+struct LabelRegistry {
+    map: HashMap<LinkLabel<'static>, LinkTarget<'static>>,
+}
+
+impl LinkTarget<'_> {
+    fn into_static(self) -> LinkTarget<'static> {
+        LinkTarget {
+            url: self.url.into_static(),
+            title: self.title.into_static(),
+        }
+    }
+}
+
+impl<'a> LinkLabel<'a> {
+    fn new(label: &'a str) -> Self {
+        Self(normalize_label(label))
+    }
+
+    fn into_static(self) -> LinkLabel<'static> {
+        LinkLabel(UniCase::new(self.0.into_inner().into_static()))
+    }
+}
+
+impl LabelRegistry {
+    fn from_reference_definitions(
+        defs: &RefDefs<'_>,
+        url_map: &HashMap<&str, Option<Cow<'_, str>>>,
+    ) -> Self {
+        let mut map = HashMap::new();
+        for (label, def) in defs.iter() {
+            let label = LinkLabel::new(label);
+            let url = match url_map.get(def.dest.as_ref()) {
+                Some(Some(url)) => url.as_ref().into(),
+                Some(None) | None => def.dest.clone(),
+            };
+            let title = def.title.clone().unwrap_or(CowStr::Borrowed(""));
+            let target = LinkTarget { url, title };
+            map.insert(label.clone().into_static(), target.clone().into_static());
+        }
+        Self { map }
+    }
+
+    fn allocate_label<'a>(
+        &mut self,
+        label: &'a CowStr<'a>,
+        url: &str,
+        title: &str,
+    ) -> LinkLabel<'a> {
+        let label = LinkLabel::new(label);
+        let target = LinkTarget {
+            url: url.into(),
+            title: title.into(),
+        };
+        if let Some(existing) = self.map.get(&label) {
+            if *existing == target {
+                return label;
+            }
+        } else {
+            self.map
+                .insert(label.clone().into_static(), target.clone().into_static());
+            return label;
+        }
+        let label_base = strip_code_span_backticks(label.0.as_ref());
+        for i in 1.. {
+            let new_label_text = format!("{label_base}@{i}");
+            let new_label = LinkLabel::new(&new_label_text);
+            if let Some(existing) = self.map.get(&new_label) {
+                if *existing == target {
+                    return new_label.into_static();
+                }
+                continue;
+            }
+            self.map.insert(
+                new_label.clone().into_static(),
+                target.clone().into_static(),
+            );
+            return new_label.into_static();
+        }
+        unreachable!()
+    }
+}
+
+fn normalize_label(label: &str) -> UniCase<CowStr<'_>> {
+    // The following is quoted from the CommonMark spec
+    // <https://spec.commonmark.org/0.31.2/#matches>
+    //
+    // > To normalize a label, strip off the opening and closing brackets,
+    // > perform the Unicode case fold, strip leading and trailing spaces,
+    // > tabs, and line endings, and collapse consecutive internal spaces,
+    // > tabs, and line endings to a single space.
+    //
+
+    // We do not need to strip brackets here, because we only get the label content.
+
+    let label = label.trim_matches(is_whitespace);
+    let label = collapse_consecutive_whitespace(label);
+    let label = sanitize_label_for_cmark_to_cmark(label);
+
+    // `pulldown-cmark` uses `UniCase` to perform Unicode case folding.
+    UniCase::new(label)
+}
+
+// In the CommonMark spec, "spaces, tabs, and line endings" are defined as:
+//
+// * A space is `U+0020`
+//   <https://spec.commonmark.org/0.31.2/#space>
+// * A tab is `U+0009`
+//   <https://spec.commonmark.org/0.31.2/#tab>
+// * A line ending is a line feed (U+000A), a carriage return (U+000D) not followed by a line feed, or a carriage return and a following line feed.
+//   <https://spec.commonmark.org/0.31.2/#line-ending>
+//
+// However, `pulldown-cmark` treats '\x09'..='\x0D' (HT, LF, FF, CR) and '\x20' as whitespace, which does not exactly match the CommonMark spec.
+// <https://github.com/pulldown-cmark/pulldown-cmark/blob/2f251a6e9db0c550e2b9337881bb7d48fe27cdfc/pulldown-cmark/src/scanners.rs#L436-L438>
+//
+// In `cargo-sync-rdme`, we follow `pulldown-cmark`'s behavior.
+// We cannot use `char::is_ascii_whitespace()` here because it does not treat U+000B (VT) as whitespace.
+fn is_whitespace(c: char) -> bool {
+    matches!(c, '\x09'..='\x0D' | '\x20')
+}
+
+fn is_whitespace_byte(b: u8) -> bool {
+    matches!(b, b'\x09'..=b'\x0D' | b'\x20')
+}
+
+fn collapse_consecutive_whitespace(label: &str) -> CowStr<'_> {
+    let has_consecutive_ws = label
+        .as_bytes()
+        .array_windows()
+        .any(|[a, b]| is_whitespace_byte(*a) && is_whitespace_byte(*b));
+    if !has_consecutive_ws {
+        return label.into();
+    }
+    let mut collapsed = String::with_capacity(label.len());
+    let mut prev_was_ws = false;
+    for c in label.chars() {
+        if is_whitespace(c) {
+            if !prev_was_ws {
+                collapsed.push(' ');
+                prev_was_ws = true;
+            }
+        } else {
+            collapsed.push(c);
+            prev_was_ws = false;
+        }
+    }
+    collapsed.into()
+}
+
+fn sanitize_label_for_cmark_to_cmark(label: CowStr<'_>) -> CowStr<'_> {
+    // `pulldown-cmark-to-cmark` does not escape brackets in link labels, so we replace them with parentheses to avoid breaking the Markdown output.
+    // <https://github.com/Byron/pulldown-cmark-to-cmark/issues/109>
+    if label.contains('[') || label.contains(']') {
+        let replaced = label.replace('[', "(").replace(']', ")");
+        replaced.into()
+    } else {
+        label
+    }
+}
+
+fn strip_code_span_backticks(label: &str) -> &str {
+    label
+        .strip_prefix('`')
+        .and_then(|l| l.strip_suffix('`'))
+        .unwrap_or(label)
 }


### PR DESCRIPTION
## Summary

Preserve resolved intra-doc links as reference-style Markdown links instead of always expanding them to inline URLs.

This updates the intra-link conversion logic to:

- keep existing intra-doc reference links in reference form when possible
- convert inline intra-doc links to generated reference-style links
- preserve existing labels when possible
- allocate distinct labels when different targets would otherwise collide under Markdown's case-insensitive label matching
- leave non-intra-doc links unchanged

## Implementation notes

- track reference definitions with case-insensitive label normalization
- initialize the label registry from existing reference definitions, using resolved destinations when applicable
- rewrite unknown intra-doc references by adding generated reference definitions instead of forcing inline URLs
- add `@N` suffixes when different targets would otherwise reuse the same reference label
- update the example README output and changelog to reflect the new behavior

## Validation

- `cargo test`
- `cargo run -- --workspace --toolchain nightly --check`
- `diagnostics` on `CHANGELOG.md`
- `diagnostics` on `examples/lib/README.md`

## User-visible impact

Synced Markdown now preserves reference-style link output for resolved intra-doc links, so generated README content stays closer to the original Markdown structure while remaining valid when labels would collide.
