### PR TITLE
Update tombi to 1.4.0

### DIFF
--- a/.mise/tasks/rust.toml
+++ b/.mise/tasks/rust.toml
@@ -10,7 +10,7 @@ description = "Install Rust toolchains for test"
 run = [
   "rustup toolchain install nightly",
   "rustup toolchain install beta",
-  "rustup toolchain install 1.96.0"
+  "rustup toolchain install 1.96.0",
 ]
 
 ["install-toolchains-for-sync-rdme"]

--- a/mise.lock
+++ b/mise.lock
@@ -137,35 +137,35 @@ backend = "core:rust"
 components = "llvm-tools"
 
 [[tools.tombi]]
-version = "1.2.10"
+version = "1.4.0"
 backend = "aqua:tombi-toml/tombi"
 
 [tools.tombi."platforms.linux-arm64"]
-checksum = "sha256:8b4d25b27beac050000f1c36cca1b3bdafc1635efabb531ebf3777a8cea5bfc2"
-url = "https://github.com/tombi-toml/tombi/releases/download/v1.2.10/tombi-cli-1.2.10-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/508637475"
+checksum = "sha256:b70750d462954294c354a014bb90399273876b953c21e3a136aafd3d1d41f5e8"
+url = "https://github.com/tombi-toml/tombi/releases/download/v1.4.0/tombi-cli-1.4.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/513163060"
 provenance = "github-attestations"
 
 [tools.tombi."platforms.linux-x64"]
-checksum = "sha256:abb3bc596699020506d7dccde7ea5f884970a2baabd4afab9cc513c1b75cb774"
-url = "https://github.com/tombi-toml/tombi/releases/download/v1.2.10/tombi-cli-1.2.10-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/508637503"
+checksum = "sha256:e2dc1190e0590b1fd0581fa8f85017215ed9b05a4d85c1cf18e0979b6cf24fe1"
+url = "https://github.com/tombi-toml/tombi/releases/download/v1.4.0/tombi-cli-1.4.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/513163088"
 provenance = "github-attestations"
 
 [tools.tombi."platforms.macos-arm64"]
-checksum = "sha256:153adcddaa70c53358c08287ffa20697926c149f8413d700b9961793891561a7"
-url = "https://github.com/tombi-toml/tombi/releases/download/v1.2.10/tombi-cli-1.2.10-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/508637483"
+checksum = "sha256:248159d26488f11fe8c36b9239b1ab84abe3533f4a5d8d066e56c091a99ffde1"
+url = "https://github.com/tombi-toml/tombi/releases/download/v1.4.0/tombi-cli-1.4.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/513163062"
 provenance = "github-attestations"
 
 [tools.tombi."platforms.windows-arm64"]
-checksum = "sha256:7691cc1a7aaae67ed23f885977a5bfb83d413790398d22790664ed337b0887ce"
-url = "https://github.com/tombi-toml/tombi/releases/download/v1.2.10/tombi-cli-1.2.10-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/508637484"
+checksum = "sha256:b8fa7ef33f86f011716d9a5712084ac461f83147c312436cadeb15dc7af67029"
+url = "https://github.com/tombi-toml/tombi/releases/download/v1.4.0/tombi-cli-1.4.0-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/513163063"
 provenance = "github-attestations"
 
 [tools.tombi."platforms.windows-x64"]
-checksum = "sha256:3ca0e9dcddc37714b3f72822fbc0f1bd8a3b66880ff8523194ecfd0e3b3e78b3"
-url = "https://github.com/tombi-toml/tombi/releases/download/v1.2.10/tombi-cli-1.2.10-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/508637499"
+checksum = "sha256:376f26ef04c32b7de57352fb1572d550d2f728958f00bfa585cec94a1df677ab"
+url = "https://github.com/tombi-toml/tombi/releases/download/v1.4.0/tombi-cli-1.4.0-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/513163086"
 provenance = "github-attestations"

--- a/mise.toml
+++ b/mise.toml
@@ -22,7 +22,7 @@ cargo-binstall = "1.21.1"  # lets mise install cargo:* tools from binaries inste
 editorconfig-checker = "3.11.1"
 "npm:markdownlint-cli" = "0.49.1"
 rust = { version = "stable", components = ["llvm-tools"] }
-tombi = "1.2.10"
+tombi = "1.4.0"
 
 [shell_alias]
 editorconfig-checker = "ec"


### PR DESCRIPTION
## Summary
- update the pinned `tombi` version in `mise.toml` from `1.2.10` to `1.4.0`
- refresh the corresponding `mise.lock` release asset URLs and checksums
- add a trailing comma in `.mise/tasks/rust.toml` to keep the array multi-line instead of being collapsed onto one line by TOML formatting

## Motivation
This keeps the repository's pinned TOML formatter/linter up to date with the latest upstream release while preserving a locked, reproducible tool setup.

The trailing comma change is intentional. It prevents `tombi` from reformatting the array onto a single line, which keeps the file easier to read and produces a more stable layout.

## Validation
- `mise run ci:lint-toml`

## Impact
- no runtime or library behavior changes
- affects local development and CI environments that install `tombi` via `mise`

## Risk
Low. The change only updates the pinned `tombi` tool version and its lockfile metadata, plus a formatting-preserving trailing comma in a task definition.