### PR TITLE
Add titles to resolved intra-doc links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Emit resolved intra-doc links as reference-style Markdown links instead of expanding them to inline links with resolved URLs.
 
   Inline intra-doc links are converted to generated reference-style links. Existing intra-doc reference links keep their labels and reference form when possible, and `cargo-sync-rdme` adds or adjusts reference definitions as needed to keep the output valid. Non-intra-doc links are left unchanged.
+* Add `title` attributes to resolved intra-doc links after expansion so generated Markdown matches `rustdoc` more closely.
+
+  Resolved intra-doc links now carry titles such as `"struct crate::Type"` in generated reference definitions. Existing explicit Markdown titles are preserved.
 * Match `rustdoc` more closely for namespace-qualified intra-doc links such as [`struct@Struct`] by omitting the `namespace@` prefix from the rendered link text while still resolving the link to the namespace-qualified target.
 
 ### Removed

--- a/examples/lib/README.md
+++ b/examples/lib/README.md
@@ -215,101 +215,101 @@ and en/em dashes.
 [^markdown-extension-footnote]: In `rustdoc`, footnotes are collected at the end of the rendered Markdown block.
 
 [intra-doc-link]: https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html
-[Struct]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
-[`Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
-[struct-without-backtick]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
-[struct-with-backtick]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
-[`crate::Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
-[`self::Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html
-[`Enum`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html
-[`Trait`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html
-[`Union`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html
-[`module`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html
-[`CONSTANT`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html
-[`function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html
-[`Struct::field`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#structfield.field
-[`Enum::Variant`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Variant
-[`Trait::method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.method
-[`Clone`]: https://doc.rust-lang.org/nightly/core/clone/derive.Clone.html
-[`STATIC`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.STATIC.html
-[`declarative_macro`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
-[`TypeAlias`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html
-[`i32`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html
-[`function()`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html
-[`declarative_macro!`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
-[`declarative_macro!()`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
-[declarative_macro!\[\]]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
-[`declarative_macro!{}`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html
-[`crate`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/index.html
-[`std`]: https://doc.rust-lang.org/nightly/std/index.html
-[`std::collections`]: https://doc.rust-lang.org/nightly/std/collections/index.html
-[`num::bigint`]: https://docs.rs/num/0.4/num/bigint/index.html
-[`std::collections::HashMap`]: https://doc.rust-lang.org/nightly/std/collections/hash/map/struct.HashMap.html
-[num::BigInt@1]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html
-[`std::ops::Range::start`]: https://doc.rust-lang.org/nightly/core/ops/range/struct.Range.html#structfield.start
-[`num::Complex::re`]: https://docs.rs/num-complex/0.4/num_complex/struct.Complex.html#structfield.re
-[`TupleStruct::0`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.TupleStruct.html#structfield.0
-[`std::cmp::Reverse::0`]: https://doc.rust-lang.org/nightly/core/cmp/struct.Reverse.html#structfield.0
-[`std::mem::MaybeUninit`]: https://doc.rust-lang.org/nightly/core/mem/maybe_uninit/union.MaybeUninit.html
-[`Union::x`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html#structfield.x
-[`Option`]: https://doc.rust-lang.org/nightly/core/option/enum.Option.html
-[`num::traits::FloatErrorKind`]: https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html
-[`Option::Some`]: https://doc.rust-lang.org/nightly/core/option/enum.Option.html#variant.Some
-[`num::traits::FloatErrorKind::Empty`]: https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html#variant.Empty
-[`Enum::Struct::field`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Struct.field.field
-[`Enum::Tuple::0`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Tuple.field.0
-[`Option::Some::0`]: https://doc.rust-lang.org/nightly/core/option/enum.Option.html#variant.Some.field.0
-[`serde::de::Unexpected::Other::0`]: https://docs.rs/serde_core/1.0.229/serde_core/de/enum.Unexpected.html#variant.Other.field.0
-[`std::io::Result`]: https://doc.rust-lang.org/nightly/core/io/error/type.Result.html
-[`num::BigRational`]: https://docs.rs/num-rational/0.4/num_rational/type.BigRational.html
-[`Iterator`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html
-[`num::Num`]: https://docs.rs/num-traits/0.2/num_traits/trait.Num.html
-[`Iterator::next`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#tymethod.next
-[`num::Zero::is_zero`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.is_zero
-[`Trait::provided_method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#method.provided_method
-[`Iterator::size_hint`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#tymethod.size_hint
-[`num::Zero::set_zero`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.set_zero
-[`Trait::assoc_fn`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.assoc_fn
-[`FromIterator::from_iter`]: https://doc.rust-lang.org/nightly/core/iter/traits/collect/trait.FromIterator.html#tymethod.from_iter
-[`num::Zero::zero`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.zero
-[`Trait::CONST`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedconstant.CONST
-[`num::traits::ConstZero::ZERO`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.ConstZero.html#associatedconstant.ZERO
-[`Trait::Type`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedtype.Type
-[`Iterator::Item`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#associatedtype.Item
-[`num::Num::FromStrRadixErr`]: https://docs.rs/num-traits/0.2/num_traits/trait.Num.html#associatedtype.FromStrRadixErr
-[`Struct::method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.method
-[`Vec::clone`]: https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.clone
-[`num::BigInt::is_zero`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.is_zero
-[`Struct::provided_method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.provided_method
-[`std::slice::Iter::size_hint`]: https://doc.rust-lang.org/nightly/core/slice/iter/struct.Iter.html#method.size_hint
-[`num::BigInt::set_zero`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.set_zero
-[`Struct::assoc_fn`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.assoc_fn
-[`Vec::from_iter`]: https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.from_iter
-[`num::BigInt::zero`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.zero
-[`Struct::CONST`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedconstant.CONST
-[`Struct::Type`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedtype.Type
-[`std::slice::Iter::Item`]: https://doc.rust-lang.org/nightly/core/slice/iter/struct.Iter.html#associatedtype.Item
-[`num::BigInt::FromStrRadixErr`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#associatedtype.FromStrRadixErr
-[`Struct::inhr_method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.inhr_method
-[`Vec::len`]: https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.len
-[`num::BigInt::sign`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.sign
-[`Struct::inhr_assoc_fn`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.inhr_assoc_fn
-[`Vec::new`]: https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.new
-[`num::BigInt::new`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.new
-[`Struct::INHR_CONST`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedconstant.INHR_CONST
-[`i32::MAX`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html#associatedconstant.MAX
-[num::BigInt::ZERO@1]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#associatedconstant.ZERO
-[`std::path::MAIN_SEPARATOR`]: https://doc.rust-lang.org/nightly/std/path/constant.MAIN_SEPARATOR.html
-[`std::iter::from_fn`]: https://doc.rust-lang.org/nightly/core/iter/sources/from_fn/fn.from_fn.html
-[`num::abs`]: https://docs.rs/num-traits/0.2/num_traits/sign/fn.abs.html
-[`i32::count_ones`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html#method.count_ones
-[`i32::from_str_radix`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html#method.from_str_radix
-[`println`]: https://doc.rust-lang.org/nightly/std/macro.println.html
-[`derive`]: https://doc.rust-lang.org/nightly/core/macros/builtin/attr.derive.html
-[`async_trait::async_trait`]: https://docs.rs/async-trait/0.1.92/async_trait/attr.async_trait.html
-[`serde::Serialize`]: https://docs.rs/serde_derive/1.0.229/serde_derive/derive.Serialize.html
-[`ReexportedFromPrivateMod`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/private/struct.ReexportedFromPrivateMod.html
-[`foreign_function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.foreign_function.html
-[`FOREIGN_STATIC`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.FOREIGN_STATIC.html
+[Struct]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html "struct cargo_sync_rdme_example_lib::Struct"
+[`Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html "struct cargo_sync_rdme_example_lib::Struct"
+[struct-without-backtick]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html "struct cargo_sync_rdme_example_lib::Struct"
+[struct-with-backtick]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html "struct cargo_sync_rdme_example_lib::Struct"
+[`crate::Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html "struct cargo_sync_rdme_example_lib::Struct"
+[`self::Struct`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html "struct cargo_sync_rdme_example_lib::Struct"
+[`Enum`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html "enum cargo_sync_rdme_example_lib::Enum"
+[`Trait`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html "trait cargo_sync_rdme_example_lib::Trait"
+[`Union`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html "union cargo_sync_rdme_example_lib::Union"
+[`module`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/module/index.html "module cargo_sync_rdme_example_lib::module"
+[`CONSTANT`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/constant.CONSTANT.html "constant cargo_sync_rdme_example_lib::CONSTANT"
+[`function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html "fn cargo_sync_rdme_example_lib::function"
+[`Struct::field`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#structfield.field "field cargo_sync_rdme_example_lib::Struct::field"
+[`Enum::Variant`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Variant "variant cargo_sync_rdme_example_lib::Enum::Variant"
+[`Trait::method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.method "method cargo_sync_rdme_example_lib::Trait::method"
+[`Clone`]: https://doc.rust-lang.org/nightly/core/clone/derive.Clone.html "derive core::clone::Clone"
+[`STATIC`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.STATIC.html "static cargo_sync_rdme_example_lib::STATIC"
+[`declarative_macro`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html "macro cargo_sync_rdme_example_lib::declarative_macro"
+[`TypeAlias`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/type.TypeAlias.html "type cargo_sync_rdme_example_lib::TypeAlias"
+[`i32`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html "primitive std::i32"
+[`function()`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.function.html "fn cargo_sync_rdme_example_lib::function"
+[`declarative_macro!`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html "macro cargo_sync_rdme_example_lib::declarative_macro"
+[`declarative_macro!()`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html "macro cargo_sync_rdme_example_lib::declarative_macro"
+[declarative_macro!\[\]]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html "macro cargo_sync_rdme_example_lib::declarative_macro"
+[`declarative_macro!{}`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/macro.declarative_macro.html "macro cargo_sync_rdme_example_lib::declarative_macro"
+[`crate`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/index.html "module cargo_sync_rdme_example_lib"
+[`std`]: https://doc.rust-lang.org/nightly/std/index.html "module std"
+[`std::collections`]: https://doc.rust-lang.org/nightly/std/collections/index.html "module std::collections"
+[`num::bigint`]: https://docs.rs/num/0.4/num/bigint/index.html "module num::bigint"
+[`std::collections::HashMap`]: https://doc.rust-lang.org/nightly/std/collections/hash/map/struct.HashMap.html "struct std::collections::hash::map::HashMap"
+[num::BigInt@1]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html "struct num_bigint::bigint::BigInt"
+[`std::ops::Range::start`]: https://doc.rust-lang.org/nightly/core/ops/range/struct.Range.html#structfield.start "field core::ops::range::Range::start"
+[`num::Complex::re`]: https://docs.rs/num-complex/0.4/num_complex/struct.Complex.html#structfield.re "field num_complex::Complex::re"
+[`TupleStruct::0`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.TupleStruct.html#structfield.0 "field cargo_sync_rdme_example_lib::TupleStruct::0"
+[`std::cmp::Reverse::0`]: https://doc.rust-lang.org/nightly/core/cmp/struct.Reverse.html#structfield.0 "field core::cmp::Reverse::0"
+[`std::mem::MaybeUninit`]: https://doc.rust-lang.org/nightly/core/mem/maybe_uninit/union.MaybeUninit.html "union core::mem::maybe_uninit::MaybeUninit"
+[`Union::x`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/union.Union.html#structfield.x "field cargo_sync_rdme_example_lib::Union::x"
+[`Option`]: https://doc.rust-lang.org/nightly/core/option/enum.Option.html "enum core::option::Option"
+[`num::traits::FloatErrorKind`]: https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html "enum num_traits::FloatErrorKind"
+[`Option::Some`]: https://doc.rust-lang.org/nightly/core/option/enum.Option.html#variant.Some "variant core::option::Option::Some"
+[`num::traits::FloatErrorKind::Empty`]: https://docs.rs/num-traits/0.2/num_traits/enum.FloatErrorKind.html#variant.Empty "variant num_traits::FloatErrorKind::Empty"
+[`Enum::Struct::field`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Struct.field.field "field cargo_sync_rdme_example_lib::Enum::Struct::field"
+[`Enum::Tuple::0`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/enum.Enum.html#variant.Tuple.field.0 "field cargo_sync_rdme_example_lib::Enum::Tuple::0"
+[`Option::Some::0`]: https://doc.rust-lang.org/nightly/core/option/enum.Option.html#variant.Some.field.0 "field core::option::Option::Some::0"
+[`serde::de::Unexpected::Other::0`]: https://docs.rs/serde_core/1.0.229/serde_core/de/enum.Unexpected.html#variant.Other.field.0 "field serde_core::de::Unexpected::Other::0"
+[`std::io::Result`]: https://doc.rust-lang.org/nightly/core/io/error/type.Result.html "type core::io::error::Result"
+[`num::BigRational`]: https://docs.rs/num-rational/0.4/num_rational/type.BigRational.html "type num_rational::BigRational"
+[`Iterator`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html "trait core::iter::traits::iterator::Iterator"
+[`num::Num`]: https://docs.rs/num-traits/0.2/num_traits/trait.Num.html "trait num_traits::Num"
+[`Iterator::next`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#tymethod.next "method core::iter::traits::iterator::Iterator::next"
+[`num::Zero::is_zero`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.is_zero "method num_traits::identities::Zero::is_zero"
+[`Trait::provided_method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#method.provided_method "method cargo_sync_rdme_example_lib::Trait::provided_method"
+[`Iterator::size_hint`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#tymethod.size_hint "method core::iter::traits::iterator::Iterator::size_hint"
+[`num::Zero::set_zero`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.set_zero "method num_traits::identities::Zero::set_zero"
+[`Trait::assoc_fn`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#tymethod.assoc_fn "method cargo_sync_rdme_example_lib::Trait::assoc_fn"
+[`FromIterator::from_iter`]: https://doc.rust-lang.org/nightly/core/iter/traits/collect/trait.FromIterator.html#tymethod.from_iter "method core::iter::traits::collect::FromIterator::from_iter"
+[`num::Zero::zero`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.Zero.html#tymethod.zero "method num_traits::identities::Zero::zero"
+[`Trait::CONST`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedconstant.CONST "associated constant cargo_sync_rdme_example_lib::Trait::CONST"
+[`num::traits::ConstZero::ZERO`]: https://docs.rs/num-traits/0.2/num_traits/identities/trait.ConstZero.html#associatedconstant.ZERO "associated constant num_traits::identities::ConstZero::ZERO"
+[`Trait::Type`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/trait.Trait.html#associatedtype.Type "associated type cargo_sync_rdme_example_lib::Trait::Type"
+[`Iterator::Item`]: https://doc.rust-lang.org/nightly/core/iter/traits/iterator/trait.Iterator.html#associatedtype.Item "associated type core::iter::traits::iterator::Iterator::Item"
+[`num::Num::FromStrRadixErr`]: https://docs.rs/num-traits/0.2/num_traits/trait.Num.html#associatedtype.FromStrRadixErr "associated type num_traits::Num::FromStrRadixErr"
+[`Struct::method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.method "method cargo_sync_rdme_example_lib::Struct::method"
+[`Vec::clone`]: https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.clone "method alloc::vec::Vec::clone"
+[`num::BigInt::is_zero`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.is_zero "method num_bigint::bigint::BigInt::is_zero"
+[`Struct::provided_method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.provided_method "method cargo_sync_rdme_example_lib::Struct::provided_method"
+[`std::slice::Iter::size_hint`]: https://doc.rust-lang.org/nightly/core/slice/iter/struct.Iter.html#method.size_hint "method core::slice::iter::Iter::size_hint"
+[`num::BigInt::set_zero`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.set_zero "method num_bigint::bigint::BigInt::set_zero"
+[`Struct::assoc_fn`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.assoc_fn "method cargo_sync_rdme_example_lib::Struct::assoc_fn"
+[`Vec::from_iter`]: https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.from_iter "method alloc::vec::Vec::from_iter"
+[`num::BigInt::zero`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.zero "method num_bigint::bigint::BigInt::zero"
+[`Struct::CONST`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedconstant.CONST "associated constant cargo_sync_rdme_example_lib::Struct::CONST"
+[`Struct::Type`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedtype.Type "associated type cargo_sync_rdme_example_lib::Struct::Type"
+[`std::slice::Iter::Item`]: https://doc.rust-lang.org/nightly/core/slice/iter/struct.Iter.html#associatedtype.Item "associated type core::slice::iter::Iter::Item"
+[`num::BigInt::FromStrRadixErr`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#associatedtype.FromStrRadixErr "associated type num_bigint::bigint::BigInt::FromStrRadixErr"
+[`Struct::inhr_method`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.inhr_method "method cargo_sync_rdme_example_lib::Struct::inhr_method"
+[`Vec::len`]: https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.len "method alloc::vec::Vec::len"
+[`num::BigInt::sign`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.sign "method num_bigint::bigint::BigInt::sign"
+[`Struct::inhr_assoc_fn`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#method.inhr_assoc_fn "method cargo_sync_rdme_example_lib::Struct::inhr_assoc_fn"
+[`Vec::new`]: https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.new "method alloc::vec::Vec::new"
+[`num::BigInt::new`]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#method.new "method num_bigint::bigint::BigInt::new"
+[`Struct::INHR_CONST`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/struct.Struct.html#associatedconstant.INHR_CONST "associated constant cargo_sync_rdme_example_lib::Struct::INHR_CONST"
+[`i32::MAX`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html#associatedconstant.MAX "associated constant std::i32::MAX"
+[num::BigInt::ZERO@1]: https://docs.rs/num-bigint/0.4/num_bigint/bigint/struct.BigInt.html#associatedconstant.ZERO "associated constant num_bigint::bigint::BigInt::ZERO"
+[`std::path::MAIN_SEPARATOR`]: https://doc.rust-lang.org/nightly/std/path/constant.MAIN_SEPARATOR.html "constant std::path::MAIN_SEPARATOR"
+[`std::iter::from_fn`]: https://doc.rust-lang.org/nightly/core/iter/sources/from_fn/fn.from_fn.html "fn core::iter::sources::from_fn::from_fn"
+[`num::abs`]: https://docs.rs/num-traits/0.2/num_traits/sign/fn.abs.html "fn num_traits::sign::abs"
+[`i32::count_ones`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html#method.count_ones "method std::i32::count_ones"
+[`i32::from_str_radix`]: https://doc.rust-lang.org/nightly/std/primitive.i32.html#method.from_str_radix "method std::i32::from_str_radix"
+[`println`]: https://doc.rust-lang.org/nightly/std/macro.println.html "macro std::println"
+[`derive`]: https://doc.rust-lang.org/nightly/core/macros/builtin/attr.derive.html "attr core::macros::builtin::derive"
+[`async_trait::async_trait`]: https://docs.rs/async-trait/0.1.92/async_trait/attr.async_trait.html "attr async_trait::async_trait"
+[`serde::Serialize`]: https://docs.rs/serde_derive/1.0.229/serde_derive/derive.Serialize.html "derive serde_derive::Serialize"
+[`ReexportedFromPrivateMod`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/private/struct.ReexportedFromPrivateMod.html "struct cargo_sync_rdme_example_lib::private::ReexportedFromPrivateMod"
+[`foreign_function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.foreign_function.html "fn cargo_sync_rdme_example_lib::foreign_function"
+[`FOREIGN_STATIC`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.FOREIGN_STATIC.html "static cargo_sync_rdme_example_lib::FOREIGN_STATIC"
 [commonmark-spec]: https://spec.commonmark.org/0.31.2/
 <!-- cargo-sync-rdme ]] -->

--- a/src/sync/contents/rustdoc/document.rs
+++ b/src/sync/contents/rustdoc/document.rs
@@ -300,6 +300,10 @@ impl LinkTarget<'_> {
         url.push_str(&relative_path);
         Some(url)
     }
+
+    pub(super) fn build_title(&self) -> String {
+        format!("{} {}", self.path.kind_str(), self.path.display_path())
+    }
 }
 
 #[derive(Debug)]
@@ -443,6 +447,23 @@ impl LinkItemKind {
             Self::Primitive => "primitive",
         }
     }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Struct => "struct",
+            Self::Union => "union",
+            Self::Enum => "enum",
+            Self::Function => "fn",
+            Self::TypeAlias => "type",
+            Self::Constant => "constant",
+            Self::Trait => "trait",
+            Self::Static => "static",
+            Self::Macro => "macro",
+            Self::ProcAttribute => "attr",
+            Self::ProcDerive => "derive",
+            Self::Primitive => "primitive",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -479,6 +500,16 @@ impl AnchorKind {
             Self::ProvidedMethod | Self::ImplementedMethod => "method",
             Self::AssocConst => "associatedconstant",
             Self::AssocType => "associatedtype",
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::StructField | Self::EnumVariantField => "field",
+            Self::EnumVariant => "variant",
+            Self::RequiredMethod | Self::ProvidedMethod | Self::ImplementedMethod => "method",
+            Self::AssocConst => "associated constant",
+            Self::AssocType => "associated type",
         }
     }
 }
@@ -520,6 +551,21 @@ impl<'doc> LinkTargetPath<'doc> {
                 anchors: [_, (kind, _)],
                 ..
             } => kind.as_item_kind(),
+        }
+    }
+
+    fn kind_str(self) -> &'static str {
+        match self {
+            LinkTargetPath::Module { .. } => "module",
+            LinkTargetPath::Item { kind, .. } => kind.as_str(),
+            LinkTargetPath::AnchoredItem {
+                anchor: [(kind, _)],
+                ..
+            }
+            | LinkTargetPath::NestedAnchoredItem {
+                anchors: [_, (kind, _)],
+                ..
+            } => kind.as_str(),
         }
     }
 

--- a/src/sync/contents/rustdoc/intra_link.rs
+++ b/src/sync/contents/rustdoc/intra_link.rs
@@ -47,25 +47,32 @@ impl<'map, 'url> LinkMappingConfig<'map, 'url> {
 #[derive(Debug)]
 enum ResolvedLink<'map> {
     Mapped(CowStr<'map>),
-    IntraDocResolved(String),
+    IntraDocResolved { url: String, title: String },
 }
 
 impl<'map> ResolvedLink<'map> {
     fn is_intra_doc_resolved(&self) -> bool {
-        matches!(self, Self::IntraDocResolved(_))
+        matches!(self, Self::IntraDocResolved { .. })
     }
 
     fn url(&self) -> CowStr<'map> {
         match self {
             Self::Mapped(url) => url.clone(),
-            Self::IntraDocResolved(url) => url.clone().into(),
+            Self::IntraDocResolved { url, .. } => url.clone().into(),
         }
     }
 
     fn url_as_str(&self) -> &str {
         match self {
             Self::Mapped(url) => url.as_ref(),
-            Self::IntraDocResolved(url) => url.as_ref(),
+            Self::IntraDocResolved { url, .. } => url.as_ref(),
+        }
+    }
+
+    fn title(&self) -> CowStr<'map> {
+        match self {
+            Self::Mapped(_) => "".into(),
+            Self::IntraDocResolved { title, .. } => title.clone().into(),
         }
     }
 }
@@ -80,14 +87,16 @@ fn resolve_link<'map>(
     if let Some(url) = config.mappings.get(name) {
         return Some(ResolvedLink::Mapped(url.as_str().into()));
     }
-    let Some(url) = resolver
-        .resolve_link(id)
-        .and_then(|target| target.build_url(config.local_html_root_url))
-    else {
+    let Some((url, title)) = resolver.resolve_link(id).and_then(|target| {
+        Some((
+            target.build_url(config.local_html_root_url)?,
+            target.build_title(),
+        ))
+    }) else {
         tracing::warn!("failed to resolve link");
         return None;
     };
-    Some(ResolvedLink::IntraDocResolved(url))
+    Some(ResolvedLink::IntraDocResolved { url, title })
 }
 
 #[derive(Debug)]
@@ -105,7 +114,7 @@ where
         link: BrokenLink<'input>,
     ) -> Option<(CowStr<'input>, CowStr<'input>)> {
         let resolved = self.url_map.get(&*link.reference)?.as_ref()?;
-        Some((resolved.url(), "".into()))
+        Some((resolved.url(), resolved.title()))
     }
 }
 
@@ -195,6 +204,9 @@ where
                     if let Some(Some(resolved)) = self.url_map.get(dest_url.as_ref()) {
                         *link_type = LinkType::Reference;
                         let label = reference_label_from_link_destination(dest_url);
+                        if title.is_empty() {
+                            *title = resolved.title();
+                        }
                         *id = self
                             .label_registry
                             .allocate_label(&label, resolved.url_as_str(), title)
@@ -206,6 +218,9 @@ where
                 }
                 LinkType::Reference | LinkType::Collapsed | LinkType::Shortcut => {
                     if let Some(Some(resolved)) = self.url_map.get(dest_url.as_ref()) {
+                        if title.is_empty() {
+                            *title = resolved.title();
+                        }
                         *dest_url = resolved.url();
                     }
                 }
@@ -314,11 +329,16 @@ impl LabelRegistry {
         let mut map = HashMap::new();
         for (label, def) in defs.iter() {
             let label = LinkLabel::new(label);
-            let url = match url_map.get(def.dest.as_ref()) {
-                Some(Some(resolved)) => resolved.url(),
-                Some(None) | None => def.dest.clone(),
+            let (url, title) = match url_map.get(def.dest.as_ref()) {
+                Some(Some(resolved)) => (
+                    resolved.url(),
+                    def.title.clone().unwrap_or_else(|| resolved.title()),
+                ),
+                Some(None) | None => (
+                    def.dest.clone(),
+                    def.title.clone().unwrap_or(CowStr::Borrowed("")),
+                ),
             };
-            let title = def.title.clone().unwrap_or(CowStr::Borrowed(""));
             let target = LinkTarget { url, title };
             map.insert(label.clone().into_static(), target.clone().into_static());
         }
@@ -493,8 +513,10 @@ mod tests {
     }
 
     #[expect(clippy::unnecessary_wraps)]
-    fn idr(url: &str) -> Option<ResolvedLink<'_>> {
-        Some(ResolvedLink::IntraDocResolved(url.into()))
+    fn idr<'a>(url: &'a str, title: &'a str) -> Option<ResolvedLink<'a>> {
+        let url = url.into();
+        let title = title.into();
+        Some(ResolvedLink::IntraDocResolved { url, title })
     }
 
     #[expect(clippy::unnecessary_wraps)]
@@ -511,17 +533,23 @@ mod tests {
         let links = [
             (
                 "`struct@Struct`",
-                idr("https://example.com/struct.Struct.html"),
+                idr(
+                    "https://example.com/struct.Struct.html",
+                    "struct example::Struct",
+                ),
             ),
-            ("enum@Enum", idr("https://example.com/enum.Enum.html")),
+            (
+                "enum@Enum",
+                idr("https://example.com/enum.Enum.html", "enum example::Enum"),
+            ),
         ];
-        let expected = indoc! {"
+        let expected = indoc! {r#"
             * [`Struct`]
             * [Enum]
 
-            [`Struct`]: https://example.com/struct.Struct.html
-            [Enum]: https://example.com/enum.Enum.html
-        "};
+            [`Struct`]: https://example.com/struct.Struct.html "struct example::Struct"
+            [Enum]: https://example.com/enum.Enum.html "enum example::Enum"
+        "#};
 
         let output = render(docs, links);
         assert_eq!(output, expected);
@@ -568,20 +596,102 @@ mod tests {
         let links = [
             (
                 "`struct@Struct`",
-                idr("https://example.com/struct.Struct.html"),
+                idr(
+                    "https://example.com/struct.Struct.html",
+                    "struct example::Struct",
+                ),
             ),
-            ("enum@Enum", idr("https://example.com/enum.Enum.html")),
+            (
+                "enum@Enum",
+                idr("https://example.com/enum.Enum.html", "enum example::Enum"),
+            ),
         ];
 
-        let expected = indoc! {"
+        let expected = indoc! {r#"
             * [`Struct`] and [`Struct`][Struct@1]
             * [Enum] and [Enum][Enum@1]
 
             [`Struct`]: https://example.com/other/struct.Struct.html
-            [Struct@1]: https://example.com/struct.Struct.html
+            [Struct@1]: https://example.com/struct.Struct.html "struct example::Struct"
             [Enum]: https://example.com/other/enum.Enum.html
-            [Enum@1]: https://example.com/enum.Enum.html
-        "};
+            [Enum@1]: https://example.com/enum.Enum.html "enum example::Enum"
+        "#};
+
+        let output = render(docs, links);
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn preserves_existing_titles_and_fills_missing_titles_for_reference_and_inline_links() {
+        let docs = indoc! {r#"
+            * Inline:
+              * [titled](Struct "custom title")
+              * [untitled](Enum)
+            * Reference:
+              * [titled][struct-ref]
+              * [untitled][enum-ref]
+            * Reference Unknown:
+              * [the struct][Struct]
+              * [the enum][Enum]
+            * Collapsed:
+              * [struct-ref][]
+              * [enum-ref][]
+            * Collapsed Unknown:
+              * [Struct][]
+              * [Enum][]
+            * Shortcut:
+              * [struct-ref]
+              * [enum-ref]
+            * Shortcut Unknown:
+              * [Struct]
+              * [Enum]
+
+            [struct-ref]: Struct "custom title"
+            [enum-ref]: Enum
+        "#};
+        let links = [
+            (
+                "Struct",
+                idr(
+                    "https://example.com/struct.Struct.html",
+                    "struct example::Struct",
+                ),
+            ),
+            (
+                "Enum",
+                idr("https://example.com/enum.Enum.html", "enum example::Enum"),
+            ),
+        ];
+
+        let expected = indoc! {r#"
+            * Inline:
+              * [titled][Struct]
+              * [untitled][Enum]
+            * Reference:
+              * [titled][struct-ref]
+              * [untitled][enum-ref]
+            * Reference Unknown:
+              * [the struct][Struct@1]
+              * [the enum][Enum]
+            * Collapsed:
+              * [struct-ref][]
+              * [enum-ref][]
+            * Collapsed Unknown:
+              * [Struct][Struct@1]
+              * [Enum][]
+            * Shortcut:
+              * [struct-ref]
+              * [enum-ref]
+            * Shortcut Unknown:
+              * [Struct][Struct@1]
+              * [Enum]
+
+            [Struct]: https://example.com/struct.Struct.html "custom title"
+            [Enum]: https://example.com/enum.Enum.html "enum example::Enum"
+            [struct-ref]: https://example.com/struct.Struct.html "custom title"
+            [enum-ref]: https://example.com/enum.Enum.html "enum example::Enum"
+            [Struct@1]: https://example.com/struct.Struct.html "struct example::Struct"
+        "#};
 
         let output = render(docs, links);
         assert_eq!(output, expected);


### PR DESCRIPTION
## Summary

Add `title` attributes to intra-doc links after they are resolved, so generated Markdown reference definitions match `rustdoc` more closely.

### What changed

- keep both URL and generated title text when resolving intra-doc links
- propagate titles through broken-link resolution and reference-link rewriting
- only fill in a generated title when the Markdown link does not already provide one
- update the example README output and changelog entry

## Motivation

Previously, resolved intra-doc links were emitted without titles even though `rustdoc` includes title text such as `"struct crate::Type"` for those links.

## Validation

- `cargo test`
- `cargo run -- --workspace --toolchain nightly --check`

## Impact

Generated reference definitions for resolved intra-doc links now include titles. Existing explicit Markdown titles are preserved.