### PR TITLE
Separate check mode from fix args

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -23,6 +23,8 @@ pub(crate) struct Args {
     #[clap(flatten)]
     pub(crate) toolchain: RustdocToolchainArgs,
     #[clap(flatten)]
+    pub(crate) mode: ModeArgs,
+    #[clap(flatten)]
     pub(crate) fix: FixArgs,
 }
 
@@ -100,12 +102,27 @@ pub(crate) struct RustdocToolchainArgs {
     pub(crate) install_toolchain: bool,
 }
 
-#[expect(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Mode {
+    Check,
+    Fix,
+}
+
 #[derive(Debug, Clone, Default, clap::Args)]
-pub(crate) struct FixArgs {
+pub(crate) struct ModeArgs {
     /// Check whether target files are up to date.
     #[clap(long)]
-    pub(crate) check: bool,
+    check: bool,
+}
+
+impl ModeArgs {
+    pub(crate) fn mode(&self) -> Mode {
+        if self.check { Mode::Check } else { Mode::Fix }
+    }
+}
+
+#[derive(Debug, Clone, Default, clap::Args)]
+pub(crate) struct FixArgs {
     /// Synchronize target files even if no VCS was detected.
     #[clap(long)]
     pub(crate) allow_no_vcs: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ fn main() -> miette::Result<()> {
     install_logger(args.verbosity.into());
 
     let sync_options = SyncOptions {
+        mode: args.mode.mode(),
         fix: &args.fix,
         toolchain: &args.toolchain,
         feature: &args.feature,

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -15,7 +15,7 @@ use tempfile::NamedTempFile;
 use vcs_modify_guard::{AllowOptions, ModificationSafety, UnsafeModificationReason};
 
 use crate::{
-    args::{FeatureArgs, FixArgs, RustdocToolchainArgs},
+    args::{FeatureArgs, FixArgs, Mode, RustdocToolchainArgs},
     config::Manifest,
     diff,
     traits::PackageExt as _,
@@ -95,6 +95,7 @@ pub(crate) enum SyncError {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SyncOptions<'a> {
+    pub(crate) mode: Mode,
     pub(crate) fix: &'a FixArgs,
     pub(crate) toolchain: &'a RustdocToolchainArgs,
     pub(crate) feature: &'a FeatureArgs,
@@ -171,8 +172,19 @@ pub(crate) fn sync_all(
             continue;
         }
 
+        match options.mode {
+            Mode::Check => {
+                return Err(FileIsNotUpToDateSnafu {
+                    markdown: &markdown.path,
+                    diff: diff::diff(&markdown.text, &new_text),
+                }
+                .build());
+            }
+            Mode::Fix => {}
+        }
+
         // Update README if allowed
-        check_update_allowed(&markdown.path, &markdown.text, &new_text, options.fix)?;
+        check_update_allowed(&markdown.path, options.fix)?;
         write_markdown(&markdown.path, &new_text).context(WriteMarkdownFileSnafu {
             path: markdown.path,
         })?;
@@ -194,30 +206,16 @@ pub(crate) fn write_markdown(path: &Utf8Path, text: &str) -> io::Result<()> {
     Ok(())
 }
 
-fn check_update_allowed<P>(
-    markdown: P,
-    old_text: &str,
-    new_text: &str,
-    options: &FixArgs,
-) -> Result<(), SyncError>
+fn check_update_allowed<P>(markdown: P, options: &FixArgs) -> Result<(), SyncError>
 where
     P: AsRef<Utf8Path>,
 {
     let FixArgs {
-        check,
         allow_no_vcs,
         allow_dirty,
         allow_staged,
     } = options;
     let markdown = markdown.as_ref();
-
-    ensure!(
-        !check,
-        FileIsNotUpToDateSnafu {
-            markdown,
-            diff: diff::diff(old_text, new_text),
-        }
-    );
 
     let safety = AllowOptions::new()
         .allow_no_vcs(*allow_no_vcs)


### PR DESCRIPTION
## Summary
- separate `--check` handling from `FixArgs` by introducing an explicit sync mode
- plumb the selected mode through `SyncOptions`
- keep modification safety checks focused on write-mode behavior while preserving check-mode diff reporting

## Validation
- manual code review
- `cargo test`
- `cargo clippy`

## Impact
- no intended user-visible CLI behavior change; this is an internal refactor