### PR TITLE
Refine mise task dependencies

### DIFF
--- a/.mise/tasks/ci.toml
+++ b/.mise/tasks/ci.toml
@@ -1,99 +1,92 @@
 ["ci"]
-depends = [{ task = "ci:*" }]
+depends = ["ci:*"]
 
 ["ci:check"]
-depends = [{ task = "ci:check:*" }]
+depends = ["ci:check:*"]
 
 ["ci:lint"]
-depends = [{ task = "ci:lint:*" }]
+depends = ["ci:lint:*"]
 
 ["ci:test"]
-depends = [{ task = "ci:test:*" }]
+depends = ["ci:test:*"]
 
 ["ci:coverage"]
-depends = [{ task = "ci:coverage:*" }]
+depends = ["ci:coverage:*"]
+
+["ci:sync"]
+depends = ["ci:sync:*"]
 
 ["ci:check:rust"]
-depends = { task = "show-version:rust" }
-run = [
-  { task = "check:rust:all" },
+depends = [
+  "show-version:rust",
+  "check:rust",
 ]
 
 ["ci:check:rustdoc"]
-depends = { task = "show-version:rust" }
-run = [
-  { task = "check:rustdoc" },
+depends = [
+  "show-version:rust",
+  "check:rustdoc",
 ]
 
 ["ci:check:unused-deps"]
-depends = { task = "show-version:rust" }
-run = [
-  { task = "check:unused-deps" },
+depends = [
+  "show-version:rust",
+  "check:unused-deps",
 ]
 
 ["ci:lint:rustfmt"]
-depends = { task = "show-version:rust" }
-run = [
-  { task = "format:rust --check" },
+depends = [
+  "show-version:rust",
+  "format:rust --check",
 ]
 
 ["ci:lint:rust"]
-depends = { task = "show-version:rust" }
-run = [
-  { task = "lint:rust:all" },
+depends = [
+  "show-version:rust",
+  "lint:rust",
 ]
 
 ["ci:test:rust"]
-depends = { task = "show-version:rust" }
-run = [
-  { task = "test:rust" },
+depends = [
+  "show-version:rust",
+  "test:rust",
 ]
 
 ["ci:coverage:rust-test"]
-depends = { task = "show-version:rust" }
-run = [
-  { task = "coverage:rust-test --codecov --output-path target/codecov-test.json" },
+depends = [
+  "show-version:rust",
+  "coverage:rust-test --codecov --output-path target/codecov-test.json",
 ]
 
 ["ci:coverage:rust-run"]
-depends = { task = "show-version:rust" }
-run = [
-  { task = "coverage:rust-run --codecov --output-path target/codecov-run.json" },
+depends = [
+  "show-version:rust",
+  "coverage:rust-run --codecov --output-path target/codecov-run.json",
 ]
 
 ["ci:check:release"]
-depends = { task = "show-version:rust" }
-run = [
-  { task = "check:release" },
+depends = [
+  "show-version:rust",
+  "check:release",
 ]
 
 ["ci:lint:toml"]
-run = [
-  { task = "format:toml --check" },
-  { task = "lint:toml" },
+depends = [
+  "format:toml --check",
+  "lint:toml",
 ]
 
 ["ci:lint:workflow"]
-run = [
-  { task = "lint:workflow" },
-]
+depends = ["lint:workflow"]
 
 ["ci:lint:spelling"]
-run = [
-  { task = "lint:spelling" },
-]
+depends = ["lint:spelling"]
 
 ["ci:lint:markdown"]
-run = [
-  { task = "lint:markdown" },
-]
+depends = ["lint:markdown"]
 
 ["ci:sync:markdown"]
-run = [
-  { task = "sync:markdown --check" },
-]
+depends = ["sync:markdown --check"]
 
 ["ci:lint:editorconfig"]
-run = [
-  { task = "lint:editorconfig" },
-]
+depends = ["lint:editorconfig"]

--- a/.mise/tasks/markdown.toml
+++ b/.mise/tasks/markdown.toml
@@ -4,8 +4,9 @@ usage = '''
 flag "--check" help="Run cargo-sync-rdme in check mode"
 flag "--allow-dirty" help="Sync Markdown files even if the target file is dirty"
 '''
+depends = ["install-nightly-toolchain"]
 run = '''
-cargo run -- --workspace --toolchain nightly --install-toolchain
+cargo run -- --workspace --toolchain nightly
   {{- ' --check' if usage.check else '' }}
   {{- ' --allow-dirty' if usage.allow_dirty else '' }}
 '''

--- a/.mise/tasks/pages.toml
+++ b/.mise/tasks/pages.toml
@@ -1,5 +1,6 @@
 ["pages:build"]
 description = "Build the documentation for GitHub Pages"
+depends = ["install-nightly-toolchain"]
 run = [
   '''
   cargo +nightly doc --workspace --all-features --no-deps

--- a/.mise/tasks/rust.toml
+++ b/.mise/tasks/rust.toml
@@ -5,6 +5,10 @@ run = [
   "cargo -vV",
 ]
 
+["install-nightly-toolchain"]
+description = "Install nightly Rust toolchain"
+run = "rustup toolchain install nightly"
+
 ["format:rust"]
 description = "Format Rust files"
 usage = '''
@@ -16,30 +20,14 @@ cargo fmt --all
 '''
 
 ["check:rust"]
-description = "Check Rust compilation across exhaustive feature combinations"
-usage = '''
-flag "--examples" help="Check examples"
-flag "--tests" help="Check tests"
-flag "--benches" help="Check benches"
-flag "--all-targets" help="Check all targets"
-'''
-env = { CARGO_BUILD_WARNINGS = "deny" }
-run = '''
-cargo hack --workspace --feature-powerset check
-  {{- ' --examples' if usage.examples else '' }}
-  {{- ' --tests' if usage.tests else '' }}
-  {{- ' --benches' if usage.benches else '' }}
-  {{- ' --all-targets' if usage.all_targets else '' }}
-'''
-
-["check:rust:all"]
 description = "Check Rust compilation across all target groups and exhaustive feature combinations"
+env = { CARGO_BUILD_WARNINGS = "deny" }
 run = [
-  { task = "check:rust" },
-  { task = "check:rust --examples" },
-  { task = "check:rust --tests" },
-  { task = "check:rust --benches" },
-  { task = "check:rust --all-targets" },
+  "cargo hack --workspace --feature-powerset check",
+  "cargo hack --workspace --feature-powerset check --examples",
+  "cargo hack --workspace --feature-powerset check --tests",
+  "cargo hack --workspace --feature-powerset check --benches",
+  "cargo hack --workspace --feature-powerset check --all-targets",
 ]
 
 ["check:rustdoc"]
@@ -52,34 +40,19 @@ description = "Check for unused dependencies"
 run = "cargo machete"
 
 ["lint:rust"]
-description = "Lint Rust code across exhaustive feature combinations"
-usage = '''
-flag "--examples" help="Check examples"
-flag "--tests" help="Check tests"
-flag "--benches" help="Check benches"
-flag "--all-targets" help="Check all targets"
-'''
-env = { CARGO_BUILD_WARNINGS = "deny" }
-run = '''
-cargo hack --workspace --feature-powerset clippy
-  {{- ' --examples' if usage.examples else '' }}
-  {{- ' --tests' if usage.tests else '' }}
-  {{- ' --benches' if usage.benches else '' }}
-  {{- ' --all-targets' if usage.all_targets else '' }}
-'''
-
-["lint:rust:all"]
 description = "Lint Rust across all target groups and exhaustive feature combinations"
+env = { CARGO_BUILD_WARNINGS = "deny" }
 run = [
-  { task = "lint:rust" },
-  { task = "lint:rust --examples" },
-  { task = "lint:rust --tests" },
-  { task = "lint:rust --benches" },
-  { task = "lint:rust --all-targets" },
+  "cargo hack --workspace --feature-powerset clippy",
+  "cargo hack --workspace --feature-powerset clippy --examples",
+  "cargo hack --workspace --feature-powerset clippy --tests",
+  "cargo hack --workspace --feature-powerset clippy --benches",
+  "cargo hack --workspace --feature-powerset clippy --all-targets",
 ]
 
 ["test:rust"]
 description = "Run Rust tests across exhaustive feature combinations"
+depends = ["install-nightly-toolchain"]
 run = "cargo hack --workspace --feature-powerset test"
 
 ["coverage:rust-test"]
@@ -88,6 +61,7 @@ usage = '''
 flag "--codecov" help="Export coverage data in \"Codecov Custom Coverage\" format"
 flag "--output-path <output>" help="Specify a file to write coverage data into."
 '''
+depends = ["install-nightly-toolchain"]
 # cargo-llvm-cov cleans its working directories at runtime, so test/run coverage
 # tasks must use separate directories when invoked from aggregate CI tasks.
 env = { CARGO_LLVM_COV_TARGET_DIR = "target/llvm-cov-target-test", CARGO_LLVM_COV_BUILD_DIR = "target/llvm-cov-target-test" }
@@ -106,6 +80,7 @@ usage = '''
 flag "--codecov" help="Export coverage data in \"Codecov Custom Coverage\" format"
 flag "--output-path <output>" help="Specify a file to write coverage data into."
 '''
+depends = ["install-nightly-toolchain"]
 # cargo-llvm-cov cleans its working directories at runtime, so test/run coverage
 # tasks must use separate directories when invoked from aggregate CI tasks.
 env = { CARGO_LLVM_COV_TARGET_DIR = "target/llvm-cov-target-run", CARGO_LLVM_COV_BUILD_DIR = "target/llvm-cov-target-run" }
@@ -113,5 +88,5 @@ run = '''
 cargo llvm-cov --all-features
   {{- ' --codecov' if usage.codecov else '' }}
   {{- ' --output-path ' ~ usage.output_path if usage.output_path else '' }}
-  {{- '' }} run -- --workspace --toolchain nightly --install-toolchain --check
+  {{- '' }} run -- --workspace --toolchain nightly --check
 '''

--- a/tests/intra_link.rs
+++ b/tests/intra_link.rs
@@ -19,19 +19,11 @@ const SPAN_START_MARKER: &str = "<!-- SYNC_RDME_INTEGRATION_TEST::SPAN_START -->
 const SPAN_END_MARKER: &str = "<!-- SYNC_RDME_INTEGRATION_TEST::SPAN_END -->";
 const HTML_ROOT_URL: &str = "https://example.com/html_root/";
 
-// `cargo test` runs these rstest cases in parallel. When the nightly toolchain is
-// not installed yet, having multiple cases probe `+nightly` concurrently can make
-// rustup trip over itself while installing it. Probe `rustc +nightly` once up
-// front so the installation, if needed, happens only once per test process.
-//
-// A per-process `Once` is sufficient for now because this is currently the only
-// integration test binary that prepares the nightly toolchain. If that changes,
-// we may need a cross-process lock instead.
 fn ensure_nightly_toolchain_installed() {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
-        let result = Command::new("rustc")
-            .args(["+nightly", "--version"])
+        let result = Command::new("rustup")
+            .args(["run", "nightly", "cargo", "--version", "--verbose"])
             .assert()
             .success();
         eprintln!("{result}");


### PR DESCRIPTION
## Summary
- add an explicit `install-nightly-toolchain` mise task and depend on it from Rust tasks that require nightly
- move CI aggregate tasks to explicit `depends`, add a `ci:sync` group, and standardize dependency declarations to string literals
- inline the Rust check/lint fan-out directly in the task definitions so the dependency graph reflects the actual execution plan
- stop relying on command-side `--install-toolchain` flags in mise tasks and make nightly setup visible in `mise tasks deps`
- keep the integration-test nightly probe `Once`-guarded so parallel `rstest` cases only validate the toolchain once per process

## Motivation
Installing the nightly toolchain from inside parallel test execution was flaky because multiple jobs could trigger `rustup` at the same time.

Modeling nightly installation as an explicit mise dependency makes the ordering clear, keeps the meaningful work parallel, and produces a much more useful `mise tasks deps` output.

## Design notes / reviewer context
### Direct `cargo test` behavior is intentionally different
Nightly installation is handled explicitly by mise task dependencies. `cargo test` does not install nightly from inside the test binary; running tests directly requires the nightly toolchain to already be installed.

This avoids surprising toolchain installation as a side effect of test execution and keeps toolchain setup aligned with the task graph.

### Why the integration test probe uses `Once`
The test helper uses `rustup run nightly ...` to verify that nightly is available before executing the nightly-dependent test flow.

That verification is process-global state, so probing it once per test process is sufficient. Guarding it with `Once` avoids redundant concurrent probes across parallel `rstest` cases while preserving fail-fast behavior.

### Why some tasks still use `run`
A few tasks still intentionally use `run` rather than `depends` where execution order is semantically important, for example when one step must update files before a later step validates or consumes them. The goal here was not to eliminate `run`, but to move genuinely dependency-shaped relationships into `depends`.

## Validation
- `mise tasks deps ci`
- `cargo test --test intra_link --no-run`
