### PR TITLE
Use concrete Snafu errors in sync flow

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@ use std::{env, io, process};
 
 use clap::{CommandFactory as _, Parser as _};
 use clap_complete::{Generator, Shell};
-use miette::miette;
 use tracing::Level;
 use tracing_subscriber::{EnvFilter, filter::LevelFilter};
 
@@ -29,11 +28,8 @@ mod sync;
 mod traits;
 mod with_source;
 
-/// Result type for `cargo-sync-rdme` command.
-type Result<T> = miette::Result<T>;
-
 /// Entry point of `cargo-sync-rdme` command.
-fn main() -> Result<()> {
+fn main() -> miette::Result<()> {
     let bin_name = env!("CARGO_BIN_NAME");
     let env_prefix = bin_name.to_uppercase().replace('-', "_");
     if let Ok(shell) = env::var(format!("{env_prefix}_COMPLETE")) {
@@ -56,7 +52,7 @@ fn main() -> Result<()> {
     });
 
     let args = Args::parse_from(args);
-    install_logger(args.verbosity.into())?;
+    install_logger(args.verbosity.into());
 
     let sync_options = SyncOptions {
         fix: &args.fix,
@@ -72,7 +68,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn install_logger(verbosity: Option<Level>) -> Result<()> {
+fn install_logger(verbosity: Option<Level>) {
     let env_filter = if env::var_os("RUST_LOG").is_some() {
         EnvFilter::from_default_env()
     } else {
@@ -93,10 +89,7 @@ fn install_logger(verbosity: Option<Level>) -> Result<()> {
         .with_env_filter(env_filter)
         .with_writer(io::stderr)
         .with_target(false)
-        .try_init()
-        .map_err(|e| miette!(e))?;
-
-    Ok(())
+        .init();
 }
 
 fn print_completion(bin_name: &str, shell: &str) {

--- a/src/sync/contents/mod.rs
+++ b/src/sync/contents/mod.rs
@@ -35,7 +35,7 @@ pub(super) fn create_all(
 
 #[derive(Debug, Snafu, miette::Diagnostic)]
 #[snafu(display("failed to create replacement contents"))]
-pub(super) struct CreateAllContentsError {
+pub(crate) struct CreateAllContentsError {
     #[related]
     errors: Vec<CreateContentsError>,
 }

--- a/src/sync/marker/find.rs
+++ b/src/sync/marker/find.rs
@@ -37,7 +37,7 @@ pub(in super::super) fn find_all<'events>(
 
 #[derive(Debug, Snafu, miette::Diagnostic)]
 #[snafu(display("failed to parse cargo-sync-rdme markers"))]
-pub(in super::super) struct FindAllError {
+pub(crate) struct FindAllError {
     #[source_code]
     source_code: NamedSource<Arc<str>>,
     #[related]

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -8,22 +8,90 @@ use cargo_metadata::{
     Metadata, Package,
     camino::{Utf8Path, Utf8PathBuf},
 };
-use miette::{IntoDiagnostic as _, NamedSource, WrapErr as _, bail};
+use miette::NamedSource;
 use pulldown_cmark::{Options, Parser};
+use snafu::{ResultExt as _, Snafu, ensure};
 use tempfile::NamedTempFile;
 use vcs_modify_guard::{AllowOptions, ModificationSafety, UnsafeModificationReason};
 
 use crate::{
-    Result,
     args::{FeatureArgs, FixArgs, RustdocToolchainArgs},
     config::Manifest,
     diff,
     traits::PackageExt as _,
-    with_source::WithSource,
+    with_source::{self, WithSource},
 };
 
 mod contents;
 mod marker;
+
+#[derive(Debug, Snafu, miette::Diagnostic)]
+pub(crate) enum SyncError {
+    #[snafu(transparent)]
+    #[diagnostic(transparent)]
+    ReadPackageManifest {
+        #[snafu(source)]
+        #[diagnostic_source]
+        source: with_source::ReadFileError,
+    },
+    #[snafu(display("failed to read markdown file: {path}"))]
+    ReadMarkdownFile {
+        path: Utf8PathBuf,
+        #[snafu(source)]
+        source: io::Error,
+    },
+    #[snafu(display("failed to write markdown file: {path}"))]
+    WriteMarkdownFile {
+        path: Utf8PathBuf,
+        #[snafu(source)]
+        source: io::Error,
+    },
+    #[snafu(display(
+        "no target files found. Please specify `package.readme` or `package.metadata.cargo-sync-rdme.extra-targets`"
+    ))]
+    NoTargetFilesFound,
+    #[snafu(transparent)]
+    #[diagnostic(transparent)]
+    FindMarkers {
+        #[snafu(source)]
+        #[diagnostic_source]
+        source: marker::FindAllError,
+    },
+    #[snafu(transparent)]
+    #[diagnostic(transparent)]
+    CreateContents {
+        #[snafu(source)]
+        #[diagnostic_source]
+        source: contents::CreateAllContentsError,
+    },
+    #[snafu(display("the file is not up-to-date: {markdown}\n{diff}"))]
+    FileIsNotUpToDate { markdown: Utf8PathBuf, diff: String },
+    #[snafu(display("failed to check whether the file can be modified: {markdown}"))]
+    CheckFileModificationSafety {
+        markdown: Utf8PathBuf,
+        #[snafu(source)]
+        source: vcs_modify_guard::ModifyGuardError,
+    },
+    #[snafu(display(
+        "the file is not under version control: {markdown}\nUse --allow-no-vcs to override this check."
+    ))]
+    NoVcs { markdown: Utf8PathBuf },
+    #[snafu(display(
+        "the file has uncommitted changes: {markdown}\nUse --allow-dirty to override this check."
+    ))]
+    DirtyFile { markdown: Utf8PathBuf },
+    #[snafu(display(
+        "the file has staged changes: {markdown}\nUse --allow-staged to override this check."
+    ))]
+    StagedFile { markdown: Utf8PathBuf },
+    #[snafu(display(
+        "the file is not safe to modify for some reason: {markdown}\nreason: {reason:?}"
+    ))]
+    UnsafeToModifyForSomeReason {
+        markdown: Utf8PathBuf,
+        reason: UnsafeModificationReason,
+    },
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct SyncOptions<'a> {
@@ -39,11 +107,10 @@ struct MarkdownFile {
 }
 
 impl MarkdownFile {
-    fn new(package: &Package, path: &Utf8Path) -> Result<Self> {
+    fn new(package: &Package, path: &Utf8Path) -> Result<Self, SyncError> {
         let path = package.root_directory().join(path);
         let text = fs::read_to_string(&path)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to read markdown file: {path}"))?
+            .context(ReadMarkdownFileSnafu { path: &path })?
             .into();
         Ok(Self { path, text })
     }
@@ -59,7 +126,7 @@ pub(crate) fn sync_all(
     workspace: &Metadata,
     package: &Package,
     options: &SyncOptions<'_>,
-) -> Result<()> {
+) -> Result<(), SyncError> {
     let manifest = ManifestFile::from_toml("package manifest", &package.manifest_path)?;
     let _span = tracing::info_span!("sync", "{}", package.name).entered();
 
@@ -77,11 +144,7 @@ pub(crate) fn sync_all(
         )
         .collect::<Vec<_>>();
 
-    if paths.is_empty() {
-        bail!(
-            "no target files found. Please specify `package.readme` or `package.metadata.cargo-sync-rdme.extra-targets`"
-        );
-    }
+    ensure!(!paths.is_empty(), NoTargetFilesFoundSnafu);
 
     for path in paths {
         tracing::info!("syncing markdown file: {path}");
@@ -110,9 +173,9 @@ pub(crate) fn sync_all(
 
         // Update README if allowed
         check_update_allowed(&markdown.path, &markdown.text, &new_text, options.fix)?;
-        write_readme(&markdown.path, &new_text)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to write markdown file: {path}"))?;
+        write_markdown(&markdown.path, &new_text).context(WriteMarkdownFileSnafu {
+            path: markdown.path,
+        })?;
 
         tracing::info!("updated markdown file: {path}");
     }
@@ -120,7 +183,7 @@ pub(crate) fn sync_all(
     Ok(())
 }
 
-pub(crate) fn write_readme(path: &Utf8Path, text: &str) -> io::Result<()> {
+pub(crate) fn write_markdown(path: &Utf8Path, text: &str) -> io::Result<()> {
     let output_dir = path.parent().unwrap();
     let mut tempfile = NamedTempFile::new_in(output_dir)?;
     tempfile.as_file_mut().write_all(text.as_bytes())?;
@@ -136,7 +199,7 @@ fn check_update_allowed<P>(
     old_text: &str,
     new_text: &str,
     options: &FixArgs,
-) -> Result<()>
+) -> Result<(), SyncError>
 where
     P: AsRef<Utf8Path>,
 {
@@ -148,45 +211,28 @@ where
     } = options;
     let markdown = markdown.as_ref();
 
-    if *check {
-        bail!(
-            "the file is not up-to-date: {markdown}\n{}",
-            diff::diff(old_text, new_text)
-        );
-    }
+    ensure!(
+        !check,
+        FileIsNotUpToDateSnafu {
+            markdown,
+            diff: diff::diff(old_text, new_text),
+        }
+    );
 
     let safety = AllowOptions::new()
         .allow_no_vcs(*allow_no_vcs)
         .allow_dirty(*allow_dirty)
         .allow_staged(*allow_staged)
         .check_safe_to_modify(markdown)
-        .into_diagnostic()
-        .wrap_err_with(|| {
-            format!("failed to check whether the file can be modified: {markdown}")
-        })?;
+        .context(CheckFileModificationSafetySnafu { markdown })?;
 
     match safety {
-        ModificationSafety::Safe => {}
+        ModificationSafety::Safe => Ok(()),
         ModificationSafety::Unsafe(reason) => match reason {
-            UnsafeModificationReason::NoVcs => {
-                bail!(
-                    "the file is not under version control: {markdown}\nUse --allow-no-vcs to override this check."
-                );
-            }
-            UnsafeModificationReason::Dirty { .. } => {
-                bail!(
-                    "the file has uncommitted changes: {markdown}\nUse --allow-dirty to override this check."
-                );
-            }
-            UnsafeModificationReason::Staged { .. } => {
-                bail!(
-                    "the file has staged changes: {markdown}\nUse --allow-staged to override this check."
-                );
-            }
-            reason => bail!(
-                "the file is not safe to modify for some reason: {markdown}\nreason: {reason:?}"
-            ),
+            UnsafeModificationReason::NoVcs => Err(NoVcsSnafu { markdown }.build()),
+            UnsafeModificationReason::Dirty { .. } => Err(DirtyFileSnafu { markdown }.build()),
+            UnsafeModificationReason::Staged { .. } => Err(StagedFileSnafu { markdown }.build()),
+            reason => Err(UnsafeToModifyForSomeReasonSnafu { markdown, reason }.build()),
         },
     }
-    Ok(())
 }


### PR DESCRIPTION
## Summary
- replace generic `miette` error construction in the sync path with a concrete `SyncError` enum built with `snafu`
- keep marker/content aggregate errors as explicit source types instead of erasing them into a generic error
- make tracing initialization infallible in `main`, treating repeated initialization as a programming bug rather than a recoverable runtime error

## Motivation
Using concrete error types makes each failure mode in the sync flow easier to understand and preserves more structured diagnostic information than wrapping everything into a generic `miette` error.

For tracing setup, `tracing_subscriber::fmt().init()` should only fail in cases that indicate a bug in the program setup, so carrying a user-facing error type for that path is unnecessary.

## Validation
- `cargo test`
- project diagnostics: no errors or warnings

## Impact
CLI error reporting should stay user-friendly while making the implementation more explicit about which operations can fail and how they fail.