### PR TITLE
Migrate test helpers to Snapbox

### DIFF
--- a/.mise/tasks/rust.toml
+++ b/.mise/tasks/rust.toml
@@ -100,3 +100,9 @@ cargo llvm-cov --all-features
   {{- ' --output-path ' ~ usage.output_path if usage.output_path else '' }}
   {{- '' }} run -- --workspace --toolchain nightly --check
 '''
+
+[update-ui-test-snapshots]
+description = "Update UI test snapshots"
+depends = ["install-toolchains-for-rust-test"]
+env = { SNAPSHOTS = "overwrite" }
+run = "cargo test --test ui"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "anstyle-lossy"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9ca7d0f520afcd6d817970d0b2d5fd7c630c75e7783cae046b8b8a783c5befa"
+dependencies = [
+ "anstyle",
+]
+
+[[package]]
 name = "anstyle-parse"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +78,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "anstyle-svg"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab68e0b71ea68eb6b399ffe1957f26330aeed91f5e578d442a1c2f3df69f6ec1"
+dependencies = [
+ "anstyle",
+ "anstyle-lossy",
+ "anstyle-parse",
+ "html-escape",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -89,37 +111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "assert_cmd"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
-dependencies = [
- "anstream",
- "anstyle",
- "bstr",
- "libc",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
-name = "assert_fs"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ecf5c70ca07b7f80220bce936f0556a960ca6fb00fc2bd4125b5e581b218137"
-dependencies = [
- "anstream",
- "anstyle",
- "globwalk",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "tempfile",
 ]
 
 [[package]]
@@ -245,7 +236,6 @@ dependencies = [
 name = "cargo-sync-rdme"
 version = "0.7.0"
 dependencies = [
- "assert_fs",
  "cargo_metadata",
  "clap",
  "clap-cargo",
@@ -266,6 +256,7 @@ dependencies = [
  "similar",
  "similar-asserts",
  "snafu",
+ "snapbox",
  "supports-color",
  "tempfile",
  "test-helper",
@@ -424,6 +415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,25 +446,6 @@ name = "crossbeam-channel"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -573,12 +554,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -1566,30 +1541,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
-name = "globset"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags 2.13.1",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1592,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "html-escape"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9356095b4b41197bba32173600e1582792cda618f65d12f68e2e77d273413c5"
 
 [[package]]
 name = "html5ever"
@@ -1754,22 +1711,6 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "ignore"
-version = "0.4.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
 ]
 
 [[package]]
@@ -1986,6 +1927,12 @@ name = "nonempty"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2212,33 +2159,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "predicates"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
-dependencies = [
- "anstyle",
- "difflib",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -2665,6 +2585,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "snapbox"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de56eb4784a2c5c1efede55a0f06fbf481bc12b42b355b9525c15db1e3581a8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "anstyle-svg",
+ "content_inspector",
+ "dunce",
+ "filetime",
+ "normalize-line-endings",
+ "serde_json",
+ "similar",
+ "snapbox-macros",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4a172e483585ebbc7c7f7d1705ca7e3f94f606ed78caa14805673189fd5455"
+dependencies = [
+ "anstream",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,20 +2736,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
 name = "test-helper"
 version = "0.1.0"
 dependencies = [
- "assert_cmd",
- "assert_fs",
  "cargo_metadata",
  "pulldown-cmark",
  "scraper",
+ "snapbox",
 ]
 
 [[package]]
@@ -3094,15 +3036,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,6 @@ repository = "https://github.com/gifnksm/cargo-sync-rdme"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-assert_cmd = { version = "2.2.2", features = ["color-auto"] }
-assert_fs = { version = "1.1.4", features = ["color-auto"] }
 cargo_metadata = "0.23.1"
 clap = { version = "4.6.6", features = ["derive"] }
 clap-cargo = { version = "0.18.3" }
@@ -72,6 +70,7 @@ serde_yaml = "0.9.34"
 similar = { version = "3.2.0", features = ["inline", "unicode"] }
 similar-asserts = "2.0.0"
 snafu = "0.9.2"
+snapbox = { version = "1.2.2", features = ["dir", "term-svg"] }
 supports-color = "3.0.2"
 tempfile = "3.27.0"
 test-helper = { path = "crates/test-helper" }
@@ -154,10 +153,10 @@ vcs-modify-guard.workspace = true
 void.workspace = true
 
 [dev-dependencies]
-assert_fs.workspace = true
 indoc.workspace = true
 rstest.workspace = true
 similar-asserts.workspace = true
+snapbox.workspace = true
 test-helper.workspace = true
 
 [build-dependencies]

--- a/crates/test-helper/Cargo.toml
+++ b/crates/test-helper/Cargo.toml
@@ -8,11 +8,10 @@ license.workspace = true
 publish = false
 
 [dependencies]
-assert_cmd.workspace = true
-assert_fs.workspace = true
 cargo_metadata.workspace = true
 pulldown-cmark.workspace = true
 scraper.workspace = true
+snapbox = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/test-helper/src/lib.rs
+++ b/crates/test-helper/src/lib.rs
@@ -10,11 +10,13 @@ use std::{
     sync::LazyLock,
 };
 
-use assert_cmd::{Command, assert::Assert};
-use assert_fs::{TempDir, fixture::ChildPath, prelude::*};
 use cargo_metadata::{Metadata, MetadataCommand};
 use pulldown_cmark::{Event, Parser, Tag, TagEnd, TextMergeStream};
 use scraper::{Html, Selector};
+use snapbox::{
+    cmd::{Command, OutputAssert},
+    dir::DirRoot,
+};
 
 pub const SPAN_START_MARKER: &str = "<!-- SYNC_RDME_INTEGRATION_TEST::SPAN_START -->";
 pub const SPAN_END_MARKER: &str = "<!-- SYNC_RDME_INTEGRATION_TEST::SPAN_END -->";
@@ -22,7 +24,7 @@ pub const HTML_ROOT_URL: &str = "https://example.com/html_root/";
 
 #[derive(Debug)]
 pub struct Workspace {
-    temp_dir: TempDir,
+    root: DirRoot,
     metadata: Metadata,
 }
 
@@ -32,27 +34,20 @@ impl AsRef<Path> for Workspace {
     }
 }
 
-impl PathChild for Workspace {
-    fn child<P>(&self, path: P) -> ChildPath
-    where
-        P: AsRef<Path>,
-    {
-        self.temp_dir.child(path)
-    }
-}
-
 impl Workspace {
     #[must_use]
     pub fn from_fixture(fixture_name: &str) -> Self {
-        let temp_dir = TempDir::new().unwrap();
-        copy_package_fixtures(&temp_dir, fixture_name);
-        let metadata = get_workspace_metadata(temp_dir.path());
-        Self { temp_dir, metadata }
+        let root = DirRoot::mutable_temp()
+            .unwrap()
+            .with_template(&package_fixture_path(fixture_name))
+            .unwrap();
+        let metadata = get_workspace_metadata(root.path().unwrap());
+        Self { root, metadata }
     }
 
     #[must_use]
     pub fn root_path(&self) -> &Path {
-        self.temp_dir.path()
+        self.root.path().unwrap()
     }
 
     #[must_use]
@@ -67,7 +62,7 @@ impl Workspace {
         assert!(!doc_comment.is_empty());
         assert!(doc_comment.ends_with('\n'));
 
-        let librs_path = self.child(path);
+        let librs_path = self.root_path().join(path);
         let content = fs::read_to_string(&librs_path).unwrap();
         let new_content = format!("{doc_comment}{content}");
         fs::write(&librs_path, &new_content).unwrap();
@@ -75,7 +70,7 @@ impl Workspace {
 
     #[must_use]
     pub fn cargo_sync_rdme(&self) -> CargoSyncRdme<'_> {
-        CargoSyncRdme::new(self)
+        CargoSyncRdme::new_in_workspace(self)
     }
 
     #[must_use]
@@ -87,12 +82,12 @@ impl Workspace {
 
     #[must_use]
     pub fn cargo_doc(&self) -> CargoDoc<'_> {
-        CargoDoc::new(self)
+        CargoDoc::new_in_workspace(self)
     }
 
     #[must_use]
     pub fn cargo_doc_default(&self) -> CargoDoc<'_> {
-        let mut cmd = CargoDoc::new(self);
+        let mut cmd = CargoDoc::new_in_workspace(self);
         cmd.workspace();
         cmd
     }
@@ -118,19 +113,21 @@ static PATH_ENV: LazyLock<OsString> = LazyLock::new(|| {
     env::join_paths(iter::once(SYNC_RDME_EXE_DIR.to_path_buf()).chain(path_env)).unwrap()
 });
 
-fn copy_package_fixtures(tempdir: &TempDir, fixture_name: &str) {
-    let project_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let src = PathBuf::from(format!(
-        "{project_manifest_dir}/tests/fixtures/packages/{fixture_name}"
-    ));
+#[must_use]
+pub fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("tests")
+        .join("fixtures")
+}
 
-    assert!(
-        src.is_dir(),
-        "package fixture directory does not exist: {}",
-        src.display()
-    );
+#[must_use]
+pub fn snapshot_path(fixture_name: &str) -> PathBuf {
+    fixtures_dir().join("snapshots").join(fixture_name)
+}
 
-    tempdir.copy_from(src, &["**/*"]).unwrap();
+#[must_use]
+pub fn package_fixture_path(fixture_name: &str) -> PathBuf {
+    fixtures_dir().join("packages").join(fixture_name)
 }
 
 fn get_workspace_metadata(path: &Path) -> Metadata {
@@ -142,43 +139,46 @@ fn get_workspace_metadata(path: &Path) -> Metadata {
 }
 
 fn cargo_command(toolchain: Option<&'static str>) -> Command {
-    let mut cmd;
     if let Some(toolchain) = toolchain {
-        cmd = Command::new("rustup");
-        cmd.args(["run", toolchain, "cargo"]);
+        Command::new("rustup").args(["run", toolchain, "cargo"])
     } else {
-        cmd = Command::new(&*CARGO);
+        Command::new(&*CARGO)
     }
-    cmd.env("PATH", &*PATH_ENV);
-    cmd
+    .env("PATH", &*PATH_ENV)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CargoSyncRdme<'a> {
-    workspace: &'a Workspace,
+    workspace_root: Option<&'a Path>,
     current_dir: Option<PathBuf>,
     cargo_toolchain: Option<&'static str>,
     args: Vec<OsString>,
+    envs: Vec<(OsString, OsString)>,
 }
 
 impl<'a> CargoSyncRdme<'a> {
     #[must_use]
-    pub fn new(workspace: &'a Workspace) -> Self {
+    pub fn new_in_workspace(workspace: &'a Workspace) -> Self {
         Self {
-            workspace,
-            current_dir: None,
-            cargo_toolchain: None,
-            args: vec![],
+            workspace_root: Some(workspace.root_path()),
+            current_dir: Some(workspace.root_path().to_path_buf()),
+            ..Self::default()
         }
     }
 
-    pub fn current_dir<P>(&mut self, path: P) -> &mut Self
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn current_dir<P>(&mut self, subpath: P) -> &mut Self
     where
         P: AsRef<Path>,
     {
-        let path = path.as_ref();
+        let workspace = self.workspace_root.unwrap();
+        let path = subpath.as_ref();
         assert!(path.is_relative());
-        self.current_dir = Some(path.to_owned());
+        self.current_dir = Some(workspace.join(path));
         self
     }
 
@@ -197,6 +197,11 @@ impl<'a> CargoSyncRdme<'a> {
         self
     }
 
+    pub fn force_color(&mut self) -> &mut Self {
+        self.envs([("CLICOLOR_FORCE", "1")]);
+        self
+    }
+
     pub fn args<I>(&mut self, args: I) -> &mut Self
     where
         I: IntoIterator,
@@ -207,34 +212,64 @@ impl<'a> CargoSyncRdme<'a> {
         self
     }
 
+    pub fn envs<I, K, V>(&mut self, envs: I) -> &mut Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.envs.extend(
+            envs.into_iter()
+                .map(|(k, v)| (k.as_ref().to_owned(), v.as_ref().to_owned())),
+        );
+        self
+    }
+
     #[must_use]
-    pub fn assert(&self) -> Assert {
-        let mut cmd = cargo_command(self.cargo_toolchain);
-        cmd.arg("sync-rdme").args(&self.args);
+    pub fn assert(&self) -> OutputAssert {
+        let mut cmd = cargo_command(self.cargo_toolchain)
+            .arg("sync-rdme")
+            .args(&self.args)
+            .envs(self.envs.iter().map(|(k, v)| (k, v)));
         if let Some(current_dir) = &self.current_dir {
-            cmd.current_dir(self.workspace.child(current_dir));
-        } else {
-            cmd.current_dir(self.workspace.root_path());
+            cmd = cmd.current_dir(current_dir);
         }
         cmd.assert()
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CargoDoc<'a> {
-    workspace: &'a Workspace,
+    workspace_root: Option<&'a Path>,
+    current_dir: Option<PathBuf>,
     cargo_toolchain: Option<&'static str>,
     args: Vec<OsString>,
 }
 
 impl<'a> CargoDoc<'a> {
     #[must_use]
-    pub fn new(workspace: &'a Workspace) -> Self {
+    pub fn new_in_workspace(workspace: &'a Workspace) -> Self {
         Self {
-            workspace,
-            cargo_toolchain: None,
-            args: vec![],
+            workspace_root: Some(workspace.root_path()),
+            current_dir: Some(workspace.root_path().to_path_buf()),
+            ..Self::default()
         }
+    }
+
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn current_dir<P>(&mut self, subpath: P) -> &mut Self
+    where
+        P: AsRef<Path>,
+    {
+        let workspace = self.workspace_root.unwrap();
+        let path = subpath.as_ref();
+        assert!(path.is_relative());
+        self.current_dir = Some(workspace.join(path));
+        self
     }
 
     pub fn cargo_toolchain(&mut self, toolchain: &'static str) -> &mut Self {
@@ -258,14 +293,12 @@ impl<'a> CargoDoc<'a> {
     }
 
     #[must_use]
-    pub fn assert(&self) -> Assert {
-        let result = cargo_command(self.cargo_toolchain)
-            .current_dir(self.workspace.root_path())
-            .arg("doc")
-            .args(&self.args)
-            .assert();
-        eprintln!("{result}");
-        result
+    pub fn assert(&self) -> OutputAssert {
+        let mut cmd = cargo_command(self.cargo_toolchain);
+        if let Some(current_dir) = &self.current_dir {
+            cmd = cmd.current_dir(current_dir);
+        }
+        cmd.arg("doc").args(&self.args).assert()
     }
 }
 

--- a/tests/fixtures/snapshots/help.stdout.term.svg
+++ b/tests/fixtures/snapshots/help.stdout.term.svg
@@ -1,0 +1,83 @@
+<svg width="1154px" height="542px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>Cargo subcommand to synchronize a package README and additional configured Markdown files with package metadata and crate documentation</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo sync-rdme</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>             Increase logging verbosity</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan class="fg-cyan">...</tspan><tspan>               Decrease logging verbosity</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>           Coloring [default: auto] [possible values: auto, always, never]</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name to run `cargo rustdoc` with</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--install-toolchain</tspan><tspan>      Install the Rust toolchain specified by `--toolchain` if it is not already installed</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--check</tspan><tspan>                  Check whether target files are up to date</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-no-vcs</tspan><tspan>           Synchronize target files even if no VCS was detected</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-dirty</tspan><tspan>            Synchronize target files even if one is dirty</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-staged</tspan><tspan>           Synchronize target files even if one has staged changes</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-V</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--version</tspan><tspan>                Print version</tspan>
+</tspan>
+    <tspan x="10px" y="316px">
+</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>       Synchronize all packages in the workspace</tspan>
+</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>  Package(s) to synchronize</tspan>
+</tspan>
+    <tspan x="10px" y="388px">
+</tspan>
+    <tspan x="10px" y="406px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
+</tspan>
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+</tspan>
+    <tspan x="10px" y="478px">
+</tspan>
+    <tspan x="10px" y="496px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
+</tspan>
+    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-m</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+</tspan>
+    <tspan x="10px" y="532px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,0 +1,18 @@
+//! Integration test for CLI output snapshots.
+
+use snapbox::Data;
+use test_helper::{self as helper, CargoSyncRdme};
+
+#[test]
+fn help_matches_snapshot() {
+    CargoSyncRdme::new()
+        .force_color()
+        .args(["--help"])
+        .assert()
+        .success()
+        .stdout_eq(Data::read_from(
+            &helper::snapshot_path("help.stdout.term.svg"),
+            None,
+        ))
+        .stderr_eq("");
+}


### PR DESCRIPTION
## Summary
- migrate the test helper crate from `assert_cmd` / `assert_fs` to `snapbox`
- add an initial CLI snapshot test that verifies the `cargo sync-rdme --help` output
- add a `mise` task to refresh the generated UI snapshot

## Motivation
This starts the move to `snapbox`-based UI testing and establishes a first snapshot around the help output.

## Validation
- `cargo fmt --check`
- `cargo test`

## Impact
No user-facing behavior change in the main binary. This only changes test infrastructure and adds a snapshot-based test for CLI output.
