### PR TITLE
Flatten CI task names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
-      - run: mise run ci:check:rust
+      - run: mise run ci:check-rust
         shell: bash
 
   check-rustdoc:
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
-      - run: mise run ci:check:rustdoc
+      - run: mise run ci:check-rustdoc
         shell: bash
 
   check-unused-deps:
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
-      - run: mise run ci:check:unused-deps
+      - run: mise run ci:check-unused-deps
         shell: bash
 
   lint-rustfmt:
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
-      - run: mise run ci:lint:rustfmt
+      - run: mise run ci:lint-rustfmt
         shell: bash
 
   lint-rust:
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
-      - run: mise run ci:lint:rust
+      - run: mise run ci:lint-rust
         shell: bash
 
   test-rust:
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
-      - run: mise run ci:test:rust
+      - run: mise run ci:test-rust
         shell: bash
 
   coverage-rust-test:
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
-      - run: mise run ci:coverage:rust-test
+      - run: mise run ci:coverage-rust-test
         shell: bash
       - uses: codecov/codecov-action@v7
         with:
@@ -186,7 +186,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
-      - run: mise run ci:coverage:rust-run
+      - run: mise run ci:coverage-rust-run
         shell: bash
       - uses: codecov/codecov-action@v7
         with:
@@ -217,7 +217,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-      - run: mise run ci:lint:toml
+      - run: mise run ci:lint-toml
         shell: bash
 
   lint-workflow:
@@ -226,7 +226,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-      - run: mise run ci:lint:workflow
+      - run: mise run ci:lint-workflow
         shell: bash
 
   lint-spelling:
@@ -235,7 +235,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-      - run: mise run ci:lint:spelling
+      - run: mise run ci:lint-spelling
         shell: bash
 
   sync-markdown:
@@ -253,7 +253,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
-      - run: mise run ci:sync:markdown
+      - run: mise run ci:sync-markdown
         shell: bash
 
   lint-markdown:
@@ -262,7 +262,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-      - run: mise run ci:lint:markdown
+      - run: mise run ci:lint-markdown
         shell: bash
 
   lint-editorconfig:
@@ -271,7 +271,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
-      - run: mise run ci:lint:editorconfig
+      - run: mise run ci:lint-editorconfig
         shell: bash
 
   ci-complete:

--- a/.mise/tasks/ci.toml
+++ b/.mise/tasks/ci.toml
@@ -7,86 +7,71 @@ depends = [
 ["ci-for-pre-release"]
 depends = ["ci:*"]
 
-["ci:check"]
-depends = ["ci:check:*"]
-
-["ci:lint"]
-depends = ["ci:lint:*"]
-
-["ci:test"]
-depends = ["ci:test:*"]
-
-["ci:coverage"]
-depends = ["ci:coverage:*"]
-
-["ci:sync"]
-depends = ["ci:sync:*"]
-
-["ci:check:rust"]
+["ci:check-rust"]
 depends = [
   "show-version:rust",
   "check:rust",
 ]
 
-["ci:check:rustdoc"]
+["ci:check-rustdoc"]
 depends = [
   "show-version:rust",
   "check:rustdoc",
 ]
 
-["ci:check:unused-deps"]
+["ci:check-unused-deps"]
 depends = [
   "show-version:rust",
   "check:unused-deps",
 ]
 
-["ci:lint:rustfmt"]
+["ci:lint-rustfmt"]
 depends = [
   "show-version:rust",
   "format:rust --check",
 ]
 
-["ci:lint:rust"]
+["ci:lint-rust"]
 depends = [
   "show-version:rust",
   "lint:rust",
 ]
 
-["ci:test:rust"]
+["ci:test-rust"]
 depends = [
   "show-version:rust",
   "test:rust",
 ]
 
-["ci:coverage:rust-test"]
+["ci:coverage-rust-test"]
 depends = [
   "show-version:rust",
   "coverage:rust-test --codecov --output-path target/codecov-test.json",
 ]
 
-["ci:coverage:rust-run"]
+["ci:coverage-rust-run"]
 depends = [
   "show-version:rust",
   "coverage:rust-run --codecov --output-path target/codecov-run.json",
 ]
 
-["ci:lint:toml"]
+["ci:lint-toml"]
 depends = [
   "format:toml --check",
   "lint:toml",
 ]
 
-["ci:lint:workflow"]
+["ci:lint-workflow"]
 depends = ["lint:workflow"]
 
-["ci:lint:spelling"]
+["ci:lint-spelling"]
 depends = ["lint:spelling"]
 
-["ci:lint:markdown"]
+["ci:lint-markdown"]
 depends = ["lint:markdown"]
 
-["ci:sync:markdown"]
+["ci:sync-markdown"]
 depends = ["sync:markdown --check"]
 
-["ci:lint:editorconfig"]
+["ci:lint-editorconfig"]
 depends = ["lint:editorconfig"]


### PR DESCRIPTION
## Summary
- rename nested `ci:*:*` task names to flatter `ci:*` names
- update the GitHub Actions workflow to call the renamed tasks
- remove intermediate grouping tasks that existed only to support the deeper hierarchy

## Motivation
There are no known users of the `ci:foo:bar` hierarchy, but it required extra indirection tasks and made the task graph harder to scan. Flattening the names keeps the same behavior while improving readability and reducing boilerplate.

## Validation
- `mise tasks validate`
- `mise tasks deps ci`
- `mise tasks deps ci-for-pre-release`
- searched for stale `ci:(check|lint|test|coverage|sync):` references in the repository

## Notes
This change is intended to be a pure task rename and cleanup. The resolved dependency graph for `ci` and `ci-for-pre-release` still includes the same underlying checks.