### PR TITLE
Use Range for marker spans

### DIFF
--- a/src/sync/marker/find.rs
+++ b/src/sync/marker/find.rs
@@ -131,7 +131,7 @@ where
     fn next_marker(&mut self) -> Result<Option<(Marker, Range<usize>)>, FindError> {
         for (event, range) in self.events.by_ref() {
             if let Event::Html(html) = &event
-                && let Some(marker) = Marker::matches((html, range.clone().into()), self.manifest)?
+                && let Some(marker) = Marker::matches((html, range.clone()), self.manifest)?
             {
                 return Ok(Some((marker, range)));
             }

--- a/src/sync/marker/mod.rs
+++ b/src/sync/marker/mod.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Arc};
+use std::{fmt, ops::Range, sync::Arc};
 
 use miette::SourceSpan;
 use snafu::{OptionExt as _, Snafu, ensure};
@@ -23,21 +23,18 @@ pub(super) enum ReplaceSpecifier {
 
 impl ReplaceSpecifier {
     fn from_str(
-        specifier: (&str, SourceSpan),
+        specifier: (&str, Range<usize>),
         manifest: &ManifestFile,
     ) -> Result<Self, ParseMarkerError> {
         let group = match specifier.0 {
             "title" => return Ok(Self::Title),
             "rustdoc" => return Ok(Self::Rustdoc),
-            "badge" => {
-                let end = specifier.1.offset() + specifier.1.len();
-                ("", SourceSpan::from((end, 0)))
-            }
+            "badge" => ("", specifier.1.end..specifier.1.end),
             _ => specifier
                 .strip_prefix_str("badge:")
                 .context(UnknownReplaceSpecifierSnafu {
                     specifier: specifier.0,
-                    span: specifier.1,
+                    span: specifier.1.clone(),
                 })?,
         };
         let badges = &manifest.value().config().badge.badges;
@@ -126,7 +123,7 @@ pub(super) enum ParseMarkerError {
 
 impl Marker {
     pub(super) fn matches(
-        text: (&str, SourceSpan),
+        text: (&str, Range<usize>),
         manifest: &ManifestFile,
     ) -> Result<Option<Marker>, ParseMarkerError> {
         let Some(body) = Self::matches_marker(text)? else {
@@ -149,8 +146,8 @@ impl Marker {
     }
 
     fn matches_marker(
-        text: (&str, SourceSpan),
-    ) -> Result<Option<(&str, SourceSpan)>, ParseMarkerError> {
+        text: (&str, Range<usize>),
+    ) -> Result<Option<(&str, Range<usize>)>, ParseMarkerError> {
         // <!-- cargo-sync-rdme <body> -->
         let Some(text) = trim_comment(text) else {
             return Ok(None);
@@ -164,7 +161,8 @@ impl Marker {
     }
 }
 
-fn trim_comment(text: (&str, SourceSpan)) -> Option<(&str, SourceSpan)> {
+#[expect(clippy::needless_pass_by_value)]
+fn trim_comment(text: (&str, Range<usize>)) -> Option<(&str, Range<usize>)> {
     let body = text
         .trim()
         .strip_prefix_str("<!--")?
@@ -189,8 +187,7 @@ mod tests {
                 [package.metadata.cargo-sync-rdme.badge.badges-foo]
             "};
             let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
-            let span = SourceSpan::from(0..s.len());
-            Marker::matches((s, span), &manifest).unwrap()
+            Marker::matches((s, 0..s.len()), &manifest).unwrap()
         }
         fn err_kind(s: &str) -> String {
             let config = indoc::indoc! {"
@@ -198,8 +195,7 @@ mod tests {
                 [package.metadata.cargo-sync-rdme.badge.badges-foo]
             "};
             let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
-            let span = SourceSpan::from(0..s.len());
-            match Marker::matches((s, span), &manifest).unwrap_err() {
+            match Marker::matches((s, 0..s.len()), &manifest).unwrap_err() {
                 ParseMarkerError::UnknownReplaceSpecifier { specifier: s, .. } => s,
                 e => panic!("unexpected: {e}"),
             }
@@ -210,8 +206,7 @@ mod tests {
                 [package.metadata.cargo-sync-rdme.badge.badges-foo]
             "};
             let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
-            let span = SourceSpan::from(0..s.len());
-            match Marker::matches((s, span), &manifest).unwrap_err() {
+            match Marker::matches((s, 0..s.len()), &manifest).unwrap_err() {
                 ParseMarkerError::NoReplaceSpecifier { .. } => {}
                 e => panic!("unexpected: {e}"),
             }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,6 @@
-use std::{ffi::OsString, process::Command};
+use std::{ffi::OsString, ops::Range, process::Command};
 
 use cargo_metadata::{Metadata, Package, camino::Utf8Path};
-use miette::SourceSpan;
 
 /// Extension methods for [`cargo_metadata::Package`].
 pub(crate) trait PackageExt {
@@ -25,6 +24,10 @@ impl PackageExt for Package {
     }
 }
 
+pub(crate) trait StrExt {
+    fn substr_range_shim(&self, substr: &str) -> Option<Range<usize>>;
+}
+
 pub(crate) trait StrSpanExt: Sized {
     fn trim(&self) -> Self {
         self.trim_start().trim_end()
@@ -37,42 +40,62 @@ pub(crate) trait StrSpanExt: Sized {
 }
 
 mod imp {
-    use super::{SourceSpan, StrSpanExt};
+    use std::ops::Range;
 
-    fn new(s: &str, offset: usize) -> (&str, SourceSpan) {
-        (s, (offset, s.len()).into())
+    use crate::traits::{StrExt, StrSpanExt};
+
+    impl StrExt for str {
+        fn substr_range_shim(&self, substr: &str) -> Option<Range<usize>> {
+            let range = self.as_bytes().as_ptr_range();
+            let substr_range = substr.as_bytes().as_ptr_range();
+            let start = range.start.addr();
+            let substr_start = substr_range.start.addr();
+            if substr_start < start {
+                return None;
+            }
+            let end = range.end.addr();
+            let substr_end = substr_range.end.addr();
+            if substr_end > end {
+                return None;
+            }
+            Some((substr_start - start)..(substr_end - start))
+        }
     }
 
-    fn same_end<'a>(original: (&str, SourceSpan), trimmed: &'a str) -> (&'a str, SourceSpan) {
-        let new_offset = original.1.offset() + (original.0.len() - trimmed.len());
-        new(trimmed, new_offset)
+    fn adjust_range(offset: usize, substr_range: Range<usize>) -> Range<usize> {
+        (offset + substr_range.start)..(offset + substr_range.end)
     }
 
-    fn same_start<'a>(original: (&str, SourceSpan), trimmed: &'a str) -> (&'a str, SourceSpan) {
-        let new_offset = original.1.offset();
-        new(trimmed, new_offset)
-    }
-
-    impl StrSpanExt for (&str, SourceSpan) {
+    impl StrSpanExt for (&str, Range<usize>) {
         fn trim_start(&self) -> Self {
-            same_end(*self, self.0.trim_start())
+            let substr = self.0.trim_start();
+            let range = adjust_range(self.1.start, self.0.substr_range_shim(substr).unwrap());
+            (substr, range)
         }
 
         fn trim_end(&self) -> Self {
-            same_start(*self, self.0.trim_end())
+            let substr = self.0.trim_end();
+            let range = adjust_range(self.1.start, self.0.substr_range_shim(substr).unwrap());
+            (substr, range)
         }
 
         fn strip_prefix_str(&self, prefix: &str) -> Option<Self> {
-            Some(same_end(*self, self.0.strip_prefix(prefix)?))
+            let substr = self.0.strip_prefix(prefix)?;
+            let range = adjust_range(self.1.start, self.0.substr_range_shim(substr).unwrap());
+            Some((substr, range))
         }
 
         fn strip_suffix_str(&self, suffix: &str) -> Option<Self> {
-            Some(same_start(*self, self.0.strip_suffix(suffix)?))
+            let substr = self.0.strip_suffix(suffix)?;
+            let range = adjust_range(self.1.start, self.0.substr_range_shim(substr).unwrap());
+            Some((substr, range))
         }
 
         fn split_once_fn(&self, f: impl Fn(char) -> bool) -> Option<(Self, Self)> {
             let (head, tail) = self.0.split_once(f)?;
-            Some((same_start(*self, head), same_end(*self, tail)))
+            let head_range = adjust_range(self.1.start, self.0.substr_range_shim(head).unwrap());
+            let tail_range = adjust_range(self.1.start, self.0.substr_range_shim(tail).unwrap());
+            Some(((head, head_range), (tail, tail_range)))
         }
     }
 }
@@ -80,6 +103,7 @@ mod imp {
 pub(crate) trait CommandExt {
     fn commandline(&self) -> OsString;
 }
+
 impl CommandExt for Command {
     fn commandline(&self) -> OsString {
         let mut cmd = OsString::new();


### PR DESCRIPTION
## Summary
- replace internal marker span plumbing from `miette::SourceSpan` to `std::ops::Range<usize>`
- update marker parsing and lookup code to pass `Range<usize>` through consistently
- introduce a temporary `substr_range_shim` so the current implementation stays close to the future standard-library API

## Motivation
This prepares the code for using standard `Range<usize>` directly instead of carrying `SourceSpan` through internal marker parsing APIs.

The temporary `substr_range_shim` is intended to be replaced with the standard library implementation once Rust 1.98 is released and the project MSRV is raised accordingly.

## Validation
- `cargo fmt --check`
- `cargo test`

## Impact
- no intended user-visible behavior change
- diagnostics should continue to point at the same markdown spans as before