### PR TITLE
Improve marker parse diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * When `--color` is not specified, colored output now follows whether stderr is connected to a terminal and respects the `NO_COLOR` and `FORCE_COLOR` environment variables.
 * Respect the `CARGO` environment variable when invoking Cargo to build rustdoc output, except when `--toolchain` is specified.
 * When neither `--package` nor `--workspace` is specified, select Cargo's default workspace packages instead of always syncing only the workspace root package.
+* Remove timestamps from messages shown during synchronization.
+* Improve diagnostics for invalid `<!-- cargo-sync-rdme ... -->` markers.
 
 ## [0.7.0] - 2026-08-11
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,7 @@ fn install_logger(verbosity: Option<Level>, use_color: bool, stream: Stream) {
         .with_ansi(use_color)
         .with_writer(writer)
         .with_target(false)
+        .without_time()
         .init();
 }
 

--- a/src/sync/marker/find.rs
+++ b/src/sync/marker/find.rs
@@ -4,7 +4,7 @@ use miette::{NamedSource, SourceSpan};
 use pulldown_cmark::Event;
 use snafu::{OptionExt as _, Snafu, ensure};
 
-use crate::sync::ManifestFile;
+use crate::sync::{ManifestFile, MarkdownPath};
 
 use super::{super::MarkdownFile, Marker, ParseMarkerError, ReplaceSpecifier};
 
@@ -12,7 +12,7 @@ pub(in super::super) fn find_all<'events>(
     markdown: &MarkdownFile<'_>,
     manifest: &ManifestFile,
     events: impl IntoIterator<Item = (Event<'events>, Range<usize>)> + 'events,
-) -> Result<Vec<(ReplaceSpecifier, Range<usize>)>, FindAllError> {
+) -> Result<Vec<(ReplaceSpecifier, Range<usize>)>, Box<FindAllError>> {
     let events = events.into_iter();
     let it = Iter { manifest, events };
     let mut markers = vec![];
@@ -27,6 +27,7 @@ pub(in super::super) fn find_all<'events>(
     ensure!(
         errors.is_empty(),
         FindAllSnafu {
+            markdown,
             source_code: markdown.to_named_source(),
             errors
         }
@@ -36,8 +37,12 @@ pub(in super::super) fn find_all<'events>(
 }
 
 #[derive(Debug, Snafu, miette::Diagnostic)]
-#[snafu(display("failed to parse cargo-sync-rdme markers"))]
+#[snafu(display(
+    "failed to parse `<!-- cargo-sync-rdme ... -->` markers in markdown file for package `{package}`: {markdown}",
+    package = markdown.package, markdown = markdown.path,
+))]
 pub(crate) struct FindAllError {
+    markdown: MarkdownPath,
     #[source_code]
     source_code: NamedSource<Arc<str>>,
     #[related]

--- a/src/sync/marker/mod.rs
+++ b/src/sync/marker/mod.rs
@@ -21,31 +21,37 @@ pub(super) enum ReplaceSpecifier {
     Rustdoc,
 }
 
-#[derive(Debug, Snafu)]
-pub(super) enum ParseReplaceSpecifierError {
-    #[snafu(display("unknown replacement specifier: {specifier:?}"))]
-    UnknownReplaceSpecifier { specifier: String },
-    #[snafu(display("badge group not found in the package manifest: package.metadata.cargo-sync-rdme.badge.badges{hyphen}{group}", hyphen = if group.is_empty() { "" } else { "-" }))]
-    NoSuchBadgeGroup { group: String },
-}
-
 impl ReplaceSpecifier {
     fn from_str(
-        specifier: &str,
+        specifier: (&str, SourceSpan),
         manifest: &ManifestFile,
-    ) -> Result<Self, ParseReplaceSpecifierError> {
-        let group = match specifier {
+    ) -> Result<Self, ParseMarkerError> {
+        let group = match specifier.0 {
             "title" => return Ok(Self::Title),
             "rustdoc" => return Ok(Self::Rustdoc),
-            "badge" => "",
+            "badge" => {
+                let end = specifier.1.offset() + specifier.1.len();
+                ("", SourceSpan::from((end, 0)))
+            }
             _ => specifier
-                .strip_prefix("badge:")
-                .context(UnknownReplaceSpecifierSnafu { specifier })?,
+                .strip_prefix_str("badge:")
+                .context(UnknownReplaceSpecifierSnafu {
+                    specifier: specifier.0,
+                    span: specifier.1,
+                })?,
         };
         let badges = &manifest.value().config().badge.badges;
-        let (name, badges) = badges
-            .get_key_value(group)
-            .context(NoSuchBadgeGroupSnafu { group })?;
+        let (name, badges) = badges.get_key_value(group.0).ok_or_else(|| {
+            if group.0.is_empty() {
+                NoDefaultBadgeConfiguredSnafu { span: specifier.1 }.build()
+            } else {
+                NoSuchBadgeGroupSnafu {
+                    group: group.0,
+                    span: group.1,
+                }
+                .build()
+            }
+        })?;
         Ok(Self::Badge {
             name: Arc::clone(name),
             badges: Arc::clone(badges),
@@ -90,10 +96,24 @@ impl fmt::Display for Marker {
 
 #[derive(Debug, Snafu, miette::Diagnostic)]
 pub(super) enum ParseMarkerError {
-    #[snafu(display("{source}"))]
-    ParseReplace {
-        #[snafu(source)]
-        source: ParseReplaceSpecifierError,
+    #[snafu(display("unknown replacement specifier: {specifier}"))]
+    UnknownReplaceSpecifier {
+        specifier: String,
+        #[label]
+        span: SourceSpan,
+    },
+    #[snafu(display(
+        "default badge group is not configured in the package manifest: package.metadata.cargo-sync-rdme.badge.badges"
+    ))]
+    NoDefaultBadgeConfigured {
+        #[label]
+        span: SourceSpan,
+    },
+    #[snafu(display(
+        "badge group not found in the package manifest: package.metadata.cargo-sync-rdme.badge.badges-{group}"
+    ))]
+    NoSuchBadgeGroup {
+        group: String,
         #[label]
         span: SourceSpan,
     },
@@ -102,12 +122,6 @@ pub(super) enum ParseMarkerError {
         #[label]
         span: SourceSpan,
     },
-}
-
-impl From<(ParseReplaceSpecifierError, SourceSpan)> for ParseMarkerError {
-    fn from((err, span): (ParseReplaceSpecifierError, SourceSpan)) -> Self {
-        Self::ParseReplace { source: err, span }
-    }
 }
 
 impl Marker {
@@ -122,8 +136,7 @@ impl Marker {
         // <replace> [[
         if let Some(replace) = body.strip_suffix_str("[[") {
             let replace = replace.trim();
-            let replace =
-                ReplaceSpecifier::from_str(replace.0, manifest).map_err(|err| (err, replace.1))?;
+            let replace = ReplaceSpecifier::from_str(replace, manifest)?;
             return Ok(Some(Marker::Start(replace)));
         }
 
@@ -131,7 +144,7 @@ impl Marker {
             return Ok(Some(Marker::End));
         }
 
-        let replace = ReplaceSpecifier::from_str(body.0, manifest).map_err(|err| (err, body.1))?;
+        let replace = ReplaceSpecifier::from_str(body, manifest)?;
         Ok(Some(Marker::Replace(replace)))
     }
 
@@ -187,10 +200,7 @@ mod tests {
             let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
             let span = SourceSpan::from(0..s.len());
             match Marker::matches((s, span), &manifest).unwrap_err() {
-                ParseMarkerError::ParseReplace {
-                    source: ParseReplaceSpecifierError::UnknownReplaceSpecifier { specifier: s },
-                    ..
-                } => s,
+                ParseMarkerError::UnknownReplaceSpecifier { specifier: s, .. } => s,
                 e => panic!("unexpected: {e}"),
             }
         }
@@ -203,7 +213,7 @@ mod tests {
             let span = SourceSpan::from(0..s.len());
             match Marker::matches((s, span), &manifest).unwrap_err() {
                 ParseMarkerError::NoReplaceSpecifier { .. } => {}
-                e @ ParseMarkerError::ParseReplace { .. } => panic!("unexpected: {e}"),
+                e => panic!("unexpected: {e}"),
             }
         }
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -56,7 +56,7 @@ pub(crate) enum SyncError {
     FindMarkers {
         #[snafu(source)]
         #[diagnostic_source]
-        source: marker::FindAllError,
+        source: Box<marker::FindAllError>,
     },
     #[snafu(transparent)]
     #[diagnostic(transparent)]
@@ -107,8 +107,8 @@ impl From<with_source::ReadFileError> for Box<SyncError> {
     }
 }
 
-impl From<marker::FindAllError> for Box<SyncError> {
-    fn from(value: marker::FindAllError) -> Self {
+impl From<Box<marker::FindAllError>> for Box<SyncError> {
+    fn from(value: Box<marker::FindAllError>) -> Self {
         Box::new(value.into())
     }
 }
@@ -148,7 +148,7 @@ pub(crate) fn sync_all(
     for path in paths {
         tracing::info!("syncing markdown file: {path}");
 
-        let mut markdown = MarkdownFile::new(package, path)?;
+        let mut markdown = MarkdownFile::new(workspace, package, path)?;
 
         // Setup markdown parser
         let parser = Parser::new_ext(&markdown.text, Options::all()).into_offset_iter();
@@ -201,10 +201,10 @@ pub(crate) struct MarkdownPath {
 }
 
 impl MarkdownPath {
-    fn new(package: &Package, path: &Utf8Path) -> Self {
+    fn new(package: &Package, path: Utf8PathBuf) -> Self {
         Self {
             package: package.name.clone(),
-            path: path.to_path_buf(),
+            path,
         }
     }
 }
@@ -213,7 +213,7 @@ impl From<&MarkdownFile<'_>> for MarkdownPath {
     fn from(markdown: &MarkdownFile<'_>) -> Self {
         Self {
             package: markdown.package.name.clone(),
-            path: markdown.relative_path.to_owned(),
+            path: markdown.relative_path.clone(),
         }
     }
 }
@@ -221,17 +221,24 @@ impl From<&MarkdownFile<'_>> for MarkdownPath {
 #[derive(Debug, Clone)]
 struct MarkdownFile<'a> {
     package: &'a Package,
-    relative_path: &'a Utf8Path,
+    relative_path: Utf8PathBuf,
     path: Utf8PathBuf,
     text: Arc<str>,
 }
 
 impl<'a> MarkdownFile<'a> {
-    fn new(package: &'a Package, relative_path: &'a Utf8Path) -> Result<Self, Box<SyncError>> {
-        let path = package.root_directory().join(relative_path);
+    fn new(
+        workspace: &'a Metadata,
+        package: &'a Package,
+        package_relative_path: &'a Utf8Path,
+    ) -> Result<Self, Box<SyncError>> {
+        let relative_path = package
+            .workspace_relative_root_directory(workspace)
+            .join(package_relative_path);
+        let path = workspace.workspace_root.join(&relative_path);
         let text = fs::read_to_string(&path)
             .with_context(|_source| ReadMarkdownFileSnafu {
-                markdown: MarkdownPath::new(package, relative_path),
+                markdown: MarkdownPath::new(package, relative_path.clone()),
             })?
             .into();
         Ok(Self {
@@ -243,7 +250,7 @@ impl<'a> MarkdownFile<'a> {
     }
 
     fn to_named_source(&self) -> NamedSource<Arc<str>> {
-        NamedSource::new(self.path.clone(), Arc::clone(&self.text))
+        NamedSource::new(&self.relative_path, Arc::clone(&self.text))
     }
 
     fn replace(&mut self, new_text: Arc<str>) -> Result<(), Box<SyncError>> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,16 +1,25 @@
-use cargo_metadata::{Package, camino::Utf8Path};
+use cargo_metadata::{Metadata, Package, camino::Utf8Path};
 use miette::SourceSpan;
 
 /// Extension methods for [`cargo_metadata::Package`].
 pub(crate) trait PackageExt {
     /// Returns the package root directory.
     fn root_directory(&self) -> &Utf8Path;
+    /// Returns the package root directory as a workspace-relative path.
+    fn workspace_relative_root_directory<'a>(&'a self, workspace: &Metadata) -> &'a Utf8Path;
 }
 
 impl PackageExt for Package {
     fn root_directory(&self) -> &Utf8Path {
         // `manifest_path` is the path to the manifest file, so parent must exist.
         self.manifest_path.parent().unwrap()
+    }
+
+    fn workspace_relative_root_directory<'a>(&'a self, workspace: &Metadata) -> &'a Utf8Path {
+        let root_dir = self.root_directory();
+        root_dir
+            .strip_prefix(&workspace.workspace_root)
+            .unwrap_or(root_dir)
     }
 }
 

--- a/tests/fixtures/snapshots/marker_parse_error_pkg-a.stderr.term.svg
+++ b/tests/fixtures/snapshots/marker_parse_error_pkg-a.stderr.term.svg
@@ -1,0 +1,110 @@
+<svg width="740px" height="758px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-cyan { fill: #00AAAA }
+    .fg-green { fill: #00AA00 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    .dimmed { opacity: 0.4; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse `&lt;!-- cargo-sync-rdme ... --&gt;` markers in markdown file</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> for package `pkg-a`: pkg-a/README.md</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+    <tspan x="10px" y="100px"><tspan>Error: </tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> no replacement specifier found</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:1:6</tspan><tspan>]</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">1</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>   · </tspan><tspan class="fg-magenta bold">     ───────────────</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan> </tspan><tspan class="dimmed">2</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="226px">
+</tspan>
+    <tspan x="10px" y="244px"><tspan>Error: </tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown replacement specifier: unknown-specifier</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:2:22</tspan><tspan>]</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan> </tspan><tspan class="dimmed">1</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="316px"><tspan> </tspan><tspan class="dimmed">2</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="334px"><tspan>   · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan> </tspan><tspan class="dimmed">3</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="370px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="388px">
+</tspan>
+    <tspan x="10px" y="406px"><tspan>Error: </tspan>
+</tspan>
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
+</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
+</tspan>
+    <tspan x="10px" y="460px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:5:22</tspan><tspan>]</tspan>
+</tspan>
+    <tspan x="10px" y="478px"><tspan> </tspan><tspan class="dimmed">4</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="496px"><tspan> </tspan><tspan class="dimmed">5</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="514px"><tspan>   · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
+</tspan>
+    <tspan x="10px" y="532px"><tspan> </tspan><tspan class="dimmed">6</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="550px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="568px">
+</tspan>
+    <tspan x="10px" y="586px"><tspan>Error: </tspan>
+</tspan>
+    <tspan x="10px" y="604px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
+</tspan>
+    <tspan x="10px" y="622px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
+</tspan>
+    <tspan x="10px" y="640px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:6:28</tspan><tspan>]</tspan>
+</tspan>
+    <tspan x="10px" y="658px"><tspan> </tspan><tspan class="dimmed">5</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="676px"><tspan> </tspan><tspan class="dimmed">6</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="694px"><tspan>   · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
+</tspan>
+    <tspan x="10px" y="712px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="730px">
+</tspan>
+    <tspan x="10px" y="748px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/fixtures/snapshots/marker_parse_error_root.stderr.term.svg
+++ b/tests/fixtures/snapshots/marker_parse_error_root.stderr.term.svg
@@ -1,0 +1,110 @@
+<svg width="740px" height="758px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-cyan { fill: #00AAAA }
+    .fg-green { fill: #00AA00 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    .dimmed { opacity: 0.4; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse `&lt;!-- cargo-sync-rdme ... --&gt;` markers in markdown file</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> for package `root`: README.md</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+    <tspan x="10px" y="100px"><tspan>Error: </tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> no replacement specifier found</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:1:6</tspan><tspan>]</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">1</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>   · </tspan><tspan class="fg-magenta bold">     ───────────────</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan> </tspan><tspan class="dimmed">2</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="226px">
+</tspan>
+    <tspan x="10px" y="244px"><tspan>Error: </tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown replacement specifier: unknown-specifier</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:2:22</tspan><tspan>]</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan> </tspan><tspan class="dimmed">1</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="316px"><tspan> </tspan><tspan class="dimmed">2</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="334px"><tspan>   · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan> </tspan><tspan class="dimmed">3</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="370px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="388px">
+</tspan>
+    <tspan x="10px" y="406px"><tspan>Error: </tspan>
+</tspan>
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
+</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
+</tspan>
+    <tspan x="10px" y="460px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:5:22</tspan><tspan>]</tspan>
+</tspan>
+    <tspan x="10px" y="478px"><tspan> </tspan><tspan class="dimmed">4</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="496px"><tspan> </tspan><tspan class="dimmed">5</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="514px"><tspan>   · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
+</tspan>
+    <tspan x="10px" y="532px"><tspan> </tspan><tspan class="dimmed">6</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="550px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="568px">
+</tspan>
+    <tspan x="10px" y="586px"><tspan>Error: </tspan>
+</tspan>
+    <tspan x="10px" y="604px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
+</tspan>
+    <tspan x="10px" y="622px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
+</tspan>
+    <tspan x="10px" y="640px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:6:28</tspan><tspan>]</tspan>
+</tspan>
+    <tspan x="10px" y="658px"><tspan> </tspan><tspan class="dimmed">5</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="676px"><tspan> </tspan><tspan class="dimmed">6</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="694px"><tspan>   · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
+</tspan>
+    <tspan x="10px" y="712px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="730px">
+</tspan>
+    <tspan x="10px" y="748px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,7 +1,10 @@
 //! Integration test for CLI output snapshots.
 
+use std::{fs::File, io::Write as _};
+
+use rstest::rstest;
 use snapbox::{Data, data::DataFormat};
-use test_helper::{self as helper, CargoSyncRdme};
+use test_helper::{self as helper, CargoSyncRdme, Workspace};
 
 fn expected(fixture_name: &str) -> Data {
     Data::read_from(
@@ -19,4 +22,38 @@ fn help_matches_snapshot() {
         .success()
         .stdout_eq(expected("help.stdout"))
         .stderr_eq("");
+}
+
+#[rstest]
+#[case("root")]
+#[case("pkg-a")]
+fn marker_parse_errors_matches_snapshot(#[case] package: &str) {
+    let workspace = Workspace::from_fixture("workspace");
+    let readme_path = workspace
+        .metadata()
+        .workspace_packages()
+        .into_iter()
+        .find(|p| p.name == package)
+        .unwrap()
+        .readme()
+        .unwrap();
+
+    let mut file = File::create(readme_path).unwrap();
+    writeln!(&mut file, "<!-- cargo-sync-rdme -->").unwrap();
+    writeln!(&mut file, "<!-- cargo-sync-rdme unknown-specifier -->").unwrap();
+    writeln!(&mut file, "<!-- cargo-sync-rdme title -->").unwrap();
+    writeln!(&mut file, "<!-- cargo-sync-rdme rustdoc -->").unwrap();
+    writeln!(&mut file, "<!-- cargo-sync-rdme badge -->").unwrap();
+    writeln!(&mut file, "<!-- cargo-sync-rdme badge:invalid-group -->").unwrap();
+    file.flush().unwrap();
+    drop(file);
+
+    workspace
+        .cargo_sync_rdme_default()
+        .force_color()
+        .args(["-p", package])
+        .assert()
+        .failure()
+        .stdout_eq("")
+        .stderr_eq(expected(&format!("marker_parse_error_{package}.stderr")));
 }


### PR DESCRIPTION
## Summary
- improve diagnostics for invalid `cargo-sync-rdme` markers in Markdown files
- stop repeating the same marker-parse message in nested diagnostics
- distinguish between a missing default badge group and a missing named badge group
- show markdown file paths relative to the workspace in diagnostics
- remove timestamps from messages shown during synchronization
- add snapshot coverage for the updated output and document the changes in `CHANGELOG.md`

## Motivation
Marker parse output repeated some messages, did not distinguish some badge-related configuration errors, and showed less helpful file context for workspace member packages. This PR makes those diagnostics clearer, updates the messages shown during synchronization, and snapshot-tests the resulting output.

## Validation
- `cargo test --test ui marker_parse_errors_matches_snapshot`
- `cargo test`

## Impact
This PR changes marker parse diagnostics, messages shown during synchronization, and related snapshots. Successful synchronization behavior is unchanged.