### PR TITLE
Adopt std::range::Range in marker code

### DIFF
--- a/src/sync/marker/find.rs
+++ b/src/sync/marker/find.rs
@@ -1,10 +1,13 @@
-use std::{ops::Range, sync::Arc};
+use std::{range::Range, sync::Arc};
 
 use miette::{NamedSource, SourceSpan};
 use pulldown_cmark::Event;
 use snafu::{OptionExt as _, Snafu, ensure};
 
-use crate::sync::{ManifestFile, MarkdownPath};
+use crate::{
+    sync::{ManifestFile, MarkdownPath},
+    traits::RangeExt as _,
+};
 
 use super::{super::MarkdownFile, Marker, ParseMarkerError, ReplaceSpecifier};
 
@@ -106,18 +109,25 @@ where
         let (specifier, start_range) = match next_marker {
             (Marker::Replace(specifier), range) => return Ok(Some((specifier, range))),
             (Marker::Start(specifier), start_range) => (specifier, start_range),
-            (Marker::End, range) => return Err(UnexpectedEndMarkerSnafu { span: range }.build()),
+            (Marker::End, range) => {
+                return Err(UnexpectedEndMarkerSnafu {
+                    span: range.to_span(),
+                }
+                .build());
+            }
         };
         let next_marker = self
             .next_marker()?
             .with_context(|| NoCorrespondingEndMarkerSnafu {
-                start_span: start_range.clone(),
+                start_span: start_range.to_span(),
             })?;
         match next_marker {
-            (Marker::End, end_range) => Ok(Some((specifier, start_range.start..end_range.end))),
+            (Marker::End, end_range) => {
+                Ok(Some((specifier, (start_range.start..end_range.end).into())))
+            }
             (_, nested_range) => Err(NestedMarkerSnafu {
-                nested_span: nested_range,
-                previous_span: start_range,
+                nested_span: nested_range.to_span(),
+                previous_span: start_range.to_span(),
             }
             .build()),
         }
@@ -131,7 +141,7 @@ where
     fn next_marker(&mut self) -> Result<Option<(Marker, Range<usize>)>, FindError> {
         for (event, range) in self.events.by_ref() {
             if let Event::Html(html) = &event
-                && let Some(marker) = Marker::matches((html, range.clone()), self.manifest)?
+                && let Some(marker) = Marker::matches((html, range), self.manifest)?
             {
                 return Ok(Some((marker, range)));
             }
@@ -154,7 +164,7 @@ mod tests {
             .iter()
             .scan(0, |offset, line| {
                 let line = line.as_ref();
-                let range = *offset..*offset + line.len() + 1;
+                let range = Range::from(*offset..*offset + line.len() + 1);
                 *offset = range.end;
                 Some(range)
             })
@@ -166,7 +176,9 @@ mod tests {
         let input = "Hello, world!";
         let mut markers = Iter {
             manifest: &ManifestFile::dummy(Manifest::default()),
-            events: Parser::new(input).into_offset_iter(),
+            events: Parser::new(input)
+                .into_offset_iter()
+                .map(|(event, range)| (event, Range::from(range))),
         };
         assert!(markers.next().is_none());
     }
@@ -195,11 +207,13 @@ mod tests {
 
         let mut markers = Iter {
             manifest: &ManifestFile::dummy(toml::from_str(config).unwrap()),
-            events: Parser::new(&input).into_offset_iter(),
+            events: Parser::new(&input)
+                .into_offset_iter()
+                .map(|(event, range)| (event, Range::from(range))),
         };
         assert_eq!(
             markers.next().unwrap().unwrap(),
-            (ReplaceSpecifier::Title, ranges[1].clone())
+            (ReplaceSpecifier::Title, ranges[1])
         );
         assert_eq!(
             markers.next().unwrap().unwrap(),
@@ -208,12 +222,12 @@ mod tests {
                     name: "".into(),
                     badges: vec![].into()
                 },
-                ranges[3].clone()
+                ranges[3],
             )
         );
         assert_eq!(
             markers.next().unwrap().unwrap(),
-            (ReplaceSpecifier::Rustdoc, ranges[5].clone())
+            (ReplaceSpecifier::Rustdoc, ranges[5])
         );
         assert!(markers.next().is_none());
     }
@@ -237,11 +251,16 @@ mod tests {
 
         let mut markers = Iter {
             manifest: &ManifestFile::dummy(toml::from_str(config).unwrap()),
-            events: Parser::new(&input).into_offset_iter(),
+            events: Parser::new(&input)
+                .into_offset_iter()
+                .map(|(event, range)| (event, Range::from(range))),
         };
         assert_eq!(
             markers.next().unwrap().unwrap(),
-            (ReplaceSpecifier::Title, ranges[1].start..ranges[4].end)
+            (
+                ReplaceSpecifier::Title,
+                (ranges[1].start..ranges[4].end).into()
+            ),
         );
         assert!(markers.next().is_none());
     }

--- a/src/sync/marker/mod.rs
+++ b/src/sync/marker/mod.rs
@@ -1,10 +1,13 @@
-use std::{fmt, ops::Range, sync::Arc};
+use std::{fmt, range::Range, sync::Arc};
 
 use miette::SourceSpan;
 use snafu::{OptionExt as _, Snafu, ensure};
 
 pub(super) use self::{find::*, replace::*};
-use crate::{config::metadata::BadgeItem, traits::StrSpanExt as _};
+use crate::{
+    config::metadata::BadgeItem,
+    traits::{RangeExt as _, StrSpanExt as _},
+};
 
 use super::ManifestFile;
 
@@ -29,22 +32,25 @@ impl ReplaceSpecifier {
         let group = match specifier.0 {
             "title" => return Ok(Self::Title),
             "rustdoc" => return Ok(Self::Rustdoc),
-            "badge" => ("", specifier.1.end..specifier.1.end),
+            "badge" => ("", (specifier.1.end..specifier.1.end).into()),
             _ => specifier
                 .strip_prefix_str("badge:")
                 .context(UnknownReplaceSpecifierSnafu {
                     specifier: specifier.0,
-                    span: specifier.1.clone(),
+                    span: specifier.1.to_span(),
                 })?,
         };
         let badges = &manifest.value().config().badge.badges;
         let (name, badges) = badges.get_key_value(group.0).ok_or_else(|| {
             if group.0.is_empty() {
-                NoDefaultBadgeConfiguredSnafu { span: specifier.1 }.build()
+                NoDefaultBadgeConfiguredSnafu {
+                    span: specifier.1.to_span(),
+                }
+                .build()
             } else {
                 NoSuchBadgeGroupSnafu {
                     group: group.0,
-                    span: group.1,
+                    span: group.1.to_span(),
                 }
                 .build()
             }
@@ -153,7 +159,12 @@ impl Marker {
             return Ok(None);
         };
 
-        ensure!(text.0 != MAGIC, NoReplaceSpecifierSnafu { span: text.1 });
+        ensure!(
+            text.0 != MAGIC,
+            NoReplaceSpecifierSnafu {
+                span: text.1.to_span()
+            }
+        );
         let Some((head, body)) = text.split_once_fn(char::is_whitespace) else {
             return Ok(None);
         };
@@ -161,7 +172,6 @@ impl Marker {
     }
 }
 
-#[expect(clippy::needless_pass_by_value)]
 fn trim_comment(text: (&str, Range<usize>)) -> Option<(&str, Range<usize>)> {
     let body = text
         .trim()
@@ -187,7 +197,7 @@ mod tests {
                 [package.metadata.cargo-sync-rdme.badge.badges-foo]
             "};
             let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
-            Marker::matches((s, 0..s.len()), &manifest).unwrap()
+            Marker::matches((s, (0..s.len()).into()), &manifest).unwrap()
         }
         fn err_kind(s: &str) -> String {
             let config = indoc::indoc! {"
@@ -195,7 +205,7 @@ mod tests {
                 [package.metadata.cargo-sync-rdme.badge.badges-foo]
             "};
             let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
-            match Marker::matches((s, 0..s.len()), &manifest).unwrap_err() {
+            match Marker::matches((s, (0..s.len()).into()), &manifest).unwrap_err() {
                 ParseMarkerError::UnknownReplaceSpecifier { specifier: s, .. } => s,
                 e => panic!("unexpected: {e}"),
             }
@@ -206,7 +216,7 @@ mod tests {
                 [package.metadata.cargo-sync-rdme.badge.badges-foo]
             "};
             let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
-            match Marker::matches((s, 0..s.len()), &manifest).unwrap_err() {
+            match Marker::matches((s, (0..s.len()).into()), &manifest).unwrap_err() {
                 ParseMarkerError::NoReplaceSpecifier { .. } => {}
                 e => panic!("unexpected: {e}"),
             }

--- a/src/sync/marker/replace.rs
+++ b/src/sync/marker/replace.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, iter, ops::Range};
+use std::{borrow::Cow, iter, range::Range};
 
 use super::{super::contents::Contents, Marker, ReplaceSpecifier};
 
@@ -10,9 +10,9 @@ pub(in super::super) fn replace_all(
     let pairs = markers
         .iter()
         .zip(contents)
-        .map(|((replace, range), contents)| ((replace.clone(), contents), range.clone()));
+        .map(|((replace, range), contents)| ((replace.clone(), contents), *range));
 
-    interpolate_ranges(0..text.len(), pairs)
+    interpolate_ranges((0..text.len()).into(), pairs)
         .map(|(contents, range)| match contents {
             Some((replace, contents)) => {
                 if contents.text().is_empty() {
@@ -39,17 +39,17 @@ fn interpolate_ranges<T>(
     let mut offset = range.start;
     iter::from_fn(move || match items.peek() {
         Some(&(_, Range { start, .. })) if offset < start => {
-            let range = offset..start;
+            let range = (offset..start).into();
             offset = start;
             Some((None, range))
         }
         Some(_) => {
             let (item, Range { start, end }) = items.next().unwrap();
             offset = end;
-            Some((Some(item), start..end))
+            Some((Some(item), (start..end).into()))
         }
         None if offset < range.end => {
-            let range = offset..range.end;
+            let range = Range::from(offset..range.end);
             offset = range.end;
             Some((None, range))
         }
@@ -63,26 +63,35 @@ mod tests {
 
     #[test]
     fn interpolate_ranges() {
-        let items = [(1, 0..1), (2, 1..2), (3, 2..3)];
-        let ranges = super::interpolate_ranges(0..3, items);
-        assert_eq!(
-            ranges.collect::<Vec<_>>(),
-            vec![(Some(1), 0..1), (Some(2), 1..2), (Some(3), 2..3),]
-        );
-
-        let items = [(1, 3..4), (2, 4..5), (3, 6..7), (4, 8..9)];
-        let ranges = super::interpolate_ranges(0..10, items);
+        let items = [(1, (0..1).into()), (2, (1..2).into()), (3, (2..3).into())];
+        let ranges = super::interpolate_ranges((0..3).into(), items);
         assert_eq!(
             ranges.collect::<Vec<_>>(),
             vec![
-                (None, 0..3),
-                (Some(1), 3..4),
-                (Some(2), 4..5),
-                (None, 5..6),
-                (Some(3), 6..7),
-                (None, 7..8),
-                (Some(4), 8..9),
-                (None, 9..10),
+                (Some(1), (0..1).into()),
+                (Some(2), (1..2).into()),
+                (Some(3), (2..3).into()),
+            ]
+        );
+
+        let items = [
+            (1, (3..4).into()),
+            (2, (4..5).into()),
+            (3, (6..7).into()),
+            (4, (8..9).into()),
+        ];
+        let ranges = super::interpolate_ranges((0..10).into(), items);
+        assert_eq!(
+            ranges.collect::<Vec<_>>(),
+            vec![
+                (None, (0..3).into()),
+                (Some(1), (3..4).into()),
+                (Some(2), (4..5).into()),
+                (None, (5..6).into()),
+                (Some(3), (6..7).into()),
+                (None, (7..8).into()),
+                (Some(4), (8..9).into()),
+                (None, (9..10).into()),
             ]
         );
     }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     io::{self, Write as _},
+    range::Range,
     sync::Arc,
 };
 
@@ -154,7 +155,9 @@ pub(crate) fn sync_all(
         let mut markdown = MarkdownFile::new(workspace, package, path)?;
 
         // Setup markdown parser
-        let parser = Parser::new_ext(&markdown.text, Options::all()).into_offset_iter();
+        let parser = Parser::new_ext(&markdown.text, Options::all())
+            .into_offset_iter()
+            .map(|(event, range)| (event, Range::from(range)));
 
         // Find replace markers from markdown file
         let all_markers = marker::find_all(&markdown, &manifest, parser)?;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,7 @@
-use std::{ffi::OsString, ops::Range, process::Command};
+use std::{ffi::OsString, process::Command, range::Range};
 
 use cargo_metadata::{Metadata, Package, camino::Utf8Path};
+use miette::SourceSpan;
 
 /// Extension methods for [`cargo_metadata::Package`].
 pub(crate) trait PackageExt {
@@ -24,6 +25,10 @@ impl PackageExt for Package {
     }
 }
 
+pub(crate) trait RangeExt {
+    fn to_span(self) -> SourceSpan;
+}
+
 pub(crate) trait StrExt {
     fn substr_range_shim(&self, substr: &str) -> Option<Range<usize>>;
 }
@@ -40,9 +45,17 @@ pub(crate) trait StrSpanExt: Sized {
 }
 
 mod imp {
-    use std::ops::Range;
+    use std::{ops, range::Range};
 
-    use crate::traits::{StrExt, StrSpanExt};
+    use miette::SourceSpan;
+
+    use crate::traits::{RangeExt, StrExt, StrSpanExt};
+
+    impl RangeExt for Range<usize> {
+        fn to_span(self) -> SourceSpan {
+            SourceSpan::from(ops::Range::from(self))
+        }
+    }
 
     impl StrExt for str {
         fn substr_range_shim(&self, substr: &str) -> Option<Range<usize>> {
@@ -58,12 +71,12 @@ mod imp {
             if substr_end > end {
                 return None;
             }
-            Some((substr_start - start)..(substr_end - start))
+            Some(((substr_start - start)..(substr_end - start)).into())
         }
     }
 
     fn adjust_range(offset: usize, substr_range: Range<usize>) -> Range<usize> {
-        (offset + substr_range.start)..(offset + substr_range.end)
+        ((offset + substr_range.start)..(offset + substr_range.end)).into()
     }
 
     impl StrSpanExt for (&str, Range<usize>) {


### PR DESCRIPTION
## Summary
- migrate marker-related code from `std::ops::Range<usize>` to `std::range::Range<usize>`
- convert `pulldown-cmark` offset ranges immediately after parser construction so marker code only handles `std::range::Range`
- align `substr_range_shim` and related helpers with the standard library's `Range` API, and centralize `SourceSpan` conversion via `RangeExt`


## Motivation
`std::range::Range` is `Copy`, which makes these span/range values easier to pass around without cloning. This also aligns the internal interfaces with the range type returned by `substr_range` in `std`.

## Validation
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Impact
Internal refactor only; no intended user-visible behavior change.