### PR TITLE
Add -m for --manifest-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add `--install-toolchain` to install the Rust toolchain specified by `--toolchain` when it is not already installed.
 * Add `--color` to control colored output.
+* Add `-m` as a short option for `--manifest-path`.
 
 ### Fixed
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -18,17 +18,20 @@ pub(crate) struct Args {
     #[clap(long, default_value_t = ColorChoice::Auto, value_name = "WHEN")]
     pub(crate) color: ColorChoice,
     #[clap(flatten)]
-    pub(crate) workspace: WorkspaceArgs,
-    #[clap(flatten)]
-    pub(crate) package: PackageArgs,
-    #[clap(flatten)]
-    pub(crate) feature: FeatureArgs,
-    #[clap(flatten)]
     pub(crate) toolchain: RustdocToolchainArgs,
     #[clap(flatten)]
     pub(crate) mode: ModeArgs,
     #[clap(flatten)]
     pub(crate) fix: FixArgs,
+    #[clap(flatten)]
+    #[clap(next_help_heading = "Package Selection")]
+    pub(crate) package: PackageSelection,
+    #[clap(flatten)]
+    #[clap(next_help_heading = "Feature Selection")]
+    pub(crate) feature: FeatureSelection,
+    #[clap(flatten)]
+    #[clap(next_help_heading = "Manifest Options")]
+    pub(crate) manifest: ManifestOptions,
 }
 
 #[derive(Debug, Clone, Copy, Default, clap::Args)]
@@ -63,25 +66,25 @@ impl From<Verbosity> for Option<Level> {
 }
 
 #[derive(Debug, Clone, Default, clap::Args)]
-pub(crate) struct WorkspaceArgs {
+pub(crate) struct ManifestOptions {
     /// Path to Cargo.toml.
-    #[clap(long, value_name = "PATH")]
+    #[clap(long, short = 'm', value_name = "PATH")]
     pub(crate) manifest_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Default, clap::Args)]
-pub(crate) struct PackageArgs {
+pub(crate) struct PackageSelection {
     /// Synchronize all packages in the workspace.
     #[clap(long)]
     pub(crate) workspace: bool,
 
-    /// Package to synchronize.
-    #[clap(long = "package", short, value_name = "SPEC")]
+    /// Package(s) to synchronize.
+    #[clap(long = "package", short = 'p', value_name = "SPEC")]
     pub(crate) packages: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, clap::Args)]
-pub(crate) struct FeatureArgs {
+pub(crate) struct FeatureSelection {
     /// Space or comma separated list of features to activate.
     #[clap(long, short = 'F', value_name = "FEATURES")]
     pub(crate) features: Vec<String>,

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -12,7 +12,7 @@ use std::{
 use cargo_metadata::{Metadata, Package};
 use snafu::{OptionExt as _, ResultExt as _, Snafu, ensure};
 
-use crate::args::{FeatureArgs, PackageArgs, RustdocToolchainArgs, WorkspaceArgs};
+use crate::args::{FeatureSelection, ManifestOptions, PackageSelection, RustdocToolchainArgs};
 
 pub(crate) fn command_path() -> Cow<'static, OsStr> {
     if let Some(cargo) = env::var_os("CARGO") {
@@ -59,8 +59,8 @@ pub(crate) enum MetadataError {
     },
 }
 
-pub(crate) fn metadata(args: &WorkspaceArgs) -> Result<Metadata, MetadataError> {
-    let WorkspaceArgs { manifest_path } = args;
+pub(crate) fn metadata(args: &ManifestOptions) -> Result<Metadata, MetadataError> {
+    let ManifestOptions { manifest_path } = args;
 
     let mut cmd = cargo_metadata::MetadataCommand::new();
     cmd.no_deps();
@@ -79,9 +79,9 @@ pub(crate) enum SelectPackageError {
 
 pub(crate) fn select_packages<'meta>(
     meta: &'meta Metadata,
-    args: &PackageArgs,
+    args: &PackageSelection,
 ) -> Result<Vec<&'meta Package>, SelectPackageError> {
-    let PackageArgs {
+    let PackageSelection {
         workspace,
         packages,
     } = args;
@@ -105,8 +105,8 @@ pub(crate) fn select_packages<'meta>(
         .collect()
 }
 
-pub(crate) fn feature_args(args: &FeatureArgs) -> impl Iterator<Item = &str> {
-    let FeatureArgs {
+pub(crate) fn feature_args(args: &FeatureSelection) -> impl Iterator<Item = &str> {
+    let FeatureSelection {
         features,
         all_features,
         no_default_features,

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> miette::Result<()> {
         feature: &args.feature,
     };
 
-    let workspace = cargo::metadata(&args.workspace)?;
+    let workspace = cargo::metadata(&args.manifest)?;
     for package in cargo::select_packages(&workspace, &args.package)? {
         sync::sync_all(&workspace, package, &sync_options)?;
     }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -16,7 +16,7 @@ use tempfile::NamedTempFile;
 use vcs_modify_guard::{AllowOptions, ModificationSafety, UnsafeModificationReason};
 
 use crate::{
-    args::{FeatureArgs, FixArgs, Mode, RustdocToolchainArgs},
+    args::{FeatureSelection, FixArgs, Mode, RustdocToolchainArgs},
     config::Manifest,
     diff,
     traits::PackageExt as _,
@@ -100,7 +100,7 @@ pub(crate) struct SyncOptions<'a> {
     pub(crate) diagnostic_stream: Stream,
     pub(crate) fix: &'a FixArgs,
     pub(crate) toolchain: &'a RustdocToolchainArgs,
-    pub(crate) feature: &'a FeatureArgs,
+    pub(crate) feature: &'a FeatureSelection,
 }
 
 #[derive(Debug, Clone)]

--- a/tests/select_packages.rs
+++ b/tests/select_packages.rs
@@ -14,6 +14,8 @@ use test_helper::{self as helper, Workspace};
 #[case("workspace", "pkg-a", &["-p", "pkg-b"], &["pkg-b"])]
 #[case("workspace", "pkg-b", &[], &["pkg-b"])]
 #[case("workspace", "pkg-b/src", &[], &["pkg-b"])]
+#[case("workspace", "pkg-b/src", &["--manifest-path", "../../Cargo.toml"], &["root"])]
+#[case("workspace", "pkg-b/src", &["-m", "../../Cargo.toml"], &["root"])]
 #[case("workspace_default", "", &[], &["pkg-a"])]
 #[case("workspace_default", "", &["--workspace"], &["pkg-a", "pkg-b", "root"])]
 #[case("workspace_default", "", &["-p", "pkg-a", "-p", "pkg-b"], &["pkg-a", "pkg-b"])]


### PR DESCRIPTION
## Summary

- add `-m` as a short option for `--manifest-path`
- group CLI help output to match Cargo subcommand conventions more closely
- rename the internal argument structs to match their responsibilities
- add regression coverage for manifest-based package selection from a nested working directory
- document the new short option in `CHANGELOG.md`

## Validation

- `cargo test --test select_packages`
- `cargo run --quiet -- sync-rdme --help`
- `diagnostics` on `CHANGELOG.md`

## User-visible impact

Users can now pass `-m` as a shorthand for `--manifest-path`.
