### PR TITLE
Update help text and snapshot tests

### DIFF
--- a/crates/test-helper/src/lib.rs
+++ b/crates/test-helper/src/lib.rs
@@ -14,7 +14,7 @@ use cargo_metadata::{Metadata, MetadataCommand};
 use pulldown_cmark::{Event, Parser, Tag, TagEnd, TextMergeStream};
 use scraper::{Html, Selector};
 use snapbox::{
-    cmd::{Command, OutputAssert},
+    cmd::{self, Command, OutputAssert},
     dir::DirRoot,
 };
 
@@ -99,7 +99,7 @@ static CARGO: LazyLock<PathBuf> = LazyLock::new(|| {
 });
 
 static SYNC_RDME_EXE: LazyLock<PathBuf> = LazyLock::new(|| {
-    let exe = PathBuf::from(env::var_os("CARGO_BIN_EXE_cargo-sync-rdme").unwrap());
+    let exe = cmd::cargo_bin("cargo-sync-rdme");
     assert_eq!(exe.file_prefix().unwrap(), "cargo-sync-rdme");
     exe
 });

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::ColorChoice;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 
-/// Cargo subcommand to synchronize a package README and additional configured Markdown files with package metadata and crate documentation.
+/// Synchronize a package README and additional configured Markdown files with package metadata and crate documentation.
 #[derive(Debug, Clone, Default, clap::Parser)]
 #[command(
     name = "cargo-sync-rdme",

--- a/tests/fixtures/snapshots/help.stdout.term.svg
+++ b/tests/fixtures/snapshots/help.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1154px" height="542px" xmlns="http://www.w3.org/2000/svg">
+<svg width="986px" height="542px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -20,7 +20,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Cargo subcommand to synchronize a package README and additional configured Markdown files with package metadata and crate documentation</tspan>
+    <tspan x="10px" y="28px"><tspan>Synchronize a package README and additional configured Markdown files with package metadata and crate documentation</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,7 +1,14 @@
 //! Integration test for CLI output snapshots.
 
-use snapbox::Data;
+use snapbox::{Data, data::DataFormat};
 use test_helper::{self as helper, CargoSyncRdme};
+
+fn expected(fixture_name: &str) -> Data {
+    Data::read_from(
+        &helper::snapshot_path(&format!("{fixture_name}.term.svg")),
+        Some(DataFormat::TermSvg),
+    )
+}
 
 #[test]
 fn help_matches_snapshot() {
@@ -10,9 +17,6 @@ fn help_matches_snapshot() {
         .args(["--help"])
         .assert()
         .success()
-        .stdout_eq(Data::read_from(
-            &helper::snapshot_path("help.stdout.term.svg"),
-            None,
-        ))
+        .stdout_eq(expected("help.stdout"))
         .stderr_eq("");
 }


### PR DESCRIPTION
## Summary
- shorten the top-level `cargo sync-rdme --help` description
- update the help snapshot to match the new output
- refactor the UI snapshot test helper to load `.term.svg` fixtures explicitly as `TermSvg`
- resolve the test binary with `snapbox::cmd::cargo_bin`

## Validation
- `cargo test --test ui`
- `cargo test --tests`

## User-visible impact
- the first line of `cargo sync-rdme --help` is shorter and reads more naturally