### PR TITLE
Move arg parsing and tune rustdoc verbosity

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,7 +1,25 @@
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
-use clap::ColorChoice;
+use clap::{ColorChoice, Parser as _};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
+
+pub(crate) fn parse() -> Args {
+    // We support running this command both as a cargo subcommand and as a standalone binary.
+    //
+    // * cargo sync-rdme [OPTIONS]
+    //   => cargo executes the command as: cargo-sync-rdme sync-rdme [OPTIONS]
+    // * cargo-sync-rdme [OPTIONS]
+    //
+    // When run as a cargo subcommand, we need to remove the argv[1] (`sync-rdme`) before parsing the arguments.
+    let args = env::args().enumerate().filter_map(|(idx, arg)| {
+        if idx == 1 && arg == "sync-rdme" {
+            None
+        } else {
+            Some(arg)
+        }
+    });
+    Args::parse_from(args)
+}
 
 /// Synchronize a package README and additional configured Markdown files with package metadata and crate documentation.
 #[derive(Debug, Clone, Default, clap::Parser)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,9 @@
 
 use std::{assert_matches, env, io, process};
 
-use clap::{ColorChoice, CommandFactory as _, Parser as _};
+use clap::{ColorChoice, CommandFactory as _};
 use clap_complete::{Generator, Shell};
+use clap_verbosity_flag::{InfoLevel, Verbosity};
 use miette::MietteHandlerOpts;
 use supports_color::Stream;
 use tracing::Level;
@@ -43,26 +44,16 @@ fn main() -> miette::Result<()> {
         process::exit(0);
     }
 
-    // If this command is run by cargo, the first argument is the subcommand name
-    // `sync-rdme`. We need to remove it to avoid parsing error.
-    let args = env::args().enumerate().filter_map(|(idx, arg)| {
-        if idx == 1 && arg == "sync-rdme" {
-            None
-        } else {
-            Some(arg)
-        }
-    });
-
-    let args = Args::parse_from(args);
-    let verbosity = args.verbosity.into();
+    let args = args::parse();
     let output_stream = Stream::Stderr;
     let use_color = should_use_color(args.color, output_stream);
     set_console_color(use_color, output_stream);
     set_miette_hook(use_color, output_stream);
-    install_logger(verbosity, use_color, output_stream);
+    install_logger(args.verbosity, use_color, output_stream);
 
     let sync_options = SyncOptions {
         mode: args.mode.mode(),
+        verbosity: args.verbosity.into(),
         diff_stream: output_stream,
         fix: &args.fix,
         toolchain: &args.toolchain,
@@ -105,11 +96,11 @@ fn set_miette_hook(use_color: bool, stream: Stream) {
     .unwrap();
 }
 
-fn install_logger(verbosity: Option<Level>, use_color: bool, stream: Stream) {
-    let env_filter = if env::var_os("RUST_LOG").is_some() {
+fn install_logger(verbosity: Verbosity<InfoLevel>, use_color: bool, stream: Stream) {
+    let env_filter = if !verbosity.is_present() && env::var_os("RUST_LOG").is_some() {
         EnvFilter::from_default_env()
     } else {
-        let default_level = match verbosity {
+        let default_level = match verbosity.into() {
             Some(Level::ERROR) => LevelFilter::ERROR,
             Some(Level::WARN) => LevelFilter::WARN,
             Some(Level::INFO) => LevelFilter::INFO,

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -117,8 +117,10 @@ pub(super) fn create(
 
 fn run_rustdoc(package: &Package, options: &SyncOptions<'_>) -> CreateResult<()> {
     let mut command = cargo::command_for_build_doc(options.toolchain);
-    if !tracing::enabled!(Level::DEBUG) {
-        command.arg("-q");
+    match options.verbosity {
+        Some(Level::TRACE) => _ = command.arg("-v"),
+        Some(Level::DEBUG) => {}
+        _ => _ = command.arg("-q"),
     }
     command
         .args(["rustdoc", "--package", &package.name])

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -8,11 +8,13 @@ use cargo_metadata::{
     Metadata, Package, PackageName,
     camino::{Utf8Path, Utf8PathBuf},
 };
+
 use miette::NamedSource;
 use pulldown_cmark::{Options, Parser};
 use snafu::{ResultExt as _, Snafu, ensure};
 use supports_color::Stream;
 use tempfile::NamedTempFile;
+use tracing::Level;
 use vcs_modify_guard::{AllowOptions, ModificationSafety, UnsafeModificationReason};
 
 use crate::{
@@ -122,6 +124,7 @@ impl From<contents::CreateAllContentsError> for Box<SyncError> {
 #[derive(Debug, Clone)]
 pub(crate) struct SyncOptions<'a> {
     pub(crate) mode: Mode,
+    pub(crate) verbosity: Option<Level>,
     pub(crate) diff_stream: Stream,
     pub(crate) fix: &'a FixArgs,
     pub(crate) toolchain: &'a RustdocToolchainArgs,


### PR DESCRIPTION
## Summary
- move the existing cargo subcommand argument normalization into `args::parse()`
- keep `main` focused on top-level command setup by delegating CLI parsing
- tune `cargo rustdoc` verbosity so it stays quiet by default, uses normal output at debug, and enables verbose output at trace

## Validation
- `cargo test --quiet --test ui help_matches_snapshot`
- `cargo test --quiet --test ui check_output_matches_snapshot`
- `cargo test --quiet`