### PR TITLE
Escape generated reference labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,9 +1938,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+checksum = "ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60"
 dependencies = [
  "pulldown-cmark",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ clap_mangen = "0.3.2"
 console = "0.16.4"
 miette = { version = "7.6.0", features = ["fancy"] }
 pulldown-cmark = "0.13.4"
-pulldown-cmark-to-cmark = "22.0.0"
+pulldown-cmark-to-cmark = "22.0.1"
 rustdoc-types = "0.61.0"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"

--- a/examples/lib/README.md
+++ b/examples/lib/README.md
@@ -94,7 +94,7 @@ It will be extracted and used to generate README.md.
   * ``[`declarative_macro!()`]``
     → [`declarative_macro!()`]
   * ``[`declarative_macro![]`](declarative_macro![])``
-    → [`declarative_macro![]`][declarative_macro!()]
+    → [`declarative_macro![]`][declarative_macro!\[\]]
   * ``[`declarative_macro!{}`]``
     → [`declarative_macro!{}`]
 
@@ -246,7 +246,7 @@ and en/em dashes.
 [`function()`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html
 [`declarative_macro!`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
 [`declarative_macro!()`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
-[declarative_macro!()]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
+[declarative_macro!\[\]]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
 [`declarative_macro!{}`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
 [`crate`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/index.html
 [`std`]: https://doc.rust-lang.org/nightly/std/index.html

--- a/src/sync/contents/rustdoc/intra_link.rs
+++ b/src/sync/contents/rustdoc/intra_link.rs
@@ -119,8 +119,9 @@ impl LinkMapper<'_, '_> {
                     LinkType::Inline => {
                         if let Some(Some(new_dest_url)) = self.map.get(dest_url.as_ref()) {
                             *link_type = LinkType::Reference;
+                            let label = reference_label_from_link_destination(dest_url);
                             *id = refs
-                                .allocate_label(dest_url, new_dest_url, title)
+                                .allocate_label(&label, new_dest_url, title)
                                 .0
                                 .into_inner()
                                 .into_static();
@@ -262,7 +263,6 @@ fn normalize_label(label: &str) -> UniCase<CowStr<'_>> {
 
     let label = label.trim_matches(is_whitespace);
     let label = collapse_consecutive_whitespace(label);
-    let label = sanitize_label_for_cmark_to_cmark(label);
 
     // `pulldown-cmark` uses `UniCase` to perform Unicode case folding.
     UniCase::new(label)
@@ -314,20 +314,43 @@ fn collapse_consecutive_whitespace(label: &str) -> CowStr<'_> {
     collapsed.into()
 }
 
-fn sanitize_label_for_cmark_to_cmark(label: CowStr<'_>) -> CowStr<'_> {
-    // `pulldown-cmark-to-cmark` does not escape brackets in link labels, so we replace them with parentheses to avoid breaking the Markdown output.
-    // <https://github.com/Byron/pulldown-cmark-to-cmark/issues/109>
-    if label.contains('[') || label.contains(']') {
-        let replaced = label.replace('[', "(").replace(']', ")");
-        replaced.into()
-    } else {
-        label
-    }
-}
-
 fn strip_code_span_backticks(label: &str) -> &str {
     label
         .strip_prefix('`')
         .and_then(|l| l.strip_suffix('`'))
         .unwrap_or(label)
+}
+
+// Raw `[` and `]` are not valid in CommonMark reference-label source syntax, so
+// labels that contain brackets must be written with escapes. `pulldown-cmark`
+// keeps those escapes in the parsed label text instead of unescaping them.
+//
+// When we synthesize a label from an inline intra-doc link destination, we need
+// to produce the same representation that `pulldown-cmark` would use for a
+// parsed escaped label. Otherwise `pulldown-cmark-to-cmark` would emit an
+// invalid reference definition containing raw brackets.
+fn reference_label_from_link_destination(label: &str) -> CowStr<'_> {
+    if !label.contains(['[', ']']) {
+        return label.into();
+    }
+    let mut escaped = String::with_capacity(label.len());
+    let mut chars = label.chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => {
+                escaped.push(ch);
+                if let Some(ch) = chars.next() {
+                    escaped.push(ch);
+                }
+            }
+            '[' | ']' => {
+                escaped.push('\\');
+                escaped.push(ch);
+            }
+            _ => {
+                escaped.push(ch);
+            }
+        }
+    }
+    escaped.into()
 }


### PR DESCRIPTION
## Summary

Narrow bracket escaping to the path that synthesizes reference labels from inline intra-doc link destinations.

## What changed

- bump `pulldown-cmark-to-cmark` from `22.0.0` to `22.0.1`
- stop rewriting brackets during general label normalization
- escape brackets only when generating a new reference label from an inline intra-doc link destination
- keep parsed reference labels unchanged
- update the example README output accordingly

## Why

`pulldown-cmark-to-cmark` `22.0.0` had a bug where generated reference definitions could lose bracket escapes in link labels, producing invalid Markdown for labels containing brackets ([Byron/pulldown-cmark-to-cmark#109]).

Version `22.0.1` fixes that upstream by escaping brackets in generated link labels while leaving parser-provided explicit reference IDs unchanged. With that fix available, `cargo-sync-rdme` no longer needs to rewrite every label during normalization. The escaping only needs to happen on the narrower path where it synthesizes a reference label from an inline intra-doc link destination.

## Validation

- `just ci-rustfmt`
- `just ci-test`
- `just ci-sync-rdme`

## User-visible impact

Generated reference labels for inline intra-doc links containing brackets now preserve the original target spelling more accurately while still emitting valid Markdown reference definitions.

[Byron/pulldown-cmark-to-cmark#109]: https://github.com/Byron/pulldown-cmark-to-cmark/issues/109
