### PR TITLE
Refine rustdoc logging output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Respect the `CARGO` environment variable when invoking Cargo to build rustdoc output, except when `--toolchain` is specified.
 * When neither `--package` nor `--workspace` is specified, select Cargo's default workspace packages instead of always syncing only the workspace root package.
 * Remove timestamps from messages shown during synchronization.
+* Refine the log messages shown during synchronization.
 * Improve diagnostics for invalid `<!-- cargo-sync-rdme ... -->` markers.
 
 ## [0.7.0] - 2026-08-11

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -12,7 +12,10 @@ use std::{
 use cargo_metadata::{Metadata, Package};
 use snafu::{OptionExt as _, ResultExt as _, Snafu, ensure};
 
-use crate::args::{FeatureSelection, ManifestOptions, PackageSelection, RustdocToolchainArgs};
+use crate::{
+    args::{FeatureSelection, ManifestOptions, PackageSelection, RustdocToolchainArgs},
+    traits::CommandExt as _,
+};
 
 pub(crate) fn command_path() -> Cow<'static, OsStr> {
     if let Some(cargo) = env::var_os("CARGO") {
@@ -210,16 +213,6 @@ pub(crate) enum ToolchainError {
     },
 }
 
-fn describe_command(cmd: &Command) -> OsString {
-    let mut s = OsString::new();
-    s.push(cmd.get_program());
-    for arg in cmd.get_args() {
-        s.push(" ");
-        s.push(arg);
-    }
-    s
-}
-
 pub(crate) fn toolchain(args: Option<&RustdocToolchainArgs>) -> Result<Toolchain, ToolchainError> {
     let mut cmd = if let Some(args) = args {
         command_for_build_doc(args)
@@ -230,26 +223,26 @@ pub(crate) fn toolchain(args: Option<&RustdocToolchainArgs>) -> Result<Toolchain
         .args(["--version", "--verbose"])
         .output()
         .with_context(|_source| CommandExecutionFailedSnafu {
-            commandline: describe_command(&cmd),
+            commandline: cmd.commandline(),
         })?;
     ensure!(
         output.status.success(),
         CommandFailedSnafu {
-            commandline: describe_command(&cmd),
+            commandline: cmd.commandline(),
             status: output.status,
             stderr: output.stderr,
         }
     );
     let stdout =
         String::from_utf8(output.stdout).with_context(|_source| InvalidUtf8OutputSnafu {
-            commandline: describe_command(&cmd),
+            commandline: cmd.commandline(),
             stderr: output.stderr.clone(),
         })?;
     let release_line = stdout
         .lines()
         .find_map(|line| line.trim().strip_prefix("release:"))
         .with_context(|| NoReleaseLineInOutputSnafu {
-            commandline: describe_command(&cmd),
+            commandline: cmd.commandline(),
             stderr: output.stderr,
         })?;
     let Ok(toolchain) = Toolchain::from_str(release_line.trim());

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,11 +54,12 @@ fn main() -> miette::Result<()> {
     });
 
     let args = Args::parse_from(args);
+    let verbosity = args.verbosity.into();
     let output_stream = Stream::Stderr;
     let use_color = should_use_color(args.color, output_stream);
     set_console_color(use_color, output_stream);
     set_miette_hook(use_color, output_stream);
-    install_logger(args.verbosity.into(), use_color, output_stream);
+    install_logger(verbosity, use_color, output_stream);
 
     let sync_options = SyncOptions {
         mode: args.mode.mode(),

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -1,8 +1,9 @@
-use std::process::ExitStatus;
+use std::{ffi::OsString, process::ExitStatus};
 
 use cargo_metadata::{Metadata, Package, PackageName};
 use pulldown_cmark::Options;
 use snafu::{OptionExt as _, ResultExt as _, Snafu, ensure};
+use tracing::Level;
 
 use crate::{
     cargo,
@@ -13,6 +14,7 @@ use crate::{
             intra_link::LinkMappingConfig,
         },
     },
+    traits::CommandExt as _,
     with_source::{ReadFileError, WithSource},
 };
 
@@ -25,13 +27,18 @@ type CreateResult<T> = Result<T, CreateRustdocError>;
 
 #[derive(Debug, Snafu, miette::Diagnostic)]
 pub(in super::super) enum CreateRustdocError {
-    #[snafu(display("failed to start rustdoc"))]
+    #[snafu(display("failed to start rustdoc: {}", commandline.display()))]
     StartRustdocProcess {
+        commandline: OsString,
         #[snafu(source)]
         source: std::io::Error,
     },
-    #[snafu(display("rustdoc exited with non-zero status code: {status}"))]
-    NonZeroExitStatus { status: ExitStatus },
+
+    #[snafu(display("rustdoc exited with status `{status}`: {}", commandline.display()))]
+    NonZeroExitStatus {
+        commandline: OsString,
+        status: ExitStatus,
+    },
     #[snafu(transparent)]
     #[diagnostic(transparent)]
     ReadFileError {
@@ -110,6 +117,9 @@ pub(super) fn create(
 
 fn run_rustdoc(package: &Package, options: &SyncOptions<'_>) -> CreateResult<()> {
     let mut command = cargo::command_for_build_doc(options.toolchain);
+    if !tracing::enabled!(Level::DEBUG) {
+        command.arg("-q");
+    }
     command
         .args(["rustdoc", "--package", &package.name])
         .args(cargo::feature_args(options.feature))
@@ -121,18 +131,20 @@ fn run_rustdoc(package: &Package, options: &SyncOptions<'_>) -> CreateResult<()>
             "--output-format=json",
         ]);
 
-    tracing::info!(
-        "executing rustdoc command: {}{}",
-        command.get_program().to_string_lossy(),
-        command.get_args().fold(String::new(), |mut s, a| {
-            s.push(' ');
-            s.push_str(a.to_string_lossy().as_ref());
-            s
-        })
+    let commandline = command.commandline();
+    tracing::debug!("executing rustdoc command: {}", commandline.display());
+    let status = command
+        .status()
+        .with_context(|_source| StartRustdocProcessSnafu {
+            commandline: &commandline,
+        })?;
+    ensure!(
+        status.success(),
+        NonZeroExitStatusSnafu {
+            commandline,
+            status,
+        }
     );
-
-    let status = command.status().context(StartRustdocProcessSnafu)?;
-    ensure!(status.success(), NonZeroExitStatusSnafu { status });
     Ok(())
 }
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -157,6 +157,7 @@ pub(crate) fn sync_all(
         let all_markers = marker::find_all(&markdown, &manifest, parser)?;
 
         // Create contents for each marker
+        tracing::info!("creating replacement contents for markdown file: {path}");
         let replaces = all_markers.iter().map(|x| x.0.clone());
         let all_contents = contents::create_all(replaces, &manifest, workspace, package, options)?;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,3 +1,5 @@
+use std::{ffi::OsString, process::Command};
+
 use cargo_metadata::{Metadata, Package, camino::Utf8Path};
 use miette::SourceSpan;
 
@@ -72,5 +74,20 @@ mod imp {
             let (head, tail) = self.0.split_once(f)?;
             Some((same_start(*self, head), same_end(*self, tail)))
         }
+    }
+}
+
+pub(crate) trait CommandExt {
+    fn commandline(&self) -> OsString;
+}
+impl CommandExt for Command {
+    fn commandline(&self) -> OsString {
+        let mut cmd = OsString::new();
+        cmd.push(self.get_program());
+        for arg in self.get_args() {
+            cmd.push(" ");
+            cmd.push(arg);
+        }
+        cmd
     }
 }

--- a/tests/fixtures/snapshots/basic_config_error/root.invalid-value.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/root.invalid-value.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1499px" height="380px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="380px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -25,13 +25,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package pkg-a -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package pkg-b -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/basic_config_error/root.unknown-field.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/root.unknown-field.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1499px" height="398px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="398px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -25,13 +25,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package pkg-a -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package pkg-b -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/basic_config_error/root.unknown-table.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/root.unknown-table.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1499px" height="416px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="416px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -25,13 +25,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package pkg-a -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package pkg-b -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/check_output/pkg-a.stderr.term.svg
+++ b/tests/fixtures/snapshots/check_output/pkg-a.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1499px" height="290px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="290px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -25,7 +25,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package pkg-a -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-yellow"> WARN</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> markdown file is not up to date: README.md</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/check_output/root.stderr.term.svg
+++ b/tests/fixtures/snapshots/check_output/root.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1482px" height="290px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="290px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -25,7 +25,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package root -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-yellow"> WARN</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> markdown file is not up to date: README.md</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/marker_parse_error/pkg-a.extra.stderr.term.svg
+++ b/tests/fixtures/snapshots/marker_parse_error/pkg-a.extra.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1499px" height="830px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="830px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -25,7 +25,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package pkg-a -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/marker_parse_error/root.extra.stderr.term.svg
+++ b/tests/fixtures/snapshots/marker_parse_error/root.extra.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1482px" height="830px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="830px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -25,7 +25,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package root -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/sync_output/pkg-a.stderr.term.svg
+++ b/tests/fixtures/snapshots/sync_output/pkg-a.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1499px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -21,13 +21,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package pkg-a -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: doc/extra.md</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package pkg-a -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: doc/extra.md</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: doc/extra.md</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/sync_output/root.stderr.term.svg
+++ b/tests/fixtures/snapshots/sync_output/root.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1482px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -21,13 +21,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package root -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: doc/extra.md</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> executing rustdoc command: rustup run nightly cargo rustdoc --package root -Zrustdoc-map -- --document-private-items -Zunstable-options --output-format=json</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: doc/extra.md</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: doc/extra.md</tspan>
 </tspan>


### PR DESCRIPTION
## Summary
- replace the info-level rustdoc command log with a higher-level progress message when creating replacement contents
- quiet the `cargo rustdoc` invocation outside debug logging while still logging the full command at debug level
- include the executed command line in rustdoc failure diagnostics, and share command rendering with toolchain errors
- update UI snapshot fixtures for the revised logging output

## Motivation
The previous info-level log printed the full `cargo rustdoc` command for every file, which was noisy in normal operation. This change keeps the normal logs focused on user-relevant progress while preserving command details for debug sessions and failure diagnostics.

## Validation
- `cargo test --quiet`

## Impact
- normal `INFO` output is less verbose
- rustdoc failures now report the command that was executed
