### PR TITLE
Disable pulldown-cmark default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,15 +569,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width 0.2.2",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,17 +1915,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags 2.13.1",
- "getopts",
  "memchr",
- "pulldown-cmark-escape",
  "unicase",
 ]
-
-[[package]]
-name = "pulldown-cmark-escape"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pulldown-cmark-to-cmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ clap_complete_nushell = "4.6.1"
 clap_mangen = "0.3.2"
 console = "0.16.4"
 miette = { version = "7.6.0", features = ["fancy"] }
-pulldown-cmark = "0.13.4"
+pulldown-cmark = { version = "0.13.4", default-features = false }
 pulldown-cmark-to-cmark = "22.0.1"
 rustdoc-types = "0.61.0"
 serde = { version = "1.0.229", features = ["derive"] }


### PR DESCRIPTION
## Summary
- disable `pulldown-cmark` default features in `Cargo.toml`
- update `Cargo.lock` to remove dependencies that were only pulled in by the unused default features

## Motivation
`cargo-sync-rdme` does not need the extra default features from `pulldown-cmark`, so this keeps the dependency surface smaller and avoids enabling unnecessary functionality.

## Validation
- `cargo test --all`
