### PR TITLE
Avoid recursive CI in release check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
-      - run: mise run ci:check:release
+      - run: mise run check:release --skip-ci
         shell: bash
 
   lint-toml:

--- a/.mise/tasks/ci.toml
+++ b/.mise/tasks/ci.toml
@@ -1,4 +1,10 @@
 ["ci"]
+depends = [
+  "ci:*",
+  { task = "check:release --skip-ci" },
+]
+
+["ci-for-pre-release"]
 depends = ["ci:*"]
 
 ["ci:check"]
@@ -62,12 +68,6 @@ depends = [
 depends = [
   "show-version:rust",
   "coverage:rust-run --codecov --output-path target/codecov-run.json",
-]
-
-["ci:check:release"]
-depends = [
-  "show-version:rust",
-  "check:release",
 ]
 
 ["ci:lint:toml"]

--- a/.mise/tasks/release.toml
+++ b/.mise/tasks/release.toml
@@ -2,11 +2,18 @@
 run = [
   { task = "sync:markdown --allow-dirty" },
   '''
-  {% if env.GITHUB_ACTIONS != 'true' %}
-  mise run ci
+  {% if env.RELEASE_CHECK_FROM_CI != 'true' %}
+  mise run ci-for-pre-release
+  {% else %}
+  # pre-release checks skipped
   {% endif %}
   '''
 ]
 
 ["check:release"]
-run = "cargo release patch -vv --allow-branch '*'"
+usage = '''
+flag "--skip-ci" help="Skip CI checks"
+'''
+run = '''
+RELEASE_CHECK_FROM_CI="{{ usage.skip_ci }}" cargo release patch --allow-branch '*'
+'''


### PR DESCRIPTION
## Summary
- avoid recursively re-entering `mise run ci` from the release check path
- add `ci-for-pre-release` so `pre-release` still runs CI when invoked outside CI
- make the `check-release` GitHub Actions job call `check:release --skip-ci` because equivalent checks already run in other jobs

## Behavior
- `mise run ci` now runs `check:release --skip-ci`
- `pre-release` runs `ci-for-pre-release` unless `RELEASE_CHECK_FROM_CI=true`
- `check:release --skip-ci` causes the cargo-release pre-release hook to skip CI

## Validation
- `mise tasks deps ci`
- `mise tasks deps ci-for-pre-release`
- `mise tasks deps ci:check`
- `mise run check:release --skip-ci`

`mise run check:release --skip-ci` completed as a cargo-release dry run and showed the pre-release hook taking the `# pre-release checks skipped` branch.