### PR TITLE
Add --color option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add `--install-toolchain` to install the Rust toolchain specified by `--toolchain` when it is not already installed.
+* Add `--color` to control colored output.
 
 ### Fixed
 
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* When `--color` is not specified, colored output now follows whether stderr is connected to a terminal and respects the `NO_COLOR` and `FORCE_COLOR` environment variables.
 * Respect the `CARGO` environment variable when invoking Cargo to build rustdoc output, except when `--toolchain` is specified.
 * When neither `--package` nor `--workspace` is specified, select Cargo's default workspace packages instead of always syncing only the workspace root package.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "similar",
  "similar-asserts",
  "snafu",
+ "supports-color",
  "tempfile",
  "test-helper",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ serde_yaml = "0.9.34"
 similar = { version = "3.1.2", features = ["inline", "unicode"] }
 similar-asserts = "2.0.0"
 snafu = "0.9.2"
+supports-color = "3.0.2"
 tempfile = "3.27.0"
 test-helper = { path = "crates/test-helper" }
 toml = { version = "1.1.4", features = ["preserve_order"] }
@@ -138,6 +139,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 similar.workspace = true
 snafu.workspace = true
+supports-color.workspace = true
 tempfile.workspace = true
 toml.workspace = true
 tracing.workspace = true

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::ArgAction;
+use clap::{ArgAction, ColorChoice};
 use tracing::Level;
 
 /// Command line interface definition for `cargo-sync-rdme` command.
@@ -14,6 +14,9 @@ use tracing::Level;
 pub(crate) struct Args {
     #[clap(flatten)]
     pub(crate) verbosity: Verbosity,
+    /// Coloring.
+    #[clap(long, default_value_t = ColorChoice::Auto, value_name = "WHEN")]
+    pub(crate) color: ColorChoice,
     #[clap(flatten)]
     pub(crate) workspace: WorkspaceArgs,
     #[clap(flatten)]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Write as _};
 
-use console::{Style, style};
 use similar::{ChangeTag, TextDiff};
+use supports_color::Stream;
 
 #[derive(Debug)]
 struct Line(Option<usize>);
@@ -15,7 +15,35 @@ impl fmt::Display for Line {
     }
 }
 
-pub(crate) fn diff(old: &str, new: &str) -> String {
+#[derive(Debug)]
+struct DiffStyler {
+    stream: Stream,
+}
+
+impl DiffStyler {
+    fn new(stream: Stream) -> Self {
+        Self { stream }
+    }
+
+    fn style(&self) -> console::Style {
+        let s = console::Style::new();
+        match self.stream {
+            Stream::Stdout => s.for_stdout(),
+            Stream::Stderr => s.for_stderr(),
+        }
+    }
+
+    fn styled<D>(&self, val: D) -> console::StyledObject<D> {
+        let s = console::style(val);
+        match self.stream {
+            Stream::Stdout => s.for_stdout(),
+            Stream::Stderr => s.for_stderr(),
+        }
+    }
+}
+
+pub(crate) fn diff(old: &str, new: &str, stream: Stream) -> String {
+    let styling = DiffStyler::new(stream);
     let diff = TextDiff::from_lines(old, new);
     let mut output = String::new();
 
@@ -25,25 +53,29 @@ pub(crate) fn diff(old: &str, new: &str) -> String {
         }
         for op in group {
             for change in diff.iter_inline_changes(op) {
-                let (sign, s) = match change.tag() {
-                    ChangeTag::Delete => ("-", Style::new().red()),
-                    ChangeTag::Insert => ("+", Style::new().green()),
-                    ChangeTag::Equal => (" ", Style::new().dim()),
+                let (sign, style) = match change.tag() {
+                    ChangeTag::Delete => ("-", styling.style().red()),
+                    ChangeTag::Insert => ("+", styling.style().green()),
+                    ChangeTag::Equal => (" ", styling.style().dim()),
                 };
                 write!(
                     &mut output,
                     "{}{} │{}",
-                    style(Line(change.old_index())).dim(),
-                    style(Line(change.new_index())).dim(),
-                    s.apply_to(sign).bold(),
+                    styling.styled(Line(change.old_index())).dim(),
+                    styling.styled(Line(change.new_index())).dim(),
+                    style.apply_to(sign).bold(),
                 )
                 .unwrap();
                 for (emphasized, value) in change.iter_strings_lossy() {
                     if emphasized {
-                        write!(&mut output, "{}", s.apply_to(value).underlined().on_black())
-                            .unwrap();
+                        write!(
+                            &mut output,
+                            "{}",
+                            style.apply_to(value).underlined().on_black()
+                        )
+                        .unwrap();
                     } else {
-                        write!(&mut output, "{}", s.apply_to(value)).unwrap();
+                        write!(&mut output, "{}", style.apply_to(value)).unwrap();
                     }
                 }
                 if change.missing_newline() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,10 @@
 
 use std::{env, io, process};
 
-use clap::{CommandFactory as _, Parser as _};
+use clap::{ColorChoice, CommandFactory as _, Parser as _};
 use clap_complete::{Generator, Shell};
+use miette::MietteHandlerOpts;
+use supports_color::Stream;
 use tracing::Level;
 use tracing_subscriber::{EnvFilter, filter::LevelFilter};
 
@@ -52,10 +54,14 @@ fn main() -> miette::Result<()> {
     });
 
     let args = Args::parse_from(args);
-    install_logger(args.verbosity.into());
+    let use_color = should_use_color(args.color);
+    set_console_color(use_color);
+    set_miette_hook(use_color);
+    install_logger(args.verbosity.into(), use_color);
 
     let sync_options = SyncOptions {
         mode: args.mode.mode(),
+        diagnostic_stream: Stream::Stderr,
         fix: &args.fix,
         toolchain: &args.toolchain,
         feature: &args.feature,
@@ -69,7 +75,26 @@ fn main() -> miette::Result<()> {
     Ok(())
 }
 
-fn install_logger(verbosity: Option<Level>) {
+fn should_use_color(choice: ColorChoice) -> bool {
+    match choice {
+        ColorChoice::Always => true,
+        ColorChoice::Auto => supports_color::on(Stream::Stderr).is_some(),
+        ColorChoice::Never => false,
+    }
+}
+
+fn set_console_color(use_color: bool) {
+    console::set_colors_enabled_stderr(use_color);
+}
+
+fn set_miette_hook(use_color: bool) {
+    miette::set_hook(Box::new(move |_| {
+        Box::new(MietteHandlerOpts::new().color(use_color).build())
+    }))
+    .unwrap();
+}
+
+fn install_logger(verbosity: Option<Level>, use_color: bool) {
     let env_filter = if env::var_os("RUST_LOG").is_some() {
         EnvFilter::from_default_env()
     } else {
@@ -88,6 +113,7 @@ fn install_logger(verbosity: Option<Level>) {
 
     tracing_subscriber::fmt()
         .with_env_filter(env_filter)
+        .with_ansi(use_color)
         .with_writer(io::stderr)
         .with_target(false)
         .init();

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -11,6 +11,7 @@ use cargo_metadata::{
 use miette::NamedSource;
 use pulldown_cmark::{Options, Parser};
 use snafu::{ResultExt as _, Snafu, ensure};
+use supports_color::Stream;
 use tempfile::NamedTempFile;
 use vcs_modify_guard::{AllowOptions, ModificationSafety, UnsafeModificationReason};
 
@@ -96,6 +97,7 @@ pub(crate) enum SyncError {
 #[derive(Debug, Clone)]
 pub(crate) struct SyncOptions<'a> {
     pub(crate) mode: Mode,
+    pub(crate) diagnostic_stream: Stream,
     pub(crate) fix: &'a FixArgs,
     pub(crate) toolchain: &'a RustdocToolchainArgs,
     pub(crate) feature: &'a FeatureArgs,
@@ -176,7 +178,7 @@ pub(crate) fn sync_all(
             Mode::Check => {
                 return Err(FileIsNotUpToDateSnafu {
                     markdown: &markdown.path,
-                    diff: diff::diff(&markdown.text, &new_text),
+                    diff: diff::diff(&markdown.text, &new_text, options.diagnostic_stream),
                 }
                 .build());
             }


### PR DESCRIPTION
## Summary

- add `--color <WHEN>` with `auto`, `always`, and `never`
- use `supports-color` for `auto` mode so color output follows stderr terminal detection and standard color-related environment variables
- apply the selected color policy consistently to tracing output, `miette` diagnostics, and `--check` diffs rendered via `console`
- update `CHANGELOG.md`

## Validation

- `cargo test`
- `cargo run -- --help`
- manually verified `--check` color behavior for:
  - default `auto`
  - `--color=always`
  - `--color=never`
  - `NO_COLOR=1`
  - `FORCE_COLOR=1`

## User-visible behavior

- `--color` can now force or disable colored output explicitly
- when `--color` is not specified, colored output now disables itself on non-terminal stderr
- `--check` diffs now follow the same color policy as other diagnostics
