### PR TITLE
Align error handling with Snafu conventions

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use cargo_metadata::{Metadata, Package};
-use snafu::{OptionExt as _, ResultExt as _, Snafu};
+use snafu::{OptionExt as _, ResultExt as _, Snafu, ensure};
 
 use crate::args::{FeatureArgs, PackageArgs, RustdocToolchainArgs, WorkspaceArgs};
 
@@ -232,14 +232,14 @@ pub(crate) fn toolchain(args: Option<&RustdocToolchainArgs>) -> Result<Toolchain
         .with_context(|_source| CommandExecutionFailedSnafu {
             commandline: describe_command(&cmd),
         })?;
-    if !output.status.success() {
-        return Err(CommandFailedSnafu {
+    ensure!(
+        output.status.success(),
+        CommandFailedSnafu {
             commandline: describe_command(&cmd),
             status: output.status,
             stderr: output.stderr,
         }
-        .build());
-    }
+    );
     let stdout =
         String::from_utf8(output.stdout).with_context(|_source| InvalidUtf8OutputSnafu {
             commandline: describe_command(&cmd),

--- a/src/sync/contents/badge.rs
+++ b/src/sync/contents/badge.rs
@@ -7,7 +7,7 @@ use cargo_metadata::{
 };
 use miette::{NamedSource, SourceSpan};
 use serde::Deserialize;
-use snafu::{IntoError as _, OptionExt as _, ResultExt as _, Snafu};
+use snafu::{IntoError as _, OptionExt as _, ResultExt as _, Snafu, ensure};
 use url::Url;
 
 use super::Escape;
@@ -48,9 +48,7 @@ pub(super) fn create_all(
         }
     }
 
-    if !errors.is_empty() {
-        return Err(CreateAllBadgesError { errors });
-    }
+    ensure!(errors.is_empty(), CreateAllBadgesSnafu { errors });
 
     Ok(output)
 }
@@ -400,13 +398,12 @@ impl BadgeLink {
         workspace: &Metadata,
         package: &Package,
     ) -> CreateResult<Vec<CreateResult<Self>>> {
-        let Some(repository) = &package.repository else {
-            return Err(MissingRepositoryMetadataSnafu {
+        let repository = package
+            .repository
+            .as_ref()
+            .context(MissingRepositoryMetadataSnafu {
                 path: &package.manifest_path,
-            }
-            .build()
-            .into());
-        };
+            })?;
         let repo_path = repository
             .strip_prefix("https://github.com/")
             .context(InvalidGithubRepositorySnafu)?;
@@ -449,13 +446,12 @@ impl BadgeLink {
         manifest: &ManifestFile,
         package: &Package,
     ) -> CreateResult<Self> {
-        let Some(repository) = &package.repository else {
-            return Err(MissingRepositoryMetadataSnafu {
+        let repository = package
+            .repository
+            .as_ref()
+            .context(MissingRepositoryMetadataSnafu {
                 path: &package.manifest_path,
-            }
-            .build()
-            .into());
-        };
+            })?;
         let repo_path = repository
             .strip_prefix("https://github.com/")
             .context(InvalidGithubRepositorySnafu)?;

--- a/src/sync/contents/mod.rs
+++ b/src/sync/contents/mod.rs
@@ -1,18 +1,18 @@
 use std::fmt;
 
 use cargo_metadata::{Metadata, Package};
-use snafu::Snafu;
+use snafu::{Snafu, ensure};
 
 use crate::sync::SyncOptions;
 
-use super::{ManifestFile, marker::Replace};
+use super::{ManifestFile, marker::ReplaceSpecifier};
 
 mod badge;
 mod rustdoc;
 mod title;
 
 pub(super) fn create_all(
-    replaces: impl IntoIterator<Item = Replace>,
+    replaces: impl IntoIterator<Item = ReplaceSpecifier>,
     manifest: &ManifestFile,
     workspace: &Metadata,
     package: &Package,
@@ -28,9 +28,7 @@ pub(super) fn create_all(
         }
     }
 
-    if !errors.is_empty() {
-        return Err(CreateAllContentsError { errors });
-    }
+    ensure!(errors.is_empty(), CreateAllContentsSnafu { errors });
 
     Ok(contents)
 }
@@ -65,7 +63,7 @@ pub(super) struct Contents {
     text: String,
 }
 
-impl Replace {
+impl ReplaceSpecifier {
     fn create_content(
         self,
         manifest: &ManifestFile,
@@ -74,11 +72,11 @@ impl Replace {
         options: &SyncOptions<'_>,
     ) -> Result<Contents, CreateContentsError> {
         let text = match self {
-            Replace::Title => title::create(package),
-            Replace::Badge { name: _, badges } => {
+            ReplaceSpecifier::Title => title::create(package),
+            ReplaceSpecifier::Badge { name: _, badges } => {
                 badge::create_all(&badges, manifest, workspace, package)?
             }
-            Replace::Rustdoc => rustdoc::create(manifest, workspace, package, options)?,
+            ReplaceSpecifier::Rustdoc => rustdoc::create(manifest, workspace, package, options)?,
         };
 
         assert!(text.is_empty() || text.ends_with('\n'));

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -2,7 +2,7 @@ use std::process::ExitStatus;
 
 use cargo_metadata::{Metadata, Package, PackageName};
 use pulldown_cmark::Options;
-use snafu::{OptionExt as _, ResultExt as _, Snafu};
+use snafu::{OptionExt as _, ResultExt as _, Snafu, ensure};
 
 use crate::{
     cargo,
@@ -132,9 +132,7 @@ fn run_rustdoc(package: &Package, options: &SyncOptions<'_>) -> CreateResult<()>
     );
 
     let status = command.status().context(StartRustdocProcessSnafu)?;
-    if !status.success() {
-        return Err(NonZeroExitStatusSnafu { status }.build());
-    }
+    ensure!(status.success(), NonZeroExitStatusSnafu { status });
     Ok(())
 }
 

--- a/src/sync/marker/find.rs
+++ b/src/sync/marker/find.rs
@@ -2,17 +2,17 @@ use std::{ops::Range, sync::Arc};
 
 use miette::{NamedSource, SourceSpan};
 use pulldown_cmark::Event;
-use snafu::Snafu;
+use snafu::{Snafu, ensure};
 
 use crate::sync::ManifestFile;
 
-use super::{super::MarkdownFile, Marker, ParseMarkerError, Replace};
+use super::{super::MarkdownFile, Marker, ParseMarkerError, ReplaceSpecifier};
 
 pub(in super::super) fn find_all<'events>(
     readme: &MarkdownFile,
     manifest: &ManifestFile,
     events: impl IntoIterator<Item = (Event<'events>, Range<usize>)> + 'events,
-) -> Result<Vec<(Replace, Range<usize>)>, FindAllError> {
+) -> Result<Vec<(ReplaceSpecifier, Range<usize>)>, FindAllError> {
     let events = events.into_iter();
     let it = Iter { manifest, events };
     let mut markers = vec![];
@@ -24,13 +24,13 @@ pub(in super::super) fn find_all<'events>(
         }
     }
 
-    if !errors.is_empty() {
-        let source_code = readme.to_named_source();
-        return Err(FindAllError {
-            source_code,
-            errors,
-        });
-    }
+    ensure!(
+        errors.is_empty(),
+        FindAllSnafu {
+            source_code: readme.to_named_source(),
+            errors
+        }
+    );
 
     Ok(markers)
 }
@@ -83,7 +83,7 @@ impl<'event, I> Iterator for Iter<'_, I>
 where
     I: Iterator<Item = (Event<'event>, Range<usize>)>,
 {
-    type Item = Result<(Replace, Range<usize>), FindError>;
+    type Item = Result<(ReplaceSpecifier, Range<usize>), FindError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match itry!(self.next_marker())? {
@@ -158,15 +158,15 @@ mod tests {
     fn replace_marker() {
         let lines = [
             "Good morning, world!".to_string(),
-            Marker::Replace(Replace::Title).to_string(),
+            Marker::Replace(ReplaceSpecifier::Title).to_string(),
             "Good afternoon, world!".to_string(),
-            Marker::Replace(Replace::Badge {
+            Marker::Replace(ReplaceSpecifier::Badge {
                 name: "".into(),
                 badges: vec![].into(),
             })
             .to_string(),
             "Good evening, world!".to_string(),
-            Marker::Replace(Replace::Rustdoc).to_string(),
+            Marker::Replace(ReplaceSpecifier::Rustdoc).to_string(),
             "Good night, world!".to_string(),
         ];
         let ranges = line_ranges(&lines);
@@ -182,12 +182,12 @@ mod tests {
         };
         assert_eq!(
             markers.next().unwrap().unwrap(),
-            (Replace::Title, ranges[1].clone())
+            (ReplaceSpecifier::Title, ranges[1].clone())
         );
         assert_eq!(
             markers.next().unwrap().unwrap(),
             (
-                Replace::Badge {
+                ReplaceSpecifier::Badge {
                     name: "".into(),
                     badges: vec![].into()
                 },
@@ -196,7 +196,7 @@ mod tests {
         );
         assert_eq!(
             markers.next().unwrap().unwrap(),
-            (Replace::Rustdoc, ranges[5].clone())
+            (ReplaceSpecifier::Rustdoc, ranges[5].clone())
         );
         assert!(markers.next().is_none());
     }
@@ -205,7 +205,7 @@ mod tests {
     fn replace_region() {
         let lines = [
             "Good morning, world!".to_string(),
-            Marker::Start(Replace::Title).to_string(),
+            Marker::Start(ReplaceSpecifier::Title).to_string(),
             "Good afternoon, world!".to_string(),
             "# Heading!".to_string(),
             Marker::End.to_string(),
@@ -224,7 +224,7 @@ mod tests {
         };
         assert_eq!(
             markers.next().unwrap().unwrap(),
-            (Replace::Title, ranges[1].start..ranges[4].end)
+            (ReplaceSpecifier::Title, ranges[1].start..ranges[4].end)
         );
         assert!(markers.next().is_none());
     }

--- a/src/sync/marker/mod.rs
+++ b/src/sync/marker/mod.rs
@@ -1,7 +1,7 @@
 use std::{fmt, sync::Arc};
 
 use miette::SourceSpan;
-use snafu::{OptionExt as _, Snafu};
+use snafu::{OptionExt as _, Snafu, ensure};
 
 pub(super) use self::{find::*, replace::*};
 use crate::{config::metadata::BadgeItem, traits::StrSpanExt as _};
@@ -12,7 +12,7 @@ mod find;
 mod replace;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum Replace {
+pub(super) enum ReplaceSpecifier {
     Title,
     Badge {
         name: Arc<str>,
@@ -22,26 +22,25 @@ pub(super) enum Replace {
 }
 
 #[derive(Debug, Snafu)]
-pub(super) enum ParseReplaceError {
+pub(super) enum ParseReplaceSpecifierError {
     #[snafu(display("unknown replacement specifier: {specifier:?}"))]
-    UnknownReplace { specifier: String },
+    UnknownReplaceSpecifier { specifier: String },
     #[snafu(display("badge group not found in the package manifest: package.metadata.cargo-sync-rdme.badge.badges{hyphen}{group}", hyphen = if group.is_empty() { "" } else { "-" }))]
     NoSuchBadgeGroup { group: String },
 }
 
-impl Replace {
-    fn from_str(s: &str, manifest: &ManifestFile) -> Result<Self, ParseReplaceError> {
-        let group = match s {
+impl ReplaceSpecifier {
+    fn from_str(
+        specifier: &str,
+        manifest: &ManifestFile,
+    ) -> Result<Self, ParseReplaceSpecifierError> {
+        let group = match specifier {
             "title" => return Ok(Self::Title),
             "rustdoc" => return Ok(Self::Rustdoc),
             "badge" => "",
-            _ => {
-                if let Some(group) = s.strip_prefix("badge:") {
-                    group
-                } else {
-                    return Err(UnknownReplaceSnafu { specifier: s }.build());
-                }
-            }
+            _ => specifier
+                .strip_prefix("badge:")
+                .context(UnknownReplaceSpecifierSnafu { specifier })?,
         };
         let badges = &manifest.value().config().badge.badges;
         let (name, badges) = badges
@@ -54,7 +53,7 @@ impl Replace {
     }
 }
 
-impl fmt::Display for Replace {
+impl fmt::Display for ReplaceSpecifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Title => write!(f, "title"),
@@ -72,8 +71,8 @@ impl fmt::Display for Replace {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum Marker {
-    Replace(Replace),
-    Start(Replace),
+    Replace(ReplaceSpecifier),
+    Start(ReplaceSpecifier),
     End,
 }
 
@@ -94,19 +93,19 @@ pub(super) enum ParseMarkerError {
     #[snafu(display("{source}"))]
     ParseReplace {
         #[snafu(source)]
-        source: ParseReplaceError,
+        source: ParseReplaceSpecifierError,
         #[label]
         span: SourceSpan,
     },
     #[snafu(display("no replacement specifier found"))]
-    NoReplace {
+    NoReplaceSpecifier {
         #[label]
         span: SourceSpan,
     },
 }
 
-impl From<(ParseReplaceError, SourceSpan)> for ParseMarkerError {
-    fn from((err, span): (ParseReplaceError, SourceSpan)) -> Self {
+impl From<(ParseReplaceSpecifierError, SourceSpan)> for ParseMarkerError {
+    fn from((err, span): (ParseReplaceSpecifierError, SourceSpan)) -> Self {
         Self::ParseReplace { source: err, span }
     }
 }
@@ -121,7 +120,8 @@ impl Marker {
         // <replace> [[
         if let Some(replace) = body.strip_suffix_str("[[") {
             let replace = replace.trim();
-            let replace = Replace::from_str(replace.0, manifest).map_err(|err| (err, replace.1))?;
+            let replace =
+                ReplaceSpecifier::from_str(replace.0, manifest).map_err(|err| (err, replace.1))?;
             return Ok(Some(Marker::Start(replace)));
         }
 
@@ -129,7 +129,7 @@ impl Marker {
             return Ok(Some(Marker::End));
         }
 
-        let replace = Replace::from_str(body.0, manifest).map_err(|err| (err, body.1))?;
+        let replace = ReplaceSpecifier::from_str(body.0, manifest).map_err(|err| (err, body.1))?;
         Ok(Some(Marker::Replace(replace)))
     }
 
@@ -139,9 +139,7 @@ impl Marker {
         // <!-- cargo-sync-rdme <body> -->
         let text = opt_try!(trim_comment(text));
 
-        if text.0 == MAGIC {
-            return Err(NoReplaceSnafu { span: text.1 }.build());
-        }
+        ensure!(text.0 != MAGIC, NoReplaceSpecifierSnafu { span: text.1 });
         let (head, body) = opt_try!(text.split_once_fn(char::is_whitespace));
         Ok((head.0 == MAGIC).then_some(body))
     }
@@ -184,7 +182,7 @@ mod tests {
             let span = SourceSpan::from(0..s.len());
             match Marker::matches((s, span), &manifest).unwrap_err() {
                 ParseMarkerError::ParseReplace {
-                    source: ParseReplaceError::UnknownReplace { specifier: s },
+                    source: ParseReplaceSpecifierError::UnknownReplaceSpecifier { specifier: s },
                     ..
                 } => s,
                 e => panic!("unexpected: {e}"),
@@ -198,7 +196,7 @@ mod tests {
             let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
             let span = SourceSpan::from(0..s.len());
             match Marker::matches((s, span), &manifest).unwrap_err() {
-                ParseMarkerError::NoReplace { .. } => {}
+                ParseMarkerError::NoReplaceSpecifier { .. } => {}
                 e @ ParseMarkerError::ParseReplace { .. } => panic!("unexpected: {e}"),
             }
         }
@@ -208,15 +206,15 @@ mod tests {
 
         assert_eq!(
             ok("<!-- cargo-sync-rdme title -->"),
-            Some(Marker::Replace(Replace::Title))
+            Some(Marker::Replace(ReplaceSpecifier::Title))
         );
         assert_matches!(
             ok("<!-- cargo-sync-rdme badge [[ -->"),
-            Some(Marker::Start(Replace::Badge { name, .. })) if name.is_empty()
+            Some(Marker::Start(ReplaceSpecifier::Badge { name, .. })) if name.is_empty()
         );
         assert_matches!(
             ok("<!-- cargo-sync-rdme badge[[-->"),
-            Some(Marker::Start(Replace::Badge { name, ..})) if name.is_empty()
+            Some(Marker::Start(ReplaceSpecifier::Badge { name, ..})) if name.is_empty()
         );
         assert_eq!(ok("<!-- cargo-sync-rdme ]] -->"), Some(Marker::End));
 

--- a/src/sync/marker/replace.rs
+++ b/src/sync/marker/replace.rs
@@ -1,10 +1,10 @@
 use std::{borrow::Cow, iter, ops::Range};
 
-use super::{super::contents::Contents, Marker, Replace};
+use super::{super::contents::Contents, Marker, ReplaceSpecifier};
 
 pub(in super::super) fn replace_all(
     text: &str,
-    markers: &[(Replace, Range<usize>)],
+    markers: &[(ReplaceSpecifier, Range<usize>)],
     contents: &[Contents],
 ) -> String {
     let pairs = markers


### PR DESCRIPTION
## Summary
- align several error-handling paths with Snafu conventions by using `ensure!` and `context(...)` where they read naturally
- rename marker replacement types and parse error variants to make their intent clearer, such as `ReplaceSpecifier` and `ParseReplaceSpecifierError`
- keep behavior the same while simplifying a few manual error construction branches

## Validation
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Impact
This is an internal refactor for clearer error handling and naming. No user-visible behavior change is intended.

## Risk
Low. The changes are focused on error construction paths and type/variant naming.