### PR TITLE
Print check diffs directly to stderr

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Write as _};
+use std::{fmt, io};
 
 use similar::{ChangeTag, TextDiff};
 use supports_color::Stream;
@@ -42,14 +42,18 @@ impl DiffStyler {
     }
 }
 
-pub(crate) fn diff(old: &str, new: &str, stream: Stream) -> String {
+pub(crate) fn write_pretty_diff(stream: Stream, old: &str, new: &str) -> Result<(), io::Error> {
     let styling = DiffStyler::new(stream);
     let diff = TextDiff::from_lines(old, new);
-    let mut output = String::new();
+
+    let mut output: &mut dyn io::Write = match stream {
+        Stream::Stdout => &mut io::stdout().lock(),
+        Stream::Stderr => &mut io::stderr().lock(),
+    };
 
     for (idx, group) in diff.grouped_ops(3).iter().enumerate() {
         if idx > 0 {
-            writeln!(&mut output, "{0:─^1$}┼{0:─^2$}", "─", 9, 120).unwrap();
+            writeln!(&mut output, "{0:─^1$}┼{0:─^2$}", "─", 9, 120)?;
         }
         for op in group {
             for change in diff.iter_inline_changes(op) {
@@ -64,26 +68,23 @@ pub(crate) fn diff(old: &str, new: &str, stream: Stream) -> String {
                     styling.styled(Line(change.old_index())).dim(),
                     styling.styled(Line(change.new_index())).dim(),
                     style.apply_to(sign).bold(),
-                )
-                .unwrap();
+                )?;
                 for (emphasized, value) in change.iter_strings_lossy() {
                     if emphasized {
                         write!(
                             &mut output,
                             "{}",
                             style.apply_to(value).underlined().on_black()
-                        )
-                        .unwrap();
+                        )?;
                     } else {
-                        write!(&mut output, "{}", style.apply_to(value)).unwrap();
+                        write!(&mut output, "{}", style.apply_to(value))?;
                     }
                 }
                 if change.missing_newline() {
-                    writeln!(&mut output).unwrap();
+                    writeln!(&mut output)?;
                 }
             }
         }
     }
-
-    output
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,14 +11,14 @@
 #![warn(dead_code_pub_in_binary)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use std::{env, io, process};
+use std::{assert_matches, env, io, process};
 
 use clap::{ColorChoice, CommandFactory as _, Parser as _};
 use clap_complete::{Generator, Shell};
 use miette::MietteHandlerOpts;
 use supports_color::Stream;
 use tracing::Level;
-use tracing_subscriber::{EnvFilter, filter::LevelFilter};
+use tracing_subscriber::{EnvFilter, filter::LevelFilter, fmt::writer::BoxMakeWriter};
 
 use crate::{args::Args, sync::SyncOptions};
 
@@ -54,14 +54,15 @@ fn main() -> miette::Result<()> {
     });
 
     let args = Args::parse_from(args);
-    let use_color = should_use_color(args.color);
-    set_console_color(use_color);
-    set_miette_hook(use_color);
-    install_logger(args.verbosity.into(), use_color);
+    let output_stream = Stream::Stderr;
+    let use_color = should_use_color(args.color, output_stream);
+    set_console_color(use_color, output_stream);
+    set_miette_hook(use_color, output_stream);
+    install_logger(args.verbosity.into(), use_color, output_stream);
 
     let sync_options = SyncOptions {
         mode: args.mode.mode(),
-        diagnostic_stream: Stream::Stderr,
+        diff_stream: output_stream,
         fix: &args.fix,
         toolchain: &args.toolchain,
         feature: &args.feature,
@@ -69,32 +70,41 @@ fn main() -> miette::Result<()> {
 
     let workspace = cargo::metadata(&args.manifest)?;
     for package in cargo::select_packages(&workspace, &args.package)? {
-        sync::sync_all(&workspace, package, &sync_options)?;
+        sync::sync_all(&workspace, package, &sync_options)
+            .map_err(|source| miette::Report::new_boxed(source))?;
     }
 
     Ok(())
 }
 
-fn should_use_color(choice: ColorChoice) -> bool {
+fn should_use_color(choice: ColorChoice, stream: Stream) -> bool {
     match choice {
         ColorChoice::Always => true,
-        ColorChoice::Auto => supports_color::on(Stream::Stderr).is_some(),
+        ColorChoice::Auto => supports_color::on(stream).is_some(),
         ColorChoice::Never => false,
     }
 }
 
-fn set_console_color(use_color: bool) {
-    console::set_colors_enabled_stderr(use_color);
+fn set_console_color(use_color: bool, stream: Stream) {
+    match stream {
+        Stream::Stdout => console::set_colors_enabled(use_color),
+        Stream::Stderr => console::set_colors_enabled_stderr(use_color),
+    }
 }
 
-fn set_miette_hook(use_color: bool) {
+fn set_miette_hook(use_color: bool, stream: Stream) {
+    // Keep the same `Stream`-based interface as the other setup functions, but
+    // errors returned from `main` are always printed to stderr, so only
+    // `Stream::Stderr` is valid here.
+    assert_matches!(stream, Stream::Stderr);
+
     miette::set_hook(Box::new(move |_| {
         Box::new(MietteHandlerOpts::new().color(use_color).build())
     }))
     .unwrap();
 }
 
-fn install_logger(verbosity: Option<Level>, use_color: bool) {
+fn install_logger(verbosity: Option<Level>, use_color: bool, stream: Stream) {
     let env_filter = if env::var_os("RUST_LOG").is_some() {
         EnvFilter::from_default_env()
     } else {
@@ -110,11 +120,15 @@ fn install_logger(verbosity: Option<Level>, use_color: bool) {
             .with_default_directive(default_level.into())
             .from_env_lossy()
     };
+    let writer = match stream {
+        Stream::Stdout => BoxMakeWriter::new(io::stdout),
+        Stream::Stderr => BoxMakeWriter::new(io::stderr),
+    };
 
     tracing_subscriber::fmt()
         .with_env_filter(env_filter)
         .with_ansi(use_color)
-        .with_writer(io::stderr)
+        .with_writer(writer)
         .with_target(false)
         .init();
 }

--- a/src/sync/marker/find.rs
+++ b/src/sync/marker/find.rs
@@ -9,7 +9,7 @@ use crate::sync::ManifestFile;
 use super::{super::MarkdownFile, Marker, ParseMarkerError, ReplaceSpecifier};
 
 pub(in super::super) fn find_all<'events>(
-    readme: &MarkdownFile,
+    markdown: &MarkdownFile<'_>,
     manifest: &ManifestFile,
     events: impl IntoIterator<Item = (Event<'events>, Range<usize>)> + 'events,
 ) -> Result<Vec<(ReplaceSpecifier, Range<usize>)>, FindAllError> {
@@ -27,7 +27,7 @@ pub(in super::super) fn find_all<'events>(
     ensure!(
         errors.is_empty(),
         FindAllSnafu {
-            source_code: readme.to_named_source(),
+            source_code: markdown.to_named_source(),
             errors
         }
     );
@@ -103,9 +103,11 @@ where
             (Marker::Start(specifier), start_range) => (specifier, start_range),
             (Marker::End, range) => return Err(UnexpectedEndMarkerSnafu { span: range }.build()),
         };
-        let next_marker = self.next_marker()?.context(NoCorrespondingEndMarkerSnafu {
-            start_span: start_range.clone(),
-        })?;
+        let next_marker = self
+            .next_marker()?
+            .with_context(|| NoCorrespondingEndMarkerSnafu {
+                start_span: start_range.clone(),
+            })?;
         match next_marker {
             (Marker::End, end_range) => Ok(Some((specifier, start_range.start..end_range.end))),
             (_, nested_range) => Err(NestedMarkerSnafu {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use cargo_metadata::{
-    Metadata, Package,
+    Metadata, Package, PackageName,
     camino::{Utf8Path, Utf8PathBuf},
 };
 use miette::NamedSource;
@@ -35,22 +35,22 @@ pub(crate) enum SyncError {
         #[diagnostic_source]
         source: with_source::ReadFileError,
     },
-    #[snafu(display("failed to read markdown file: {path}"))]
+    #[snafu(display("failed to read markdown file for package `{package}`: {markdown}", package = markdown.package, markdown = markdown.path))]
     ReadMarkdownFile {
-        path: Utf8PathBuf,
+        markdown: MarkdownPath,
         #[snafu(source)]
         source: io::Error,
     },
-    #[snafu(display("failed to write markdown file: {path}"))]
+    #[snafu(display("failed to write markdown file for package `{package}`: {markdown}", package = markdown.package, markdown = markdown.path))]
     WriteMarkdownFile {
-        path: Utf8PathBuf,
+        markdown: MarkdownPath,
         #[snafu(source)]
         source: io::Error,
     },
     #[snafu(display(
-        "no target files found. Please specify `package.readme` or `package.metadata.cargo-sync-rdme.extra-targets`"
+        "no target files found for package `{package}`. Specify `package.readme` or `package.metadata.cargo-sync-rdme.extra-targets`"
     ))]
-    NoTargetFilesFound,
+    NoTargetFilesFound { package: PackageName },
     #[snafu(transparent)]
     #[diagnostic(transparent)]
     FindMarkers {
@@ -65,94 +65,90 @@ pub(crate) enum SyncError {
         #[diagnostic_source]
         source: contents::CreateAllContentsError,
     },
-    #[snafu(display("the file is not up-to-date: {markdown}\n{diff}"))]
-    FileIsNotUpToDate { markdown: Utf8PathBuf, diff: String },
-    #[snafu(display("failed to check whether the file can be modified: {markdown}"))]
+    #[snafu(display("failed to write diff output"))]
+    WriteDiff {
+        #[snafu(source)]
+        source: io::Error,
+    },
+    #[snafu(display("markdown file for package `{package}` is not up to date: {markdown}", package = markdown.package, markdown = markdown.path))]
+    CheckFailed { markdown: MarkdownPath },
+    #[snafu(display(
+        "failed to check whether the markdown file can be modified for package `{package}`: {markdown}", package = markdown.package, markdown = markdown.path
+    ))]
     CheckFileModificationSafety {
-        markdown: Utf8PathBuf,
+        markdown: MarkdownPath,
         #[snafu(source)]
         source: vcs_modify_guard::ModifyGuardError,
     },
     #[snafu(display(
-        "the file is not under version control: {markdown}\nUse --allow-no-vcs to override this check."
+        "markdown file for package `{package}` is not under version control: {markdown}\nUse --allow-no-vcs to override this check.", package = markdown.package, markdown = markdown.path
     ))]
-    NoVcs { markdown: Utf8PathBuf },
+    NoVcs { markdown: MarkdownPath },
     #[snafu(display(
-        "the file has uncommitted changes: {markdown}\nUse --allow-dirty to override this check."
+        "markdown file for package `{package}` has uncommitted changes: {markdown}\nUse --allow-dirty to override this check.", package = markdown.package, markdown = markdown.path
     ))]
-    DirtyFile { markdown: Utf8PathBuf },
+    DirtyFile { markdown: MarkdownPath },
     #[snafu(display(
-        "the file has staged changes: {markdown}\nUse --allow-staged to override this check."
+        "markdown file for package `{package}` has staged changes: {markdown}\nUse --allow-staged to override this check.", package = markdown.package, markdown = markdown.path
     ))]
-    StagedFile { markdown: Utf8PathBuf },
+    StagedFile { markdown: MarkdownPath },
     #[snafu(display(
-        "the file is not safe to modify for some reason: {markdown}\nreason: {reason:?}"
+        "markdown file for package `{package}` is not safe to modify for some reason: {markdown}\nreason: {reason:?}", package = markdown.package, markdown = markdown.path
     ))]
     UnsafeToModifyForSomeReason {
-        markdown: Utf8PathBuf,
+        markdown: MarkdownPath,
         reason: UnsafeModificationReason,
     },
+}
+
+impl From<with_source::ReadFileError> for Box<SyncError> {
+    fn from(value: with_source::ReadFileError) -> Self {
+        Box::new(value.into())
+    }
+}
+
+impl From<marker::FindAllError> for Box<SyncError> {
+    fn from(value: marker::FindAllError) -> Self {
+        Box::new(value.into())
+    }
+}
+
+impl From<contents::CreateAllContentsError> for Box<SyncError> {
+    fn from(value: contents::CreateAllContentsError) -> Self {
+        Box::new(value.into())
+    }
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct SyncOptions<'a> {
     pub(crate) mode: Mode,
-    pub(crate) diagnostic_stream: Stream,
+    pub(crate) diff_stream: Stream,
     pub(crate) fix: &'a FixArgs,
     pub(crate) toolchain: &'a RustdocToolchainArgs,
     pub(crate) feature: &'a FeatureSelection,
 }
 
-#[derive(Debug, Clone)]
-struct MarkdownFile {
-    path: Utf8PathBuf,
-    text: Arc<str>,
-}
-
-impl MarkdownFile {
-    fn new(package: &Package, path: &Utf8Path) -> Result<Self, SyncError> {
-        let path = package.root_directory().join(path);
-        let text = fs::read_to_string(&path)
-            .context(ReadMarkdownFileSnafu { path: &path })?
-            .into();
-        Ok(Self { path, text })
-    }
-
-    fn to_named_source(&self) -> NamedSource<Arc<str>> {
-        NamedSource::new(self.path.clone(), Arc::clone(&self.text))
-    }
-}
-
-type ManifestFile = WithSource<Manifest>;
-
 pub(crate) fn sync_all(
     workspace: &Metadata,
     package: &Package,
     options: &SyncOptions<'_>,
-) -> Result<(), SyncError> {
+) -> Result<(), Box<SyncError>> {
     let manifest = ManifestFile::from_toml("package manifest", &package.manifest_path)?;
     let _span = tracing::info_span!("sync", "{}", package.name).entered();
 
-    let paths = package
-        .readme
-        .as_deref()
-        .into_iter()
-        .chain(
-            manifest
-                .value()
-                .config()
-                .extra_targets
-                .iter()
-                .map(Utf8Path::new),
-        )
-        .collect::<Vec<_>>();
+    let paths = package_target_files(package, &manifest.value().config().extra_targets);
 
-    ensure!(!paths.is_empty(), NoTargetFilesFoundSnafu);
+    ensure!(
+        !paths.is_empty(),
+        NoTargetFilesFoundSnafu {
+            package: package.name.clone(),
+        }
+    );
 
     for path in paths {
         tracing::info!("syncing markdown file: {path}");
 
-        let markdown = MarkdownFile::new(package, path)?;
+        let mut markdown = MarkdownFile::new(package, path)?;
 
         // Setup markdown parser
         let parser = Parser::new_ext(&markdown.text, Options::all()).into_offset_iter();
@@ -176,20 +172,21 @@ pub(crate) fn sync_all(
 
         match options.mode {
             Mode::Check => {
-                return Err(FileIsNotUpToDateSnafu {
-                    markdown: &markdown.path,
-                    diff: diff::diff(&markdown.text, &new_text, options.diagnostic_stream),
+                tracing::warn!("markdown file is not up to date: {path}");
+                diff::write_pretty_diff(options.diff_stream, &markdown.text, &new_text)
+                    .context(WriteDiffSnafu)?;
+                return Err(CheckFailedSnafu {
+                    markdown: &markdown,
                 }
-                .build());
+                .build()
+                .into());
             }
             Mode::Fix => {}
         }
 
         // Update README if allowed
-        check_update_allowed(&markdown.path, options.fix)?;
-        write_markdown(&markdown.path, &new_text).context(WriteMarkdownFileSnafu {
-            path: markdown.path,
-        })?;
+        check_update_allowed(&markdown, options.fix)?;
+        markdown.replace(new_text.into())?;
 
         tracing::info!("updated markdown file: {path}");
     }
@@ -197,33 +194,102 @@ pub(crate) fn sync_all(
     Ok(())
 }
 
-pub(crate) fn write_markdown(path: &Utf8Path, text: &str) -> io::Result<()> {
-    let output_dir = path.parent().unwrap();
-    let mut tempfile = NamedTempFile::new_in(output_dir)?;
-    tempfile.as_file_mut().write_all(text.as_bytes())?;
-    tempfile.as_file_mut().sync_data()?;
-    let file = tempfile.persist(path).map_err(|err| err.error)?;
-    file.sync_all()?;
-    drop(file);
-    Ok(())
+#[derive(Debug, Clone)]
+pub(crate) struct MarkdownPath {
+    package: PackageName,
+    path: Utf8PathBuf,
 }
 
-fn check_update_allowed<P>(markdown: P, options: &FixArgs) -> Result<(), SyncError>
+impl MarkdownPath {
+    fn new(package: &Package, path: &Utf8Path) -> Self {
+        Self {
+            package: package.name.clone(),
+            path: path.to_path_buf(),
+        }
+    }
+}
+
+impl From<&MarkdownFile<'_>> for MarkdownPath {
+    fn from(markdown: &MarkdownFile<'_>) -> Self {
+        Self {
+            package: markdown.package.name.clone(),
+            path: markdown.relative_path.to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MarkdownFile<'a> {
+    package: &'a Package,
+    relative_path: &'a Utf8Path,
+    path: Utf8PathBuf,
+    text: Arc<str>,
+}
+
+impl<'a> MarkdownFile<'a> {
+    fn new(package: &'a Package, relative_path: &'a Utf8Path) -> Result<Self, Box<SyncError>> {
+        let path = package.root_directory().join(relative_path);
+        let text = fs::read_to_string(&path)
+            .with_context(|_source| ReadMarkdownFileSnafu {
+                markdown: MarkdownPath::new(package, relative_path),
+            })?
+            .into();
+        Ok(Self {
+            package,
+            relative_path,
+            path,
+            text,
+        })
+    }
+
+    fn to_named_source(&self) -> NamedSource<Arc<str>> {
+        NamedSource::new(self.path.clone(), Arc::clone(&self.text))
+    }
+
+    fn replace(&mut self, new_text: Arc<str>) -> Result<(), Box<SyncError>> {
+        (|| {
+            let output_dir = self.path.parent().unwrap();
+            let mut tempfile = NamedTempFile::new_in(output_dir)?;
+            tempfile.as_file_mut().write_all(new_text.as_bytes())?;
+            tempfile.as_file_mut().sync_data()?;
+            let file = tempfile.persist(&self.path).map_err(|err| err.error)?;
+            file.sync_all()?;
+            drop(file);
+            Ok(())
+        })()
+        .context(WriteMarkdownFileSnafu { markdown: &*self })?;
+        self.text = new_text;
+        Ok(())
+    }
+}
+
+type ManifestFile = WithSource<Manifest>;
+
+fn package_target_files<'a, P>(package: &'a Package, extra_targets: &'a [P]) -> Vec<&'a Utf8Path>
 where
     P: AsRef<Utf8Path>,
 {
+    let mut paths = vec![];
+    paths.extend(package.readme.as_deref());
+    paths.extend(extra_targets.iter().map(AsRef::as_ref));
+    paths
+}
+
+fn check_update_allowed(
+    markdown: &MarkdownFile<'_>,
+    options: &FixArgs,
+) -> Result<(), Box<SyncError>> {
     let FixArgs {
         allow_no_vcs,
         allow_dirty,
         allow_staged,
     } = options;
-    let markdown = markdown.as_ref();
 
     let safety = AllowOptions::new()
         .allow_no_vcs(*allow_no_vcs)
         .allow_dirty(*allow_dirty)
         .allow_staged(*allow_staged)
-        .check_safe_to_modify(markdown)
+        .check_safe_to_modify(&markdown.path)
         .context(CheckFileModificationSafetySnafu { markdown })?;
 
     match safety {
@@ -235,4 +301,5 @@ where
             reason => Err(UnsafeToModifyForSomeReasonSnafu { markdown, reason }.build()),
         },
     }
+    .map_err(Into::into)
 }

--- a/src/with_source.rs
+++ b/src/with_source.rs
@@ -51,7 +51,7 @@ impl SourceInfo {
         let name = name.into();
         let path = path.into();
         let text = fs::read_to_string(&path)
-            .context(IoSnafu {
+            .with_context(|_source| IoSnafu {
                 name: name.clone(),
                 path: path.clone(),
             })?


### PR DESCRIPTION
## Summary

### Main change
- print `--check` diffs directly to stderr instead of embedding them in the `miette` error text
- route the related output setup in `main` through the same stream so color detection, console coloring, logging, and diff output stay consistent

### Follow-up cleanup
- make sync diagnostics consistently report package names and package-relative markdown paths through a shared `MarkdownPath` helper
- box `SyncError` at result boundaries to keep the error type small and avoid `clippy::result_large_err`

## Motivation
When the diff was embedded in the `miette` error, the diff's styling and `miette`'s diagnostic styling became nested. That made `--check` output busier and harder to read.

The main change is to print the diff directly to stderr instead, and to route the related output setup in `main` through the same stream so the surrounding output behavior stays consistent.

The remaining refactors are follow-up cleanup: they make markdown-related diagnostics consistently use package-relative paths and keep `SyncError` small enough to avoid `clippy::result_large_err`.

## Validation
- `cargo test`

## User-visible impact
- `--check` now prints the diff directly to stderr instead of rendering it inside the `miette` error output
- markdown-related sync errors now consistently mention the package name and show package-relative target paths

## Risks / follow-up
- `miette` reporting still assumes stderr output, which is asserted explicitly in setup