### PR TITLE
Strip namespace prefixes from link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Emit resolved intra-doc links as reference-style Markdown links instead of expanding them to inline links with resolved URLs.
 
   Inline intra-doc links are converted to generated reference-style links. Existing intra-doc reference links keep their labels and reference form when possible, and `cargo-sync-rdme` adds or adjusts reference definitions as needed to keep the output valid. Non-intra-doc links are left unchanged.
+* Match `rustdoc` more closely for namespace-qualified intra-doc links such as [`struct@Struct`] by omitting the `namespace@` prefix from the rendered link text while still resolving the link to the namespace-qualified target.
 
 ### Removed
 

--- a/examples/lib/README.md
+++ b/examples/lib/README.md
@@ -56,36 +56,36 @@ It will be extracted and used to generate README.md.
     → [`self::Struct`]
 * Links with namespaces:
   * ``[`struct@Struct`]``
-    → [`struct@Struct`]
+    → [`Struct`]
   * ``[`enum@Enum`]``
-    → [`enum@Enum`]
+    → [`Enum`]
   * ``[`trait@Trait`]``
-    → [`trait@Trait`]
+    → [`Trait`]
   * ``[`union@Union`]``
-    → [`union@Union`]
+    → [`Union`]
   * ``[`mod@module`], [`module@module`]``
-    → [`mod@module`], [`module@module`]
+    → [`module`], [`module`]
   * ``[`const@CONSTANT`], [`constant@CONSTANT`]``
-    → [`const@CONSTANT`], [`constant@CONSTANT`]
+    → [`CONSTANT`], [`CONSTANT`]
   * ``[`fn@function`], [`function@function`]``
-    → [`fn@function`], [`function@function`]
+    → [`function`], [`function`]
   * ``[`field@Struct::field`]``
-    → [`field@Struct::field`]
+    → [`Struct::field`]
   * ``[`variant@Enum::Variant`]``
-    → [`variant@Enum::Variant`]
+    → [`Enum::Variant`]
   * ``[`method@Trait::method`]``
-    → [`method@Trait::method`]
+    → [`Trait::method`]
   * ``[`derive@Clone`]``
-    → [`derive@Clone`]
+    → [`Clone`]
   * ``[`type@Struct`]``
-    → [`type@Struct`]
+    → [`Struct`]
   * ``[`value@STATIC`]``
-    → [`value@STATIC`]
-  * ``[`macro@declarative_macro`]`` → [`macro@declarative_macro`]
+    → [`STATIC`]
+  * ``[`macro@declarative_macro`]`` → [`declarative_macro`]
   * ``[`tyalias@TypeAlias`], [`typealias@TypeAlias`]``
-    → [`tyalias@TypeAlias`], [`typealias@TypeAlias`]
+    → [`TypeAlias`], [`TypeAlias`]
   * ``[`prim@i32`], [`primitive@i32`]``
-    → [`prim@i32`], [`primitive@i32`]
+    → [`i32`], [`i32`]
 * Links with disambiguators:
   * ``[`function()`]``
     → [`function()`]
@@ -138,7 +138,7 @@ It will be extracted and used to generate README.md.
 |Primitive Associated Constant||[`i32::MAX`]||
 |Declarative Macro|[`declarative_macro`]|[`println`]||
 |Attribute Macro||[`derive`]|[`async_trait::async_trait`]|
-|Derive Macro||[`Clone`][derive@Clone]|[`serde::Serialize`][derive@serde::Serialize]|
+|Derive Macro||[`Clone`]|[`serde::Serialize`]|
 |Re-exported from Private Module|[`ReexportedFromPrivateMod`]|||
 |Foreign Function|[`foreign_function`]|||
 |Foreign Static|[`FOREIGN_STATIC`]|||
@@ -183,7 +183,6 @@ println!("Hello, world!");
 
 ````rust
 println!("Hello, world!");
-
 ````
 
 ## `rustdoc` Markdown Extensions
@@ -222,27 +221,20 @@ and en/em dashes.
 [struct-with-backtick]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
 [`crate::Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
 [`self::Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
-[`struct@Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
-[`enum@Enum`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html
-[`trait@Trait`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html
-[`union@Union`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html
-[`mod@module`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html
-[`module@module`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html
-[`const@CONSTANT`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html
-[`constant@CONSTANT`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html
-[`fn@function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html
-[`function@function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html
-[`field@Struct::field`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#structfield.field
-[`variant@Enum::Variant`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Variant
-[`method@Trait::method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.method
-[`derive@Clone`]: https://doc.rust-lang.org/nightly/core/clone/derive.Clone.html
-[`type@Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
-[`value@STATIC`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.STATIC.html
-[`macro@declarative_macro`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
-[`tyalias@TypeAlias`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html
-[`typealias@TypeAlias`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html
-[`prim@i32`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html
-[`primitive@i32`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html
+[`Enum`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html
+[`Trait`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html
+[`Union`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html
+[`module`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html
+[`CONSTANT`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html
+[`function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html
+[`Struct::field`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#structfield.field
+[`Enum::Variant`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Variant
+[`Trait::method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.method
+[`Clone`]: https://doc.rust-lang.org/nightly/core/clone/derive.Clone.html
+[`STATIC`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.STATIC.html
+[`declarative_macro`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
+[`TypeAlias`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html
+[`i32`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html
 [`function()`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html
 [`declarative_macro!`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
 [`declarative_macro!()`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
@@ -250,36 +242,28 @@ and en/em dashes.
 [`declarative_macro!{}`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
 [`crate`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/index.html
 [`std`]: https://doc.rust-lang.org/nightly/std/index.html
-[`module`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html
 [`std::collections`]: https://doc.rust-lang.org/nightly/std/collections/index.html
 [`num::bigint`]: https://docs.rs/num/0.4/num/bigint/index.html
 [`std::collections::HashMap`]: https://doc.rust-lang.org/nightly/std/collections/hash/map/struct.HashMap.html
 [num::BigInt@1]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html
-[`Struct::field`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#structfield.field
 [`std::ops::Range::start`]: https://doc.rust-lang.org/nightly/core/ops/range/struct.Range.html#structfield.start
 [`num::Complex::re`]: https://docs.rs/num-complex/0.4/num_complex/struct.Complex.html#structfield.re
 [`TupleStruct::0`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.TupleStruct.html#structfield.0
 [`std::cmp::Reverse::0`]: https://doc.rust-lang.org/nightly/core/cmp/struct.Reverse.html#structfield.0
-[`Union`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html
 [`std::mem::MaybeUninit`]: https://doc.rust-lang.org/nightly/core/mem/maybe_uninit/union.MaybeUninit.html
 [`Union::x`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html#structfield.x
-[`Enum`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html
 [`Option`]: https://doc.rust-lang.org/nightly/core/option/enum.Option.html
 [`num::traits::FloatErrorKind`]: https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html
-[`Enum::Variant`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Variant
 [`Option::Some`]: https://doc.rust-lang.org/nightly/core/option/enum.Option.html#variant.Some
 [`num::traits::FloatErrorKind::Empty`]: https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html#variant.Empty
 [`Enum::Struct::field`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Struct.field.field
 [`Enum::Tuple::0`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Tuple.field.0
 [`Option::Some::0`]: https://doc.rust-lang.org/nightly/core/option/enum.Option.html#variant.Some.field.0
 [`serde::de::Unexpected::Other::0`]: https://docs.rs/serde_core/1.0.229/serde_core/de/enum.Unexpected.html#variant.Other.field.0
-[`TypeAlias`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html
 [`std::io::Result`]: https://doc.rust-lang.org/nightly/core/io/error/type.Result.html
 [`num::BigRational`]: https://docs.rs/num-rational/0.4/num_rational/type.BigRational.html
-[`Trait`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html
 [`Iterator`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html
 [`num::Num`]: https://docs.rs/num-traits/0.2/num_traits/trait.Num.html
-[`Trait::method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.method
 [`Iterator::next`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#tymethod.next
 [`num::Zero::is_zero`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.is_zero
 [`Trait::provided_method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#method.provided_method
@@ -315,21 +299,15 @@ and en/em dashes.
 [`Struct::INHR_CONST`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedconstant.INHR_CONST
 [`i32::MAX`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html#associatedconstant.MAX
 [num::BigInt::ZERO@1]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#associatedconstant.ZERO
-[`CONSTANT`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html
 [`std::path::MAIN_SEPARATOR`]: https://doc.rust-lang.org/nightly/std/path/constant.MAIN_SEPARATOR.html
-[`STATIC`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.STATIC.html
-[`function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html
 [`std::iter::from_fn`]: https://doc.rust-lang.org/nightly/core/iter/sources/from_fn/fn.from_fn.html
 [`num::abs`]: https://docs.rs/num-traits/0.2/num_traits/sign/fn.abs.html
-[`i32`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html
 [`i32::count_ones`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html#method.count_ones
 [`i32::from_str_radix`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html#method.from_str_radix
-[`declarative_macro`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
 [`println`]: https://doc.rust-lang.org/nightly/std/macro.println.html
 [`derive`]: https://doc.rust-lang.org/nightly/core/macros/builtin/attr.derive.html
 [`async_trait::async_trait`]: https://docs.rs/async-trait/0.1.92/async_trait/attr.async_trait.html
-[derive@Clone]: https://doc.rust-lang.org/nightly/core/clone/derive.Clone.html
-[derive@serde::Serialize]: https://docs.rs/serde_derive/1.0.229/serde_derive/derive.Serialize.html
+[`serde::Serialize`]: https://docs.rs/serde_derive/1.0.229/serde_derive/derive.Serialize.html
 [`ReexportedFromPrivateMod`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/private/struct.ReexportedFromPrivateMod.html
 [`foreign_function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.foreign_function.html
 [`FOREIGN_STATIC`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.FOREIGN_STATIC.html

--- a/examples/lib/src/lib.rs
+++ b/examples/lib/src/lib.rs
@@ -101,46 +101,46 @@
 //! ## Link showcase
 //!
 //! <!-- markdownlint-disable MD060 -->
-//! | Link Target                                     | [`crate`]                     | [`std`]                         | External Crate                                |
-//! | ----------------------------------------------- | ----------------------------- | ------------------------------- | --------------------------------------------- |
-//! | Module                                          | [`module`]                    | [`std::collections`]            | [`num::bigint`]                               |
-//! | Struct                                          | [`Struct`]                    | [`std::collections::HashMap`]   | [`num::BigInt`]                               |
-//! | Struct Field                                    | [`Struct::field`]             | [`std::ops::Range::start`]      | [`num::Complex::re`]                          |
-//! | Tuple Struct Field                              | [`TupleStruct::0`]            | [`std::cmp::Reverse::0`]        |                                               |
-//! | Union                                           | [`Union`]                     | [`std::mem::MaybeUninit`]       |                                               |
-//! | Union Field                                     | [`Union::x`]                  |                                 |                                               |
-//! | Enum                                            | [`Enum`]                      | [`Option`]                      | [`num::traits::FloatErrorKind`]               |
-//! | Enum Variant                                    | [`Enum::Variant`]             | [`Option::Some`]                | [`num::traits::FloatErrorKind::Empty`]        |
-//! | Variant Field                                   | [`Enum::Struct::field`]       |                                 |                                               |
-//! | Tuple Variant Field                             | [`Enum::Tuple::0`]            | [`Option::Some::0`]             | [`serde::de::Unexpected::Other::0`]           |
-//! | Type Alias                                      | [`TypeAlias`]                 | [`std::io::Result`]             | [`num::BigRational`]                          |
-//! | Trait                                           | [`Trait`]                     | [`Iterator`]                    | [`num::Num`]                                  |
-//! | Required Method                                 | [`Trait::method`]             | [`Iterator::next`]              | [`num::Zero::is_zero`]                        |
-//! | Provided Method                                 | [`Trait::provided_method`]    | [`Iterator::size_hint`]         | [`num::Zero::set_zero`]                       |
-//! | Required Associated Function                    | [`Trait::assoc_fn`]           | [`FromIterator::from_iter`]     | [`num::Zero::zero`]                           |
-//! | Required Associated Constant                    | [`Trait::CONST`]              |                                 | [`num::traits::ConstZero::ZERO`]              |
-//! | Required Associated Type                        | [`Trait::Type`]               | [`Iterator::Item`]              | [`num::Num::FromStrRadixErr`]                 |
-//! | Trait Implementation Method                     | [`Struct::method`]            | [`Vec::clone`]                  | [`num::BigInt::is_zero`]                      |
-//! | Trait Implementation Method (overrides default) | [`Struct::provided_method`]   | [`std::slice::Iter::size_hint`] | [`num::BigInt::set_zero`]                     |
-//! | Trait Implementation Associated Function        | [`Struct::assoc_fn`]          | [`Vec::from_iter`]              | [`num::BigInt::zero`]                         |
-//! | Trait Implementation Associated Constant        | [`Struct::CONST`]             |                                 |                                               |
-//! | Trait Implementation Associated Type            | [`Struct::Type`]              | [`std::slice::Iter::Item`]      | [`num::BigInt::FromStrRadixErr`]              |
-//! | Inherent Method                                 | [`Struct::inhr_method`]       | [`Vec::len`]                    | [`num::BigInt::sign`]                         |
-//! | Inherent Associated Function                    | [`Struct::inhr_assoc_fn`]     | [`Vec::new`]                    | [`num::BigInt::new`]                          |
-//! | Inherent Associated Constant                    | [`Struct::INHR_CONST`]        | [`i32::MAX`]                    | [`num::BigInt::ZERO`]                         |
-//! | Constant                                        | [`CONSTANT`]                  | [`std::path::MAIN_SEPARATOR`]   |                                               |
-//! | Static                                          | [`STATIC`]                    |                                 |                                               |
-//! | Function                                        | [`function`]                  | [`std::iter::from_fn`]          | [`num::abs`]                                  |
-//! | Primitive Type                                  |                               | [`i32`]                         |                                               |
-//! | Primitive Method                                |                               | [`i32::count_ones`]             |                                               |
-//! | Primitive Associated Function                   |                               | [`i32::from_str_radix`]         |                                               |
-//! | Primitive Associated Constant                   |                               | [`i32::MAX`]                    |                                               |
-//! | Declarative Macro                               | [`declarative_macro`]         | [`println`]                     |                                               |
-//! | Attribute Macro                                 |                               | [`derive`]                      | [`async_trait::async_trait`]                  |
-//! | Derive Macro                                    |                               | [`Clone`](derive@Clone)         | [`serde::Serialize`](derive@serde::Serialize) |
-//! | Re-exported from Private Module                 | [`ReexportedFromPrivateMod`]  |                                 |                                               |
-//! | Foreign Function                                | [`foreign_function`]          |                                 |                                               |
-//! | Foreign Static                                  | [`FOREIGN_STATIC`]            |                                 |                                               |
+//! | Link Target                                     | [`crate`]                     | [`std`]                         | External Crate                         |
+//! | ----------------------------------------------- | ----------------------------- | ------------------------------- | -------------------------------------- |
+//! | Module                                          | [`module`]                    | [`std::collections`]            | [`num::bigint`]                        |
+//! | Struct                                          | [`Struct`]                    | [`std::collections::HashMap`]   | [`num::BigInt`]                        |
+//! | Struct Field                                    | [`Struct::field`]             | [`std::ops::Range::start`]      | [`num::Complex::re`]                   |
+//! | Tuple Struct Field                              | [`TupleStruct::0`]            | [`std::cmp::Reverse::0`]        |                                        |
+//! | Union                                           | [`Union`]                     | [`std::mem::MaybeUninit`]       |                                        |
+//! | Union Field                                     | [`Union::x`]                  |                                 |                                        |
+//! | Enum                                            | [`Enum`]                      | [`Option`]                      | [`num::traits::FloatErrorKind`]        |
+//! | Enum Variant                                    | [`Enum::Variant`]             | [`Option::Some`]                | [`num::traits::FloatErrorKind::Empty`] |
+//! | Variant Field                                   | [`Enum::Struct::field`]       |                                 |                                        |
+//! | Tuple Variant Field                             | [`Enum::Tuple::0`]            | [`Option::Some::0`]             | [`serde::de::Unexpected::Other::0`]    |
+//! | Type Alias                                      | [`TypeAlias`]                 | [`std::io::Result`]             | [`num::BigRational`]                   |
+//! | Trait                                           | [`Trait`]                     | [`Iterator`]                    | [`num::Num`]                           |
+//! | Required Method                                 | [`Trait::method`]             | [`Iterator::next`]              | [`num::Zero::is_zero`]                 |
+//! | Provided Method                                 | [`Trait::provided_method`]    | [`Iterator::size_hint`]         | [`num::Zero::set_zero`]                |
+//! | Required Associated Function                    | [`Trait::assoc_fn`]           | [`FromIterator::from_iter`]     | [`num::Zero::zero`]                    |
+//! | Required Associated Constant                    | [`Trait::CONST`]              |                                 | [`num::traits::ConstZero::ZERO`]       |
+//! | Required Associated Type                        | [`Trait::Type`]               | [`Iterator::Item`]              | [`num::Num::FromStrRadixErr`]          |
+//! | Trait Implementation Method                     | [`Struct::method`]            | [`Vec::clone`]                  | [`num::BigInt::is_zero`]               |
+//! | Trait Implementation Method (overrides default) | [`Struct::provided_method`]   | [`std::slice::Iter::size_hint`] | [`num::BigInt::set_zero`]              |
+//! | Trait Implementation Associated Function        | [`Struct::assoc_fn`]          | [`Vec::from_iter`]              | [`num::BigInt::zero`]                  |
+//! | Trait Implementation Associated Constant        | [`Struct::CONST`]             |                                 |                                        |
+//! | Trait Implementation Associated Type            | [`Struct::Type`]              | [`std::slice::Iter::Item`]      | [`num::BigInt::FromStrRadixErr`]       |
+//! | Inherent Method                                 | [`Struct::inhr_method`]       | [`Vec::len`]                    | [`num::BigInt::sign`]                  |
+//! | Inherent Associated Function                    | [`Struct::inhr_assoc_fn`]     | [`Vec::new`]                    | [`num::BigInt::new`]                   |
+//! | Inherent Associated Constant                    | [`Struct::INHR_CONST`]        | [`i32::MAX`]                    | [`num::BigInt::ZERO`]                  |
+//! | Constant                                        | [`CONSTANT`]                  | [`std::path::MAIN_SEPARATOR`]   |                                        |
+//! | Static                                          | [`STATIC`]                    |                                 |                                        |
+//! | Function                                        | [`function`]                  | [`std::iter::from_fn`]          | [`num::abs`]                           |
+//! | Primitive Type                                  |                               | [`i32`]                         |                                        |
+//! | Primitive Method                                |                               | [`i32::count_ones`]             |                                        |
+//! | Primitive Associated Function                   |                               | [`i32::from_str_radix`]         |                                        |
+//! | Primitive Associated Constant                   |                               | [`i32::MAX`]                    |                                        |
+//! | Declarative Macro                               | [`declarative_macro`]         | [`println`]                     |                                        |
+//! | Attribute Macro                                 |                               | [`derive`]                      | [`async_trait::async_trait`]           |
+//! | Derive Macro                                    |                               | [`derive@Clone`]                | [`derive@serde::Serialize`]            |
+//! | Re-exported from Private Module                 | [`ReexportedFromPrivateMod`]  |                                 |                                        |
+//! | Foreign Function                                | [`foreign_function`]          |                                 |                                        |
+//! | Foreign Static                                  | [`FOREIGN_STATIC`]            |                                 |                                        |
 //! <!-- markdownlint-enable MD060 -->
 //! # Code Blocks
 //!

--- a/src/sync/contents/rustdoc/intra_link.rs
+++ b/src/sync/contents/rustdoc/intra_link.rs
@@ -1,7 +1,11 @@
-use std::{borrow::Cow, collections::HashMap, fmt::Debug};
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt::Debug,
+};
 
 use pulldown_cmark::{
     BrokenLink, BrokenLinkCallback, CowStr, Event, LinkType, Options, Parser, RefDefs, Tag,
+    TextMergeStream,
 };
 use rustdoc_types::{Id, Item};
 use unicase::UniCase;
@@ -31,12 +35,38 @@ impl<'map, 'url> LinkMappingConfig<'map, 'url> {
         item: &'doc Item,
     ) -> Option<LinkMapper<'doc, 'map>> {
         let docs = item.docs.as_deref()?;
-        let map = item
+        let url_map = item
             .links
             .iter()
             .map(|(name, id)| (name.as_str(), resolve_link(resolver, self, name, *id)))
             .collect();
-        Some(LinkMapper { docs, map })
+        Some(LinkMapper { docs, url_map })
+    }
+}
+
+#[derive(Debug)]
+enum ResolvedLink<'map> {
+    Mapped(CowStr<'map>),
+    IntraDocResolved(String),
+}
+
+impl<'map> ResolvedLink<'map> {
+    fn is_intra_doc_resolved(&self) -> bool {
+        matches!(self, Self::IntraDocResolved(_))
+    }
+
+    fn url(&self) -> CowStr<'map> {
+        match self {
+            Self::Mapped(url) => url.clone(),
+            Self::IntraDocResolved(url) => url.clone().into(),
+        }
+    }
+
+    fn url_as_str(&self) -> &str {
+        match self {
+            Self::Mapped(url) => url.as_ref(),
+            Self::IntraDocResolved(url) => url.as_ref(),
+        }
     }
 }
 
@@ -46,9 +76,9 @@ fn resolve_link<'map>(
     config: &LinkMappingConfig<'map, '_>,
     name: &str,
     id: Id,
-) -> Option<Cow<'map, str>> {
+) -> Option<ResolvedLink<'map>> {
     if let Some(url) = config.mappings.get(name) {
-        return Some(url.into());
+        return Some(ResolvedLink::Mapped(url.as_str().into()));
     }
     let Some(url) = resolver
         .resolve_link(id)
@@ -57,13 +87,13 @@ fn resolve_link<'map>(
         tracing::warn!("failed to resolve link");
         return None;
     };
-    Some(url.into())
+    Some(ResolvedLink::IntraDocResolved(url))
 }
 
 #[derive(Debug)]
 pub(super) struct LinkMapper<'doc, 'map> {
     docs: &'doc str,
-    map: HashMap<&'doc str, Option<Cow<'map, str>>>,
+    url_map: HashMap<&'doc str, Option<ResolvedLink<'map>>>,
 }
 
 impl<'url, 'input> BrokenLinkCallback<'input> for &LinkMapper<'_, 'url>
@@ -74,71 +104,152 @@ where
         &mut self,
         link: BrokenLink<'input>,
     ) -> Option<(CowStr<'input>, CowStr<'input>)> {
-        let target = self.map.get(&*link.reference)?.as_ref()?;
-        Some((target.clone().into(), "".into()))
+        let resolved = self.url_map.get(&*link.reference)?.as_ref()?;
+        Some((resolved.url(), "".into()))
     }
 }
 
 impl LinkMapper<'_, '_> {
     pub(super) fn build_parser(&self, options: Options) -> impl Iterator<Item = Event<'_>> {
         let parser = Parser::new_with_broken_link_callback(self.docs, options, Some(self));
-        let mut refs =
-            LabelRegistry::from_reference_definitions(parser.reference_definitions(), &self.map);
-        parser.map(move |mut event| {
-            if let Event::Start(Tag::Link {
-                link_type,
-                dest_url,
-                title,
-                id,
-            }) = &mut event
-            {
-                match link_type {
-                    LinkType::ReferenceUnknown => {
-                        *link_type = LinkType::Reference;
-                        let updated_id = refs.allocate_label(id, dest_url, title).0.into_inner();
-                        if *id != updated_id {
-                            *id = updated_id.into_static();
-                        }
+        let label_registry = LabelRegistry::from_reference_definitions(
+            parser.reference_definitions(),
+            &self.url_map,
+        );
+        let stream = TextMergeStream::new(parser);
+        EventStream {
+            url_map: &self.url_map,
+            label_registry,
+            stream,
+            events: VecDeque::new(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct EventStream<'input, 'mapper, 'doc, 'map> {
+    url_map: &'mapper HashMap<&'doc str, Option<ResolvedLink<'map>>>,
+    label_registry: LabelRegistry,
+    stream: TextMergeStream<'input, Parser<'input, &'mapper LinkMapper<'doc, 'map>>>,
+    events: VecDeque<Event<'input>>,
+}
+
+impl<'input, 'map> Iterator for EventStream<'input, '_, '_, 'map>
+where
+    'map: 'input,
+{
+    type Item = Event<'input>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(event) = self.events.pop_front() {
+            return Some(event);
+        }
+        let mut event = self.stream.next()?;
+        let mut ns_prefix = None;
+        if let Event::Start(Tag::Link {
+            link_type,
+            dest_url,
+            title,
+            id,
+        }) = &mut event
+        {
+            match link_type {
+                LinkType::ReferenceUnknown => {
+                    *link_type = LinkType::Reference;
+                    let updated_id = self
+                        .label_registry
+                        .allocate_label(id, dest_url, title)
+                        .0
+                        .into_inner();
+                    if *id != updated_id {
+                        *id = updated_id.into_static();
                     }
-                    LinkType::CollapsedUnknown => {
-                        *link_type = LinkType::Collapsed;
-                        let updated_id = refs.allocate_label(id, dest_url, title).0.into_inner();
-                        if *id != updated_id {
-                            *id = updated_id.into_static();
-                            *link_type = LinkType::Reference;
-                        }
-                    }
-                    LinkType::ShortcutUnknown => {
-                        *link_type = LinkType::Shortcut;
-                        let updated_id = refs.allocate_label(id, dest_url, title).0.into_inner();
-                        if *id != updated_id {
-                            *id = updated_id.into_static();
-                            *link_type = LinkType::Reference;
-                        }
-                    }
-                    LinkType::Inline => {
-                        if let Some(Some(new_dest_url)) = self.map.get(dest_url.as_ref()) {
-                            *link_type = LinkType::Reference;
-                            let label = reference_label_from_link_destination(dest_url);
-                            *id = refs
-                                .allocate_label(&label, new_dest_url, title)
-                                .0
-                                .into_inner()
-                                .into_static();
-                            *dest_url = new_dest_url.clone().into();
-                        }
-                    }
-                    LinkType::Reference | LinkType::Collapsed | LinkType::Shortcut => {
-                        if let Some(Some(new_dest_url)) = self.map.get(dest_url.as_ref()) {
-                            *dest_url = new_dest_url.clone().into();
-                        }
-                    }
-                    LinkType::Autolink | LinkType::Email => {}
-                    LinkType::WikiLink { .. } => unreachable!(),
                 }
+                LinkType::CollapsedUnknown => {
+                    *link_type = LinkType::Collapsed;
+                    self.strip_namespace_prefix_from_label(id, &mut ns_prefix);
+                    let updated_id = self
+                        .label_registry
+                        .allocate_label(id, dest_url, title)
+                        .0
+                        .into_inner();
+                    if *id != updated_id {
+                        *id = updated_id.into_static();
+                        *link_type = LinkType::Reference;
+                    }
+                }
+                LinkType::ShortcutUnknown => {
+                    *link_type = LinkType::Shortcut;
+                    self.strip_namespace_prefix_from_label(id, &mut ns_prefix);
+                    let updated_id = self
+                        .label_registry
+                        .allocate_label(id, dest_url, title)
+                        .0
+                        .into_inner();
+                    if *id != updated_id {
+                        *id = updated_id.into_static();
+                        *link_type = LinkType::Reference;
+                    }
+                }
+                LinkType::Inline => {
+                    if let Some(Some(resolved)) = self.url_map.get(dest_url.as_ref()) {
+                        *link_type = LinkType::Reference;
+                        let label = reference_label_from_link_destination(dest_url);
+                        *id = self
+                            .label_registry
+                            .allocate_label(&label, resolved.url_as_str(), title)
+                            .0
+                            .into_inner()
+                            .into_static();
+                        *dest_url = resolved.url();
+                    }
+                }
+                LinkType::Reference | LinkType::Collapsed | LinkType::Shortcut => {
+                    if let Some(Some(resolved)) = self.url_map.get(dest_url.as_ref()) {
+                        *dest_url = resolved.url();
+                    }
+                }
+                LinkType::Autolink | LinkType::Email => {}
+                LinkType::WikiLink { .. } => unreachable!(),
             }
-            event
-        })
+        }
+        if let Some(ns_prefix) = ns_prefix
+            && let Some(mut next) = self.stream.next()
+        {
+            if let Event::Code(text) | Event::Text(text) = &mut next
+                && let Some(new_text) = text.strip_prefix(&ns_prefix)
+            {
+                *text = new_text.to_owned().into();
+            }
+            self.events.push_back(next);
+        }
+        Some(event)
+    }
+}
+
+impl EventStream<'_, '_, '_, '_> {
+    fn strip_namespace_prefix_from_label(
+        &self,
+        label: &mut CowStr<'_>,
+        ns_prefix: &mut Option<String>,
+    ) {
+        if !self
+            .url_map
+            .get(label.as_ref())
+            .and_then(Option::as_ref)
+            .is_some_and(ResolvedLink::is_intra_doc_resolved)
+        {
+            return;
+        }
+        if let Some((ns, new_id)) = label.split_once('@') {
+            if let Some(ns) = ns.strip_prefix('`') {
+                *ns_prefix = Some(format!("{ns}@"));
+                *label = format!("`{new_id}").into();
+            } else {
+                *ns_prefix = Some(format!("{ns}@"));
+                *label = new_id.to_owned().into();
+            }
+        }
     }
 }
 
@@ -193,13 +304,13 @@ impl<'a> LinkLabel<'a> {
 impl LabelRegistry {
     fn from_reference_definitions(
         defs: &RefDefs<'_>,
-        url_map: &HashMap<&str, Option<Cow<'_, str>>>,
+        url_map: &HashMap<&str, Option<ResolvedLink<'_>>>,
     ) -> Self {
         let mut map = HashMap::new();
         for (label, def) in defs.iter() {
             let label = LinkLabel::new(label);
             let url = match url_map.get(def.dest.as_ref()) {
-                Some(Some(url)) => url.as_ref().into(),
+                Some(Some(resolved)) => resolved.url(),
                 Some(None) | None => def.dest.clone(),
             };
             let title = def.title.clone().unwrap_or(CowStr::Borrowed(""));
@@ -353,4 +464,121 @@ fn reference_label_from_link_destination(label: &str) -> CowStr<'_> {
         }
     }
     escaped.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use super::*;
+
+    fn render<const N: usize>(
+        docs: &'static str,
+        links: [(&'static str, Option<ResolvedLink<'static>>); N],
+    ) -> String {
+        let map = HashMap::from(links);
+        let mapper = LinkMapper { docs, url_map: map };
+        let events = mapper.build_parser(Options::empty());
+        let mut output = String::new();
+        pulldown_cmark_to_cmark::cmark(events, &mut output).unwrap();
+        if !output.is_empty() && !output.ends_with('\n') {
+            output.push('\n');
+        }
+        output
+    }
+
+    #[expect(clippy::unnecessary_wraps)]
+    fn idr(url: &str) -> Option<ResolvedLink<'_>> {
+        Some(ResolvedLink::IntraDocResolved(url.into()))
+    }
+
+    #[expect(clippy::unnecessary_wraps)]
+    fn mapped(url: &str) -> Option<ResolvedLink<'_>> {
+        Some(ResolvedLink::Mapped(url.into()))
+    }
+
+    #[test]
+    fn strips_namespace_prefix_from_shortcut_link_text() {
+        let docs = indoc! {"
+            * [`struct@Struct`]
+            * [enum@Enum]
+        "};
+        let links = [
+            (
+                "`struct@Struct`",
+                idr("https://example.com/struct.Struct.html"),
+            ),
+            ("enum@Enum", idr("https://example.com/enum.Enum.html")),
+        ];
+        let expected = indoc! {"
+            * [`Struct`]
+            * [Enum]
+
+            [`Struct`]: https://example.com/struct.Struct.html
+            [Enum]: https://example.com/enum.Enum.html
+        "};
+
+        let output = render(docs, links);
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn preserves_atmark_prefix_for_mapped_links() {
+        let docs = indoc! {"
+            * [`struct@Struct`]
+            * [enum@Enum]
+            * [`struct@Struct`][]
+            * [enum@Enum][]
+        "};
+        let links = [
+            (
+                "`struct@Struct`",
+                mapped("https://example.com/struct.Struct.html"),
+            ),
+            ("enum@Enum", mapped("https://example.com/enum.Enum.html")),
+        ];
+        let expected = indoc! {"
+            * [`struct@Struct`]
+            * [enum@Enum]
+            * [`struct@Struct`][]
+            * [enum@Enum][]
+
+            [`struct@Struct`]: https://example.com/struct.Struct.html
+            [enum@Enum]: https://example.com/enum.Enum.html
+        "};
+
+        let output = render(docs, links);
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn converts_to_explicit_reference_when_plain_label_already_exists() {
+        let docs = indoc! {"
+            * [`Struct`] and [`struct@Struct`]
+            * [Enum] and [enum@Enum]
+
+            [`Struct`]: https://example.com/other/struct.Struct.html
+            [Enum]: https://example.com/other/enum.Enum.html
+        "};
+        let links = [
+            (
+                "`struct@Struct`",
+                idr("https://example.com/struct.Struct.html"),
+            ),
+            ("enum@Enum", idr("https://example.com/enum.Enum.html")),
+        ];
+
+        let expected = indoc! {"
+            * [`Struct`] and [`Struct`][Struct@1]
+            * [Enum] and [Enum][Enum@1]
+
+            [`Struct`]: https://example.com/other/struct.Struct.html
+            [Struct@1]: https://example.com/struct.Struct.html
+            [Enum]: https://example.com/other/enum.Enum.html
+            [Enum@1]: https://example.com/enum.Enum.html
+        "};
+
+        let output = render(docs, links);
+        assert_eq!(output, expected);
+    }
 }


### PR DESCRIPTION
## Summary

Match `rustdoc` more closely for namespace-qualified intra-doc links by removing the `namespace@` prefix from the rendered link text while still resolving the link against the namespace-qualified target.

This updates the intra-link conversion logic to:

- rewrite shortcut and collapsed namespace-qualified links such as ``[`struct@Struct`]`` to render as ``[`Struct`]``
- preserve correct behavior when the stripped label would collide with an existing reference label by falling back to an explicit reference label such as `[Struct@1]`
- keep the example README output and changelog in sync with the new behavior

## Validation

- `cargo test`
- `cargo fmt --check`
- `cargo run -- --workspace --toolchain nightly --check`

## Impact

Generated Markdown for namespace-qualified intra-doc links now matches `rustdoc` link text more closely, including both backticked and non-backticked shortcut links.