### PR TITLE
Add Renovate config validation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,15 @@ jobs:
       - run: mise run ci:lint-shell
         shell: bash
 
+  lint-renovate:
+    name: Lint (renovate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
+      - run: mise run ci:lint-renovate
+        shell: bash
+
   ci-complete:
     needs:
       - set-matrix
@@ -302,6 +311,7 @@ jobs:
       - lint-markdown
       - lint-editorconfig
       - lint-shell
+      - lint-renovate
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:

--- a/.mise/tasks/ci.toml
+++ b/.mise/tasks/ci.toml
@@ -81,3 +81,6 @@ depends = [
   "format:shell --check",
   "lint:shell",
 ]
+
+["ci:lint-renovate"]
+depends = ["lint:renovate"]

--- a/.mise/tasks/post-update.toml
+++ b/.mise/tasks/post-update.toml
@@ -1,5 +1,0 @@
-["renovate-post-update"]
-depends = [
-  "format:*",
-  "sync:markdown --allow-dirty",
-]

--- a/.mise/tasks/renovate.toml
+++ b/.mise/tasks/renovate.toml
@@ -1,0 +1,10 @@
+["renovate-post-update"]
+description = "Run Renovate post-update tasks"
+depends = [
+  "format:*",
+  "sync:markdown --allow-dirty",
+]
+
+["lint:renovate"]
+description = "Lint Renovate config files"
+run = "renovate-config-validator --strict"

--- a/mise.lock
+++ b/mise.lock
@@ -129,6 +129,13 @@ url_api = "https://api.github.com/repos/editorconfig-checker/editorconfig-checke
 version = "0.49.1"
 backend = "npm:markdownlint-cli"
 
+[[tools."npm:renovate"]]
+version = "44.31.0"
+backend = "npm:renovate"
+
+[tools."npm:renovate".options]
+trust_policy_excludes = '["@yarnpkg/libzip@3.2.2"]'
+
 [[tools.rust]]
 version = "stable"
 backend = "core:rust"

--- a/mise.toml
+++ b/mise.toml
@@ -21,6 +21,7 @@ cargo-binstall = "1.21.1"  # lets mise install cargo:* tools from binaries inste
 "cargo:typos-cli" = "1.49.0"
 editorconfig-checker = "3.11.1"
 "npm:markdownlint-cli" = "0.49.1"
+"npm:renovate" = { version = "44.31.0", trust_policy_excludes = ["@yarnpkg/libzip@3.2.2"] }
 rust = { version = "stable", components = ["llvm-tools"] }
 shellcheck = "0.11.0"
 shfmt = "3.13.1"


### PR DESCRIPTION
## Summary
- add a dedicated CI job to validate `renovate.jsonc`
- add a `mise` task for Renovate config linting
- rename the Renovate-related task file for clearer ownership
- add `npm:renovate` to the shared `mise` tool definitions so Renovate can update the pinned version

## Motivation
This catches invalid Renovate configuration in CI instead of relying on failures later when Renovate runs.

Keeping the Renovate CLI version in top-level `mise` tool definitions also allows Renovate's `mise` manager to update that pinned version automatically.

## Validation
- `mise run ci:lint-renovate`
- `mise run ci:lint-workflow`
- `mise run ci:lint-toml`

## Impact
- CI-only/tooling change
- no user-facing runtime behavior changes

## Notes
`renovate-config-validator --strict` succeeded locally. It emitted an `RE2 not usable, falling back to RegExp` warning in this environment, but validation still completed successfully.