### PR TITLE
Document why `-Zrustdoc-map` is required

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ name = "cargo-sync-rdme-example-lib"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cargo_metadata",
  "num",
  "serde",
 ]

--- a/examples/lib/Cargo.toml
+++ b/examples/lib/Cargo.toml
@@ -16,6 +16,7 @@ html-root-url = "https://gifnksm.github.io/cargo-sync-rdme/"
 
 [dependencies]
 async-trait = "0.1.92"
+cargo_metadata.workspace = true
 num = { version = "0.4.3", features = ["num-bigint"] }
 serde = { version = "1.0.229", features = ["derive"] }
 

--- a/examples/lib/README.md
+++ b/examples/lib/README.md
@@ -146,6 +146,8 @@ It will be extracted and used to generate README.md.
 
 <!-- markdownlint-enable MD060 -->
 
+* crate without `html_root_url`: [`cargo_metadata::MetadataCommand`]
+
 ## Code Blocks
 
 All code block syntaxes in [CommonMark Spec][commonmark-spec] are supported.
@@ -316,5 +318,6 @@ and en/em dashes.
 [`ReexportedFromPrivateMod`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/private/struct.ReexportedFromPrivateMod.html "struct cargo_sync_rdme_example_lib::private::ReexportedFromPrivateMod"
 [`foreign_function`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/fn.foreign_function.html "fn cargo_sync_rdme_example_lib::foreign_function"
 [`FOREIGN_STATIC`]: https://gifnksm.github.io/cargo-sync-rdme/cargo_sync_rdme_example_lib/static.FOREIGN_STATIC.html "static cargo_sync_rdme_example_lib::FOREIGN_STATIC"
+[`cargo_metadata::MetadataCommand`]: https://docs.rs/cargo_metadata/0.23.1/cargo_metadata/struct.MetadataCommand.html "struct cargo_metadata::MetadataCommand"
 [commonmark-spec]: https://spec.commonmark.org/0.31.2/
 <!-- cargo-sync-rdme ]] -->

--- a/examples/lib/src/lib.rs
+++ b/examples/lib/src/lib.rs
@@ -143,6 +143,9 @@
 //! | Foreign Function                                | [`foreign_function`]          |                                 |                                        |
 //! | Foreign Static                                  | [`FOREIGN_STATIC`]            |                                 |                                        |
 //! <!-- markdownlint-enable MD060 -->
+//!
+//! * crate without `html_root_url`: [`cargo_metadata::MetadataCommand`]
+//!
 //! # Code Blocks
 //!
 //! All code block syntaxes in [CommonMark Spec][commonmark-spec] are supported.
@@ -219,6 +222,7 @@
 
 // import unused external crates to demonstrate intra-doc links to external crates
 use async_trait as _;
+use cargo_metadata as _;
 use num as _;
 use serde as _;
 

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -124,6 +124,11 @@ fn run_rustdoc(package: &Package, options: &SyncOptions<'_>) -> CreateResult<()>
         .args(["rustdoc", "--package", &package.name])
         .args(cargo::feature_args(options.feature))
         .args([
+            // Pass `-Zrustdoc-map` so Cargo provides documentation URLs for
+            // external crates that do not define `#![doc(html_root_url = ...)]`.
+            // `cargo-sync-rdme` reads those URLs from
+            // `external_crates[*].html_root_url` when generating links to
+            // external items.
             "-Zrustdoc-map",
             "--",
             "--document-private-items",


### PR DESCRIPTION
## Summary
- add `cargo_metadata` as a direct dependency of the example library to demonstrate an external link target without `#![doc(html_root_url = ...)]`
- update the generated example README to show that `cargo_metadata::MetadataCommand` resolves to docs.rs when `-Zrustdoc-map` is enabled
- document next to the rustdoc invocation why `cargo-sync-rdme` needs Cargo to supply external documentation URLs

## Motivation
`cargo-sync-rdme` reads `external_crates[*].html_root_url` from rustdoc JSON when generating links to external items. For crates that do not define `#![doc(html_root_url = ...)]`, Cargo needs to pass those URLs through `-Zrustdoc-map`; otherwise generated links can incorrectly fall back to the local documentation root.

## Validation
- `cargo test --quiet`

## Impact
- no behavior change in the implementation itself
- the example and inline documentation now make the `-Zrustdoc-map` requirement explicit
