### PR TITLE
Pin tool versions in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,19 +10,19 @@ lockfile_platforms = [
 ]
 
 [tools]
-actionlint = "latest"
-cargo-binstall = "latest"  # lets mise install cargo:* tools from binaries instead of compiling them
-"cargo:cargo-deny" = "latest"
-"cargo:cargo-edit" = "latest"
-"cargo:cargo-hack" = "latest"
-"cargo:cargo-llvm-cov" = "latest"
-"cargo:cargo-machete" = "latest"
-"cargo:cargo-release" = "latest"
-"cargo:typos-cli" = "latest"
-editorconfig-checker = "latest"
-"npm:markdownlint-cli" = "latest"
+actionlint = "1.7.12"
+cargo-binstall = "1.21.1"  # lets mise install cargo:* tools from binaries instead of compiling them
+"cargo:cargo-deny" = "0.20.2"
+"cargo:cargo-edit" = "0.13.13"
+"cargo:cargo-hack" = "0.6.45"
+"cargo:cargo-llvm-cov" = "0.8.7"
+"cargo:cargo-machete" = "0.9.2"
+"cargo:cargo-release" = "1.1.5"
+"cargo:typos-cli" = "1.49.0"
+editorconfig-checker = "3.11.1"
+"npm:markdownlint-cli" = "0.49.1"
 rust = { version = "stable", components = ["llvm-tools"] }
-tombi = "latest"
+tombi = "1.2.10"
 
 [shell_alias]
 editorconfig-checker = "ec"


### PR DESCRIPTION
## Summary
- replace `latest` entries in `mise.toml` with exact tool versions
- keep `rust` on `stable` intentionally

## Motivation
This makes tool updates explicit in PR diffs and lets Renovate manage version bumps in `mise.toml` directly, instead of relying on floating `latest` entries.

`rust` stays on `stable` by design so the workspace keeps following the latest stable toolchain, while MSRV coverage is handled separately.

## Notes
- the pinned versions match the current `mise.lock`
- this changes tool version declarations only; it does not change the Rust toolchain policy

## Validation
- local diagnostics for `mise.toml`