### PR TITLE
Add shell linting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,15 @@ jobs:
       - run: mise run ci:lint-editorconfig
         shell: bash
 
+  lint-shell:
+    name: Lint (shell scripts)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
+      - run: mise run ci:lint-shell
+        shell: bash
+
   ci-complete:
     needs:
       - set-matrix
@@ -292,6 +301,7 @@ jobs:
       - sync-markdown
       - lint-markdown
       - lint-editorconfig
+      - lint-shell
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:

--- a/.mise/tasks/ci.toml
+++ b/.mise/tasks/ci.toml
@@ -75,3 +75,9 @@ depends = ["sync:markdown --check"]
 
 ["ci:lint-editorconfig"]
 depends = ["lint:editorconfig"]
+
+["ci:lint-shell"]
+depends = [
+  "format:shell --check",
+  "lint:shell",
+]

--- a/.mise/tasks/shell.toml
+++ b/.mise/tasks/shell.toml
@@ -1,0 +1,15 @@
+["format:shell"]
+description = "Format shell script files"
+usage = '''
+flag "--check" help="Run shfmt in check mode"
+'''
+run = '''
+shfmt
+  {{- ' -d' if usage.check else ' -w' }}
+  {{- '' }} .
+'''
+
+["lint:shell"]
+description = "Lint shell script files"
+# Only check top-level scripts. Library files are checked via the entrypoint scripts that source them.
+run = "shellcheck scripts/*"

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+external-sources=true

--- a/mise.lock
+++ b/mise.lock
@@ -136,6 +136,64 @@ backend = "core:rust"
 [tools.rust.options]
 components = "llvm-tools"
 
+[[tools.shellcheck]]
+version = "0.11.0"
+backend = "aqua:koalaman/shellcheck"
+
+[tools.shellcheck."platforms.linux-arm64"]
+checksum = "sha256:12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.xz"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056934"
+
+[tools.shellcheck."platforms.linux-x64"]
+checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056942"
+
+[tools.shellcheck."platforms.macos-arm64"]
+checksum = "sha256:56affdd8de5527894dca6dc3d7e0a99a873b0f004d7aabc30ae407d3f48b0a79"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.aarch64.tar.xz"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056932"
+
+[tools.shellcheck."platforms.windows-arm64"]
+checksum = "sha256:8a4e35ab0b331c85d73567b12f2a444df187f483e5079ceffa6bda1faa2e740e"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.zip"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056944"
+
+[tools.shellcheck."platforms.windows-x64"]
+checksum = "sha256:8a4e35ab0b331c85d73567b12f2a444df187f483e5079ceffa6bda1faa2e740e"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.zip"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056944"
+
+[[tools.shfmt]]
+version = "3.13.1"
+backend = "aqua:mvdan/sh"
+
+[tools.shfmt."platforms.linux-arm64"]
+checksum = "sha256:32d92acaa5cd8abb29fc49dac123dc412442d5713967819d8af2c29f1b3857c7"
+url = "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_arm64"
+url_api = "https://api.github.com/repos/mvdan/sh/releases/assets/390322859"
+
+[tools.shfmt."platforms.linux-x64"]
+checksum = "sha256:fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1"
+url = "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64"
+url_api = "https://api.github.com/repos/mvdan/sh/releases/assets/390322866"
+
+[tools.shfmt."platforms.macos-arm64"]
+checksum = "sha256:9680526be4a66ea1ffe988ed08af58e1400fe1e4f4aef5bd88b20bb9b3da33f8"
+url = "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_darwin_arm64"
+url_api = "https://api.github.com/repos/mvdan/sh/releases/assets/390322881"
+
+[tools.shfmt."platforms.windows-arm64"]
+checksum = "sha256:60cd368533d0ad73fa86d93d5bbf95ef40587245ce684ed138c1b31557b5fe97"
+url = "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_windows_amd64.exe"
+url_api = "https://api.github.com/repos/mvdan/sh/releases/assets/390322844"
+
+[tools.shfmt."platforms.windows-x64"]
+checksum = "sha256:60cd368533d0ad73fa86d93d5bbf95ef40587245ce684ed138c1b31557b5fe97"
+url = "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_windows_amd64.exe"
+url_api = "https://api.github.com/repos/mvdan/sh/releases/assets/390322844"
+
 [[tools.tombi]]
 version = "1.4.0"
 backend = "aqua:tombi-toml/tombi"

--- a/mise.toml
+++ b/mise.toml
@@ -22,6 +22,8 @@ cargo-binstall = "1.21.1"  # lets mise install cargo:* tools from binaries inste
 editorconfig-checker = "3.11.1"
 "npm:markdownlint-cli" = "0.49.1"
 rust = { version = "stable", components = ["llvm-tools"] }
+shellcheck = "0.11.0"
+shfmt = "3.13.1"
 tombi = "1.4.0"
 
 [shell_alias]


### PR DESCRIPTION
## Summary
- add `shellcheck` and `shfmt` to `mise.toml` and update `mise.lock`
- add shell-related mise tasks and wire them into aggregate CI tasks
- add a `lint-shell` GitHub Actions job and include it in `ci-complete`
- configure ShellCheck to follow external sourced files via `.shellcheckrc`
- lint only top-level scripts under `scripts/*`, with a comment explaining that sourced library files are checked via their entrypoints

## Validation
- `mise run ci:lint-shell`
- `mise run ci:lint-workflow`
- `mise run ci:lint-toml`

## Notes
- This change affects CI and development tooling only; there is no user-visible runtime behavior change.