### PR TITLE
Notify on Renovate post-update changes

### DIFF
--- a/.github/workflows/renovate-post-update.yml
+++ b/.github/workflows/renovate-post-update.yml
@@ -6,10 +6,11 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.actor == 'renovate[bot]' }}
 
 jobs:
   renovate-post-update:
@@ -40,10 +41,22 @@ jobs:
 
           if [[ -n "${tracked_changes}" ]]; then
             echo "changed=true" >> "${GITHUB_OUTPUT}"
+            {
+              echo 'changed_files<<EOF'
+              # shellcheck disable=SC2001,SC2016
+              sed 's/^...\(.*\)$/- `\1`/' <<< "${tracked_changes}"
+              echo EOF
+            } >> "${GITHUB_OUTPUT}"
           else
             echo "changed=false" >> "${GITHUB_OUTPUT}"
           fi
         shell: bash
+      - name: Remove sticky PR comment
+        if: steps.git-status.outputs.changed != 'true'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: renovate-post-update
+          delete: true
       - uses: actions/create-github-app-token@v3
         if: steps.git-status.outputs.changed == 'true'
         id: app-token
@@ -66,3 +79,17 @@ jobs:
           git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git"
           git push origin "HEAD:${HEAD_REF}"
         shell: bash
+      - name: Leave sticky PR comment
+        if: steps.git-status.outputs.changed == 'true'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: renovate-post-update
+          skip_unchanged: true
+          message: |
+            This PR was updated automatically by the Renovate post-update workflow and an additional commit was pushed.
+
+            Please review the generated changes before merging.
+
+            Changed files:
+
+            ${{ steps.git-status.outputs.changed_files }}


### PR DESCRIPTION
## Summary
- add a sticky PR comment when `renovate-post-update` produces tracked changes
- include the list of changed files in that comment
- delete the sticky comment again when a later Renovate run produces no tracked changes
- keep the current run from being canceled by its own follow-up `synchronize` event after the auto-push

## Motivation
The workflow can already amend Renovate PRs automatically, but reviewers have to notice the extra commit on their own. Adding a sticky comment makes the auto-generated follow-up explicit and points reviewers at the affected files.

While wiring that in, I also adjusted concurrency behavior. Without that change, the run that pushes the auto-generated commit can be canceled by the new `pull_request.synchronize` event it triggers itself, which makes any post-push notification step unreliable.

## Validation
- `mise run lint:workflow`
- local diagnostics for `.github/workflows/renovate-post-update.yml`

## Behavior notes
- the file list in the comment is derived from tracked changes detected via `git status --porcelain`
- untracked files still fail the workflow as before
- the follow-up run triggered by the workflow's own push is still skipped by the job-level `github.actor == 'renovate[bot]'` guard, so this does not introduce a loop