### PR TITLE
Add --install-toolchain option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,6 @@ jobs:
         with:
           tool: just,cargo-hack
       - uses: Swatinem/rust-cache@v2
-      - run: rustup toolchain install nightly --profile minimal
-        shell: bash
       - run: just ci-sync-rdme
         shell: bash
 
@@ -254,8 +252,6 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: just,cargo-llvm-cov
-      - run: rustup toolchain install nightly --profile minimal
-        shell: bash
       - run: just ci-coverage-sync-rdme
         shell: bash
       - uses: codecov/codecov-action@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+* Add `--install-toolchain` to install the Rust toolchain specified by `--toolchain` when it is not already installed.
+
 ## [0.7.0] - 2026-08-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -63,10 +63,16 @@ cargo sync-rdme --toolchain nightly
 ```
 
 `cargo-sync-rdme` uses the unstable features of rustdoc, so a nightly toolchain is required to generate READMEs from comments in the crate documentation.
-If the nightly toolchain is not installed, it can be installed with the following command:
+If the nightly toolchain is not installed, install it manually with the following command:
 
 ```console
 rustup toolchain install nightly
+```
+
+Alternatively, `cargo-sync-rdme` can install the requested toolchain automatically:
+
+```console
+cargo sync-rdme --toolchain nightly --install-toolchain
 ```
 
 The contents of `README.md` will be updated as follows:

--- a/justfile
+++ b/justfile
@@ -60,7 +60,7 @@ doc-all *args:
 
 # Synchronize README snippets for all packages.
 sync-rdme-all *args:
-    cargo run -- --workspace --toolchain nightly {{ args }}
+    cargo run -- --workspace --toolchain nightly --install-toolchain {{ args }}
 
 # Detect unused dependencies.
 machete *args:
@@ -156,7 +156,7 @@ ci-coverage-test:
 
 # CI: uploadable coverage artifact.
 ci-coverage-sync-rdme:
-    cargo llvm-cov --all-features --codecov --output-path target/codecov-sync-rdme.json run -- --workspace --toolchain nightly --check
+    cargo llvm-cov --all-features --codecov --output-path target/codecov-sync-rdme.json run -- --workspace --toolchain nightly --install-toolchain --check
 
 # Pre-release gate is equivalent to full CI.
 pre-release:

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -128,6 +128,9 @@ pub(crate) struct ToolchainArgs {
     /// Toolchain name to run `cargo rustdoc` with.
     #[clap(long)]
     toolchain: Option<String>,
+    /// Install the Rust toolchain specified by `--toolchain` if it is not already installed.
+    #[clap(long)]
+    install_toolchain: bool,
 }
 
 impl ToolchainArgs {
@@ -137,7 +140,11 @@ impl ToolchainArgs {
             // cargo +nightly ...` fails on windows, so use rustup instead
             // https://github.com/rust-lang/rustup/issues/3036
             let mut command = Command::new("rustup");
-            command.args(["run", toolchain, "cargo"]);
+            command.arg("run");
+            if self.install_toolchain {
+                command.arg("--install");
+            }
+            command.args([toolchain, "cargo"]);
             command
         } else {
             Command::new("cargo")


### PR DESCRIPTION
## Summary
- add a `--install-toolchain` flag that passes `--install` to `rustup run` when `--toolchain` is used
- update local and CI `sync-rdme` invocations to rely on the new flag instead of installing `nightly` separately
- align CI with the user-facing on-demand installation path instead of keeping a separate explicit `nightly` preinstall step
- document the new option in the README and changelog

## Motivation
`cargo sync-rdme --toolchain nightly` requires the toolchain to be installed ahead of time. This change lets the command install the requested toolchain on demand, matching `rustup run --install` behavior and simplifying local and CI usage.

This also intentionally makes CI exercise the same installation path directly rather than pre-installing `nightly` in a separate step.

## Validation
- `cargo run -- --help`
- `cargo test`
- `cargo run -- --workspace --toolchain nightly --install-toolchain --check`
- markdown diagnostics for `README.md` and `CHANGELOG.md`

## Impact
When `--toolchain` is specified, users can opt into automatic installation with `--install-toolchain`. Existing behavior without the new flag is unchanged.