### PR TITLE
Remove ineffective mise install overrides

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -36,8 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run audit:advisories
         shell: bash
@@ -48,8 +46,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run audit:policy
         shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,8 +42,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.job.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - name: Set matrix values
         id: set-values
@@ -59,8 +57,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:check:rust
         shell: bash
@@ -79,8 +75,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:check:rustdoc
         shell: bash
@@ -99,8 +93,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:check:unused-deps
         shell: bash
@@ -116,8 +108,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:lint:rustfmt
         shell: bash
@@ -136,8 +126,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:lint:rust
         shell: bash
@@ -156,8 +144,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:test:rust
         shell: bash
@@ -176,8 +162,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:coverage:rust-test
         shell: bash
@@ -201,8 +185,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:coverage:rust-run
         shell: bash
@@ -225,8 +207,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:check:release
         shell: bash
@@ -237,8 +217,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - run: mise run ci:lint:toml
         shell: bash
 
@@ -248,8 +226,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - run: mise run ci:lint:workflow
         shell: bash
 
@@ -259,8 +235,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - run: mise run ci:lint:spelling
         shell: bash
 
@@ -278,8 +252,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:sync:markdown
         shell: bash
@@ -290,8 +262,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - run: mise run ci:lint:markdown
         shell: bash
 
@@ -301,8 +271,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - run: mise run ci:lint:editorconfig
         shell: bash
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run pages:build
         shell: bash

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-        with:
-          install: false
       - uses: Swatinem/rust-cache@v2
       - run: mise run update-deps:rust
         shell: bash


### PR DESCRIPTION
## Summary
- remove `install: false` from GitHub Actions jobs that immediately run `mise` tasks
- rely on the default `mise-action` behavior instead of overrides that do not change tool installation in these workflows

## Why
The original intent was to let `mise run` lazily install only the tools needed by each task. The mise docs describe a different behavior:

- `mise run --skip-tools` exists because `mise run` otherwise installs tools before running tasks: <https://mise.jdx.dev/cli/run.html>
- `task.run_auto_install` defaults to true and “Automatically install[s] missing tools when executing tasks”: <https://mise.jdx.dev/configuration/settings.html#taskrun_auto_install>
- the troubleshooting docs state that `mise run` “materialises the whole configured toolset” as part of running a task: <https://github.com/jdx/mise/blob/main/docs/troubleshooting.md>

Because these workflows immediately run `mise` tasks, `install: false` did not provide the intended lazy per-tool installation behavior.

## Validation
- `mise run ci:lint:workflow`
- diagnostics: no errors or warnings