### PR TITLE
Align mise task and workflow naming

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,7 +21,7 @@ permissions: {}
 
 jobs:
   issue-reporting:
-    name: issue reporting
+    name: Audit (issue reporting)
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -31,7 +31,7 @@ jobs:
       - uses: actions-rust-lang/audit@v1
 
   advisories:
-    name: advisories
+    name: Audit (advisories)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -43,7 +43,7 @@ jobs:
         shell: bash
 
   policy:
-    name: bans licenses sources
+    name: Audit (bans, licenses, sources)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,8 +19,8 @@ env:
 permissions: {}
 
 jobs:
-  build-release-assets:
-    name: Build artifacts for ${{ matrix.job.target }}
+  build:
+    name: Build
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: true
@@ -37,6 +37,8 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: windows-11-arm
             target: aarch64-pc-windows-msvc
+    env:
+      MISE_RUST_VERSION: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
@@ -51,8 +53,8 @@ jobs:
           brew install bash
           echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
         shell: bash
-      - name: Build artifact
-        run: mise run build-dist --target "${{ matrix.job.target }}"
+      - name: Build
+        run: mise run cd:build --target "${{ matrix.job.target }}"
         shell: bash
       - name: Upload binaries as artifacts
         uses: actions/upload-artifact@v7
@@ -61,10 +63,10 @@ jobs:
           path: target/dist/*
 
   release:
-    name: Create GitHub release
+    name: Create GitHub Release
     runs-on: ubuntu-latest
     needs:
-      - build-release-assets
+      - build
     permissions:
       contents: write
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -86,7 +88,7 @@ jobs:
 
   cd-complete:
     needs:
-      - build-release-assets
+      - build
       - release
     runs-on: ubuntu-latest
     if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,25 +45,8 @@ jobs:
           jq -n --argjson rust "${rust}" --argjson os "${os}" '{ rust: $rust, os: $os }'
         shell: bash
 
-  format-rust:
-    name: Format (Rust)
-    strategy:
-      fail-fast: true
-      matrix:
-        rust: [stable]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: jdx/mise-action@v4
-        with:
-          install: false
-      - uses: Swatinem/rust-cache@v2
-      - run: mise run ci:format:rust
-        shell: bash
-
   check-rust:
-    name: Check (Rust)
+    name: Check (rust)
     needs: set-matrix
     strategy:
       fail-fast: true
@@ -122,8 +105,25 @@ jobs:
       - run: mise run ci:check:unused-deps
         shell: bash
 
+  lint-rustfmt:
+    name: Lint (rustfmt)
+    strategy:
+      fail-fast: true
+      matrix:
+        rust: [stable]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
+        with:
+          install: false
+      - uses: Swatinem/rust-cache@v2
+      - run: mise run ci:lint:rustfmt
+        shell: bash
+
   lint-rust:
-    name: Lint (Rust)
+    name: Lint (rust)
     needs: set-matrix
     strategy:
       fail-fast: true
@@ -143,7 +143,7 @@ jobs:
         shell: bash
 
   test-rust:
-    name: Test (Rust)
+    name: Test (rust)
     needs: set-matrix
     strategy:
       fail-fast: true
@@ -163,7 +163,7 @@ jobs:
         shell: bash
 
   coverage-rust-test:
-    name: Coverage (Rust test)
+    name: Coverage (rust test)
     needs: set-matrix
     strategy:
       fail-fast: true
@@ -188,7 +188,7 @@ jobs:
           fail_ci_if_error: false
 
   coverage-rust-run:
-    name: Coverage (Rust run)
+    name: Coverage (rust run)
     needs: set-matrix
     strategy:
       fail-fast: true
@@ -212,8 +212,8 @@ jobs:
           files: target/codecov-run.json
           fail_ci_if_error: false
 
-  release-dry-run:
-    name: Release dry run
+  check-release:
+    name: Check (release)
     strategy:
       fail-fast: true
       matrix:
@@ -228,22 +228,11 @@ jobs:
         with:
           install: false
       - uses: Swatinem/rust-cache@v2
-      - run: mise run release-dry-run
-        shell: bash
-
-  format-toml:
-    name: Format (TOML)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: jdx/mise-action@v4
-        with:
-          install: false
-      - run: mise run ci:format:toml
+      - run: mise run ci:check:release
         shell: bash
 
   lint-toml:
-    name: Lint (TOML)
+    name: Lint (toml)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -264,8 +253,19 @@ jobs:
       - run: mise run ci:lint:workflow
         shell: bash
 
+  lint-spelling:
+    name: Lint (spelling)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
+        with:
+          install: false
+      - run: mise run ci:lint:spelling
+        shell: bash
+
   sync-markdown:
-    name: Sync (Markdown)
+    name: Sync (markdown)
     needs: set-matrix
     strategy:
       fail-fast: true
@@ -284,19 +284,8 @@ jobs:
       - run: mise run ci:sync:markdown
         shell: bash
 
-  lint-spelling:
-    name: Lint (spelling)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: jdx/mise-action@v4
-        with:
-          install: false
-      - run: mise run ci:lint:spelling
-        shell: bash
-
   lint-markdown:
-    name: Lint (Markdown)
+    name: Lint (markdown)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -307,7 +296,7 @@ jobs:
         shell: bash
 
   lint-editorconfig:
-    name: Lint (EditorConfig)
+    name: Lint (editorconfig)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -320,7 +309,7 @@ jobs:
   ci-complete:
     needs:
       - set-matrix
-      - format-rust
+      - lint-rustfmt
       - check-rust
       - check-rustdoc
       - check-unused-deps
@@ -328,8 +317,7 @@ jobs:
       - test-rust
       - coverage-rust-test
       - coverage-rust-run
-      - release-dry-run
-      - format-toml
+      - check-release
       - lint-toml
       - lint-workflow
       - lint-spelling

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-docs:
-    name: "Publishing GitHub Pages"
+  build:
+    name: "Build"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -25,17 +25,19 @@ jobs:
         with:
           install: false
       - uses: Swatinem/rust-cache@v2
-      - run: mise run build-gh-pages
+      - run: mise run pages:build
+        shell: bash
       - uses: actions/upload-pages-artifact@v5
         with:
           path: target/doc
 
-  deploy-docs:
+  deploy:
+    name: "Deploy"
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: [build-docs]
+    needs: [build]
     steps:
       - id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -9,8 +9,8 @@ on:
 permissions: {}
 
 jobs:
-  update-deps:
-    name: Update Dependencies
+  update-deps-rust:
+    name: Update Dependencies (rust)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -20,7 +20,7 @@ jobs:
         with:
           install: false
       - uses: Swatinem/rust-cache@v2
-      - run: mise run update-deps
+      - run: mise run update-deps:rust
         shell: bash
       - uses: actions/create-github-app-token@v3
         id: app-token

--- a/.mise/tasks/cd.toml
+++ b/.mise/tasks/cd.toml
@@ -1,4 +1,4 @@
-[build-dist]
+["cd:build"]
 description = "Build release artifacts for distribution"
 # Invoke the script explicitly with bash so it works on Windows too.
 run = "bash ./scripts/build-dist"

--- a/.mise/tasks/ci.toml
+++ b/.mise/tasks/ci.toml
@@ -1,9 +1,6 @@
 ["ci"]
 depends = [{ task = "ci:*" }]
 
-["ci:format"]
-depends = [{ task = "ci:format:*" }]
-
 ["ci:check"]
 depends = [{ task = "ci:check:*" }]
 
@@ -15,12 +12,6 @@ depends = [{ task = "ci:test:*" }]
 
 ["ci:coverage"]
 depends = [{ task = "ci:coverage:*" }]
-
-["ci:format:rust"]
-depends = { task = "show-version:rust" }
-run = [
-  { task = "format:rust --check" },
-]
 
 ["ci:check:rust"]
 depends = { task = "show-version:rust" }
@@ -38,6 +29,12 @@ run = [
 depends = { task = "show-version:rust" }
 run = [
   { task = "check:unused-deps" },
+]
+
+["ci:lint:rustfmt"]
+depends = { task = "show-version:rust" }
+run = [
+  { task = "format:rust --check" },
 ]
 
 ["ci:lint:rust"]
@@ -64,13 +61,15 @@ run = [
   { task = "coverage:rust-run --codecov --output-path target/codecov-run.json" },
 ]
 
-["ci:format:toml"]
+["ci:check:release"]
+depends = { task = "show-version:rust" }
 run = [
-  { task = "format:toml --check" },
+  { task = "check:release" },
 ]
 
 ["ci:lint:toml"]
 run = [
+  { task = "format:toml --check" },
   { task = "lint:toml" },
 ]
 

--- a/.mise/tasks/pages.toml
+++ b/.mise/tasks/pages.toml
@@ -1,4 +1,4 @@
-[build-gh-pages]
+["pages:build"]
 description = "Build the documentation for GitHub Pages"
 run = [
   '''

--- a/.mise/tasks/release.toml
+++ b/.mise/tasks/release.toml
@@ -8,5 +8,5 @@ run = [
   '''
 ]
 
-[release-dry-run]
+["check:release"]
 run = "cargo release patch -vv --allow-branch '*'"

--- a/.mise/tasks/update-deps.toml
+++ b/.mise/tasks/update-deps.toml
@@ -1,4 +1,4 @@
-[update-deps]
+["update-deps:rust"]
 run = [
   "cargo upgrade --compatible",
   "cargo update",


### PR DESCRIPTION
## Summary
- align GitHub Actions job ids, display names, and `mise` task names across CI, CD, Pages, audit, and dependency update workflows
- rename release, pages, CD, and dependency update tasks to use consistent domain-prefixed namespaces
- classify non-mutating CI style checks under lint jobs and tasks, including rustfmt and TOML formatting checks

## Validation
- `mise run ci:lint:workflow`
- `mise run ci:lint:toml`
- `mise run ci:lint:rustfmt`