### PR TITLE
Use similar_asserts in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "similar",
+ "similar-asserts",
  "tempfile",
  "thiserror",
  "toml",
@@ -2150,6 +2151,16 @@ checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
 dependencies = [
  "bstr",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "997e6ca38e97437973fc9f7f50a50d1274cacd874341a4960fea90067291038c"
+dependencies = [
+ "console",
+ "similar",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ void = "1.0.2"
 
 [dev-dependencies]
 indoc = "2.0.7"
+similar-asserts = "2.0.0"
 
 [build-dependencies]
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,6 +1,7 @@
 use std::assert_matches;
 
 use indoc::{formatdoc, indoc};
+use similar_asserts::assert_eq;
 
 use crate::config::metadata::{
     BadgeItem, Codecov, GithubActions, GithubActionsWorkflow, License, Rustdoc,

--- a/src/sync/contents/mod.rs
+++ b/src/sync/contents/mod.rs
@@ -103,6 +103,8 @@ impl fmt::Display for Escape<'_> {
 mod tests {
     use super::*;
 
+    use similar_asserts::assert_eq;
+
     #[test]
     fn escape() {
         let need_escape = [

--- a/src/sync/contents/rustdoc/code_block.rs
+++ b/src/sync/contents/rustdoc/code_block.rs
@@ -108,6 +108,7 @@ fn update_codeblock_tag(tag: &mut CowStr<'_>) -> bool {
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
+    use similar_asserts::assert_eq;
 
     #[test]
     fn update_codeblock_tag() {

--- a/src/sync/contents/rustdoc/intra_link.rs
+++ b/src/sync/contents/rustdoc/intra_link.rs
@@ -494,6 +494,7 @@ fn reference_label_from_link_destination(label: &str) -> CowStr<'_> {
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
+    use similar_asserts::assert_eq;
 
     use super::*;
 

--- a/src/sync/marker/find.rs
+++ b/src/sync/marker/find.rs
@@ -120,6 +120,7 @@ where
 #[cfg(test)]
 mod tests {
     use pulldown_cmark::Parser;
+    use similar_asserts::assert_eq;
 
     use crate::config::Manifest;
 

--- a/src/sync/marker/mod.rs
+++ b/src/sync/marker/mod.rs
@@ -157,6 +157,7 @@ fn trim_comment(text: (&str, SourceSpan)) -> Option<(&str, SourceSpan)> {
 
 #[cfg(test)]
 mod tests {
+    use similar_asserts::assert_eq;
     use std::assert_matches;
 
     use super::*;

--- a/src/sync/marker/replace.rs
+++ b/src/sync/marker/replace.rs
@@ -59,6 +59,8 @@ fn interpolate_ranges<T>(
 
 #[cfg(test)]
 mod tests {
+    use similar_asserts::assert_eq;
+
     #[test]
     fn interpolate_ranges() {
         let items = [(1, 0..1), (2, 1..2), (3, 2..3)];


### PR DESCRIPTION
## Summary
- add `similar-asserts` as a dev-dependency
- import `similar_asserts::assert_eq` in test modules that use `assert_eq!`
- update the lockfile for the new test-only dependency

## Review notes
- searched the Rust test codebase for remaining `assert_eq!` calls
- all remaining uses are in modules that now import `similar_asserts::assert_eq`, so there were no missed plain std macro call sites

## Validation
- `cargo test`

## Impact
- no production behavior changes
- test assertion failures should now show more helpful diffs