### PR TITLE
Use Cargo-style help and clap-verbosity-flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Use the same styling for `--help` output as Cargo.
 * When `--color` is not specified, colored output now follows whether stderr is connected to a terminal and respects the `NO_COLOR` and `FORCE_COLOR` environment variables.
 * Respect the `CARGO` environment variable when invoking Cargo to build rustdoc output, except when `--toolchain` is specified.
 * When neither `--package` nor `--workspace` is specified, select Cargo's default workspace packages instead of always syncing only the workspace root package.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,8 @@ dependencies = [
  "assert_fs",
  "cargo_metadata",
  "clap",
+ "clap-cargo",
+ "clap-verbosity-flag",
  "clap_complete",
  "clap_complete_nushell",
  "clap_mangen",
@@ -313,6 +315,26 @@ checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-cargo"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936551935c8258754bb8216aec040957d261f977303754b9bf1a213518388006"
+dependencies = [
+ "anstyle",
+ "clap",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394"
+dependencies = [
+ "clap",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,11 @@ assert_cmd = { version = "2.2.2", features = ["color-auto"] }
 assert_fs = { version = "1.1.4", features = ["color-auto"] }
 cargo_metadata = "0.23.1"
 clap = { version = "4.6.6", features = ["derive"] }
+clap-cargo = { version = "0.18.3" }
 clap_complete = "4.6.9"
 clap_complete_nushell = "4.6.2"
 clap_mangen = "0.3.3"
+clap-verbosity-flag = { version = "3.0.4", default-features = false, features = ["tracing"] }
 console = "0.16.4"
 indoc = "2.0.7"
 miette = { version = "7.6.0", features = ["fancy"] }
@@ -126,9 +128,11 @@ unescaped_backticks = "warn"
 [dependencies]
 cargo_metadata.workspace = true
 clap.workspace = true
+clap-cargo.workspace = true
 clap_complete.workspace = true
 clap_complete_nushell.workspace = true
 clap_mangen.workspace = true
+clap-verbosity-flag.workspace = true
 console.workspace = true
 miette.workspace = true
 pulldown-cmark.workspace = true

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,110 +1,76 @@
 use std::path::PathBuf;
 
-use clap::{ArgAction, ColorChoice};
-use tracing::Level;
+use clap::ColorChoice;
+use clap_verbosity_flag::{InfoLevel, Verbosity};
 
-/// Command line interface definition for `cargo-sync-rdme` command.
+/// Cargo subcommand to synchronize a package README and additional configured Markdown files with package metadata and crate documentation.
 #[derive(Debug, Clone, Default, clap::Parser)]
-#[clap(
+#[command(
     name = "cargo-sync-rdme",
     bin_name = "cargo sync-rdme",
     version,
-    about = "Cargo subcommand to synchronize a package README and additional configured Markdown files with package metadata and crate documentation."
+    styles = clap_cargo::style::CLAP_STYLING
 )]
 pub(crate) struct Args {
-    #[clap(flatten)]
-    pub(crate) verbosity: Verbosity,
+    #[command(flatten)]
+    pub(crate) verbosity: Verbosity<InfoLevel>,
     /// Coloring.
-    #[clap(long, default_value_t = ColorChoice::Auto, value_name = "WHEN")]
+    #[arg(long, default_value_t = ColorChoice::Auto, value_name = "WHEN")]
     pub(crate) color: ColorChoice,
-    #[clap(flatten)]
+    #[command(flatten)]
     pub(crate) toolchain: RustdocToolchainArgs,
-    #[clap(flatten)]
+    #[command(flatten)]
     pub(crate) mode: ModeArgs,
-    #[clap(flatten)]
+    #[command(flatten)]
     pub(crate) fix: FixArgs,
-    #[clap(flatten)]
-    #[clap(next_help_heading = "Package Selection")]
+    #[command(flatten, next_help_heading = "Package Selection")]
     pub(crate) package: PackageSelection,
-    #[clap(flatten)]
-    #[clap(next_help_heading = "Feature Selection")]
+    #[command(flatten, next_help_heading = "Feature Selection")]
     pub(crate) feature: FeatureSelection,
-    #[clap(flatten)]
-    #[clap(next_help_heading = "Manifest Options")]
+    #[command(flatten, next_help_heading = "Manifest Options")]
     pub(crate) manifest: ManifestOptions,
-}
-
-#[derive(Debug, Clone, Copy, Default, clap::Args)]
-pub(crate) struct Verbosity {
-    /// More output per occurrence.
-    #[clap(long, short = 'v', action = ArgAction::Count, global = true)]
-    verbose: u8,
-    /// Less output per occurrence.
-    #[clap(
-        long,
-        short = 'q',
-        action = ArgAction::Count,
-        global = true,
-        conflicts_with = "verbose"
-    )]
-    quiet: u8,
-}
-
-impl From<Verbosity> for Option<Level> {
-    fn from(verb: Verbosity) -> Self {
-        let level = i8::try_from(verb.verbose).unwrap_or(i8::MAX)
-            - i8::try_from(verb.quiet).unwrap_or(i8::MAX);
-        match level {
-            i8::MIN..=-3 => None,
-            -2 => Some(Level::ERROR),
-            -1 => Some(Level::WARN),
-            0 => Some(Level::INFO),
-            1 => Some(Level::DEBUG),
-            2..=i8::MAX => Some(Level::TRACE),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Default, clap::Args)]
 pub(crate) struct ManifestOptions {
     /// Path to Cargo.toml.
-    #[clap(long, short = 'm', value_name = "PATH")]
+    #[arg(long, short = 'm', value_name = "PATH")]
     pub(crate) manifest_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Default, clap::Args)]
 pub(crate) struct PackageSelection {
     /// Synchronize all packages in the workspace.
-    #[clap(long)]
+    #[arg(long)]
     pub(crate) workspace: bool,
 
     /// Package(s) to synchronize.
-    #[clap(long = "package", short = 'p', value_name = "SPEC")]
+    #[arg(long = "package", short = 'p', value_name = "SPEC")]
     pub(crate) packages: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, clap::Args)]
 pub(crate) struct FeatureSelection {
     /// Space or comma separated list of features to activate.
-    #[clap(long, short = 'F', value_name = "FEATURES")]
+    #[arg(long, short = 'F', value_name = "FEATURES")]
     pub(crate) features: Vec<String>,
 
     /// Activate all available features.
-    #[clap(long)]
+    #[arg(long)]
     pub(crate) all_features: bool,
 
     /// Do not activate the `default` feature.
-    #[clap(long)]
+    #[arg(long)]
     pub(crate) no_default_features: bool,
 }
 
 #[derive(Debug, Clone, Default, clap::Args)]
 pub(crate) struct RustdocToolchainArgs {
     /// Toolchain name to run `cargo rustdoc` with.
-    #[clap(long)]
+    #[arg(long)]
     pub(crate) toolchain: Option<String>,
     /// Install the Rust toolchain specified by `--toolchain` if it is not already installed.
-    #[clap(long)]
+    #[arg(long)]
     pub(crate) install_toolchain: bool,
 }
 
@@ -117,7 +83,7 @@ pub(crate) enum Mode {
 #[derive(Debug, Clone, Default, clap::Args)]
 pub(crate) struct ModeArgs {
     /// Check whether target files are up to date.
-    #[clap(long)]
+    #[arg(long)]
     check: bool,
 }
 
@@ -130,12 +96,24 @@ impl ModeArgs {
 #[derive(Debug, Clone, Default, clap::Args)]
 pub(crate) struct FixArgs {
     /// Synchronize target files even if no VCS was detected.
-    #[clap(long)]
+    #[arg(long)]
     pub(crate) allow_no_vcs: bool,
     /// Synchronize target files even if one is dirty.
-    #[clap(long)]
+    #[arg(long)]
     pub(crate) allow_dirty: bool,
     /// Synchronize target files even if one has staged changes.
-    #[clap(long)]
+    #[arg(long)]
     pub(crate) allow_staged: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory as _;
+
+    use super::*;
+
+    #[test]
+    fn verify_args() {
+        Args::command().debug_assert();
+    }
 }


### PR DESCRIPTION
## Summary
- use `clap_cargo::style::CLAP_STYLING` so `--help` uses the same styling as Cargo
- replace the custom verbosity parser with `clap-verbosity-flag`
- switch from legacy `#[clap(...)]` attributes to `#[arg(...)]` and `#[command(...)]`
- add `Args::command().debug_assert()` coverage for the clap definition

## User-visible changes
- `--help` now uses Cargo-style clap styling

## Validation
- `cargo test`
- `cargo test verify_args -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- manual checks with `cargo run -- --help`, `cargo run -- --color always --help`, `cargo run -- -v -q`, and `cargo run -- -v -q --version`