### PR TITLE
Use CARGO for rustdoc builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add `--install-toolchain` to install the Rust toolchain specified by `--toolchain` when it is not already installed.
 
+### Changed
+
+* Respect the `CARGO` environment variable when invoking Cargo to build rustdoc output, except when `--toolchain` is specified.
+
 ## [0.7.0] - 2026-08-11
 
 ### Fixed

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,0 +1,24 @@
+use std::{borrow::Cow, env, ffi::OsStr, path::Path, process::Command};
+
+use cargo_metadata::Metadata;
+
+pub(crate) fn command_path() -> Cow<'static, OsStr> {
+    if let Some(cargo) = env::var_os("CARGO") {
+        cargo.into()
+    } else {
+        OsStr::new("cargo").into()
+    }
+}
+
+pub(crate) fn command() -> Command {
+    Command::new(command_path())
+}
+
+pub(crate) fn metadata(manifest_path: Option<&Path>) -> cargo_metadata::Result<Metadata> {
+    let mut cmd = cargo_metadata::MetadataCommand::new();
+    if let Some(path) = manifest_path {
+        cmd.manifest_path(path);
+    }
+    cmd.cargo_path(&command_path());
+    cmd.exec()
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -6,7 +6,7 @@ use miette::{IntoDiagnostic as _, WrapErr as _, bail, miette};
 use tracing::Level;
 use vcs_modify_guard::{AllowOptions, ModificationSafety, UnsafeModificationReason};
 
-use crate::{Result, diff};
+use crate::{Result, cargo, diff};
 
 #[derive(Debug, Clone, Copy, Default, clap::Args)]
 pub(crate) struct Verbosity {
@@ -48,15 +48,9 @@ pub(crate) struct WorkspaceArgs {
 
 impl WorkspaceArgs {
     pub(crate) fn metadata(&self) -> Result<Metadata> {
-        let mut cmd = cargo_metadata::MetadataCommand::new();
-        if let Some(path) = &self.manifest_path {
-            cmd.manifest_path(path);
-        }
-        let workspace = cmd
-            .exec()
+        cargo::metadata(self.manifest_path.as_deref())
             .into_diagnostic()
-            .wrap_err("failed to get package metadata")?;
-        Ok(workspace)
+            .wrap_err("failed to get package metadata")
     }
 }
 
@@ -134,7 +128,7 @@ pub(crate) struct ToolchainArgs {
 }
 
 impl ToolchainArgs {
-    pub(crate) fn cargo_command(&self) -> Command {
+    pub(crate) fn cargo_command_for_build_doc(&self) -> Command {
         if let Some(toolchain) = &self.toolchain {
             // Use `rustup run` instead of `cargo +toolchain ...` for two
             // reasons:
@@ -148,10 +142,9 @@ impl ToolchainArgs {
                 command.arg("--install");
             }
             command.args([toolchain, "cargo"]);
-            command
-        } else {
-            Command::new("cargo")
+            return command;
         }
+        cargo::command()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use crate::cli::App;
 #[macro_use]
 mod macros;
 
+mod cargo;
 mod cli;
 mod config;
 mod diff;
@@ -56,6 +57,7 @@ fn main() -> Result<()> {
             Some(arg)
         }
     });
+
     let app = App::parse_from(args);
     install_logger(app.verbosity.into())?;
 

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -83,7 +83,7 @@ pub(super) fn create(
 }
 
 fn run_rustdoc(app: &App, package: &Package) -> CreateResult<()> {
-    let mut command = app.toolchain.cargo_command();
+    let mut command = app.toolchain.cargo_command_for_build_doc();
     command
         .args(["rustdoc", "--package", &package.name])
         .args(app.feature.cargo_args())


### PR DESCRIPTION
## Summary

- use the `CARGO` environment variable when invoking Cargo to build rustdoc output
- keep `--toolchain` using `rustup run <toolchain> cargo` as before
- move shared Cargo resolution into a dedicated `cargo` module
- pass `cargo_path` to `cargo_metadata` explicitly so the shared Cargo resolution is obvious in code
- document the behavior change in `CHANGELOG.md`

## Background

Cargo external subcommands are invoked with the `CARGO` environment variable set to the Cargo executable that launched them. This change makes the rustdoc build path follow that convention instead of always invoking plain `cargo`, except when an explicit toolchain was requested.

## Validation

- `cargo test`
- markdown diagnostics for `CHANGELOG.md`

## Behavior change

When `CARGO` is set and `--toolchain` is not specified, `cargo sync-rdme` now uses that Cargo executable to generate rustdoc output. When `--toolchain` is specified, behavior stays the same and the command still goes through `rustup run <toolchain> cargo`.
