### PR TITLE
Use Spanned for marker parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod args;
 mod cargo;
 mod config;
 mod diff;
+mod parse;
 mod sync;
 mod traits;
 mod with_source;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,97 @@
+use std::range::Range;
+
+use miette::SourceSpan;
+
+use crate::traits::StrExt as _;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Spanned<T> {
+    pub(crate) value: T,
+    pub(crate) span: Range<usize>,
+}
+
+impl<T> Spanned<T> {
+    pub(crate) fn new(value: T, span: Range<usize>) -> Self {
+        Self { value, span }
+    }
+
+    pub(crate) fn source_span(&self) -> SourceSpan {
+        SourceSpan::from(std::ops::Range::from(self.span))
+    }
+
+    pub(crate) fn as_deref(&self) -> Spanned<&T::Target>
+    where
+        T: std::ops::Deref,
+    {
+        Spanned {
+            value: &self.value,
+            span: self.span,
+        }
+    }
+}
+
+impl<'a> Spanned<&'a str> {
+    pub(crate) fn end(&self) -> Self {
+        let end = &self.value[self.value.len()..];
+        self.substr(end)
+    }
+
+    pub(crate) fn trim(&self) -> Self {
+        let trimmed = self.value.trim();
+        self.substr(trimmed)
+    }
+
+    pub(crate) fn trim_start(&self) -> Self {
+        let trimmed = self.value.trim_start();
+        self.substr(trimmed)
+    }
+
+    pub(crate) fn trim_end(&self) -> Self {
+        let trimmed = self.value.trim_end();
+        self.substr(trimmed)
+    }
+
+    pub(crate) fn strip_prefix_str(&self, prefix: &str) -> Option<Self> {
+        let stripped = self.value.strip_prefix(prefix)?;
+        Some(self.substr(stripped))
+    }
+
+    pub(crate) fn strip_suffix_str(&self, suffix: &str) -> Option<Self> {
+        let stripped = self.value.strip_suffix(suffix)?;
+        Some(self.substr(stripped))
+    }
+
+    pub(crate) fn split_once_fn(&self, f: impl Fn(char) -> bool) -> Option<(Self, Self)> {
+        let (head, tail) = self.value.split_once(f)?;
+        Some((self.substr(head), self.substr(tail)))
+    }
+
+    fn substr(&self, substr: &'a str) -> Self {
+        let range = self.value.substr_range_shim(substr).unwrap();
+        Spanned {
+            value: substr,
+            span: Range {
+                start: self.span.start + range.start,
+                end: self.span.start + range.end,
+            },
+        }
+    }
+}
+
+impl<T> PartialEq<str> for Spanned<T>
+where
+    T: PartialEq<str>,
+{
+    fn eq(&self, other: &str) -> bool {
+        self.value == *other
+    }
+}
+
+impl<T> PartialEq<&str> for Spanned<T>
+where
+    T: for<'a> PartialEq<&'a str>,
+{
+    fn eq(&self, other: &&str) -> bool {
+        self.value == *other
+    }
+}

--- a/src/sync/marker/find.rs
+++ b/src/sync/marker/find.rs
@@ -5,6 +5,7 @@ use pulldown_cmark::Event;
 use snafu::{OptionExt as _, Snafu, ensure};
 
 use crate::{
+    parse::Spanned,
     sync::{ManifestFile, MarkdownPath},
     traits::RangeExt as _,
 };
@@ -15,7 +16,7 @@ pub(in super::super) fn find_all<'events>(
     markdown: &MarkdownFile<'_>,
     manifest: &ManifestFile,
     events: impl IntoIterator<Item = (Event<'events>, Range<usize>)> + 'events,
-) -> Result<Vec<(ReplaceSpecifier, Range<usize>)>, Box<FindAllError>> {
+) -> Result<Vec<Spanned<ReplaceSpecifier>>, Box<FindAllError>> {
     let events = events.into_iter();
     let it = Iter { manifest, events };
     let mut markers = vec![];
@@ -91,7 +92,7 @@ impl<'event, I> Iterator for Iter<'_, I>
 where
     I: Iterator<Item = (Event<'event>, Range<usize>)>,
 {
-    type Item = Result<(ReplaceSpecifier, Range<usize>), FindError>;
+    type Item = Result<Spanned<ReplaceSpecifier>, FindError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.try_next().transpose()
@@ -102,32 +103,35 @@ impl<'event, I> Iter<'_, I>
 where
     I: Iterator<Item = (Event<'event>, Range<usize>)>,
 {
-    fn try_next(&mut self) -> Result<Option<(ReplaceSpecifier, Range<usize>)>, FindError> {
-        let Some(next_marker) = self.next_marker()? else {
+    fn try_next(&mut self) -> Result<Option<Spanned<ReplaceSpecifier>>, FindError> {
+        let Some(start_marker) = self.next_marker()? else {
             return Ok(None);
         };
-        let (specifier, start_range) = match next_marker {
-            (Marker::Replace(specifier), range) => return Ok(Some((specifier, range))),
-            (Marker::Start(specifier), start_range) => (specifier, start_range),
-            (Marker::End, range) => {
+        let start_span = start_marker.span;
+        let specifier = match start_marker.value {
+            Marker::Replace(specifier) => return Ok(Some(Spanned::new(specifier, start_span))),
+            Marker::Start(specifier) => specifier,
+            Marker::End => {
                 return Err(UnexpectedEndMarkerSnafu {
-                    span: range.to_span(),
+                    span: start_span.to_span(),
                 }
                 .build());
             }
         };
-        let next_marker = self
+        let end_marker = self
             .next_marker()?
             .with_context(|| NoCorrespondingEndMarkerSnafu {
-                start_span: start_range.to_span(),
+                start_span: start_span.to_span(),
             })?;
-        match next_marker {
-            (Marker::End, end_range) => {
-                Ok(Some((specifier, (start_range.start..end_range.end).into())))
-            }
-            (_, nested_range) => Err(NestedMarkerSnafu {
-                nested_span: nested_range.to_span(),
-                previous_span: start_range.to_span(),
+        let end_span = end_marker.span;
+        match end_marker.value {
+            Marker::End => Ok(Some(Spanned::new(
+                specifier,
+                (start_span.start..end_span.end).into(),
+            ))),
+            _ => Err(NestedMarkerSnafu {
+                nested_span: end_span.to_span(),
+                previous_span: start_span.to_span(),
             }
             .build()),
         }
@@ -138,12 +142,13 @@ impl<'event, I> Iter<'_, I>
 where
     I: Iterator<Item = (Event<'event>, Range<usize>)>,
 {
-    fn next_marker(&mut self) -> Result<Option<(Marker, Range<usize>)>, FindError> {
+    fn next_marker(&mut self) -> Result<Option<Spanned<Marker>>, FindError> {
         for (event, range) in self.events.by_ref() {
-            if let Event::Html(html) = &event
-                && let Some(marker) = Marker::matches((html, range), self.manifest)?
-            {
-                return Ok(Some((marker, range)));
+            if let Event::Html(html) = event {
+                let html = Spanned::new(html, range);
+                if let Some(marker) = Marker::matches(html.as_deref(), self.manifest)? {
+                    return Ok(Some(marker));
+                }
             }
         }
         Ok(None)
@@ -213,11 +218,11 @@ mod tests {
         };
         assert_eq!(
             markers.next().unwrap().unwrap(),
-            (ReplaceSpecifier::Title, ranges[1])
+            Spanned::new(ReplaceSpecifier::Title, ranges[1])
         );
         assert_eq!(
             markers.next().unwrap().unwrap(),
-            (
+            Spanned::new(
                 ReplaceSpecifier::Badge {
                     name: "".into(),
                     badges: vec![].into()
@@ -227,7 +232,7 @@ mod tests {
         );
         assert_eq!(
             markers.next().unwrap().unwrap(),
-            (ReplaceSpecifier::Rustdoc, ranges[5])
+            Spanned::new(ReplaceSpecifier::Rustdoc, ranges[5])
         );
         assert!(markers.next().is_none());
     }
@@ -257,7 +262,7 @@ mod tests {
         };
         assert_eq!(
             markers.next().unwrap().unwrap(),
-            (
+            Spanned::new(
                 ReplaceSpecifier::Title,
                 (ranges[1].start..ranges[4].end).into()
             ),

--- a/src/sync/marker/mod.rs
+++ b/src/sync/marker/mod.rs
@@ -1,13 +1,10 @@
-use std::{fmt, range::Range, sync::Arc};
+use std::{fmt, sync::Arc};
 
 use miette::SourceSpan;
 use snafu::{OptionExt as _, Snafu, ensure};
 
 pub(super) use self::{find::*, replace::*};
-use crate::{
-    config::metadata::BadgeItem,
-    traits::{RangeExt as _, StrSpanExt as _},
-};
+use crate::{config::metadata::BadgeItem, parse::Spanned};
 
 use super::ManifestFile;
 
@@ -26,31 +23,31 @@ pub(super) enum ReplaceSpecifier {
 
 impl ReplaceSpecifier {
     fn from_str(
-        specifier: (&str, Range<usize>),
+        specifier: Spanned<&str>,
         manifest: &ManifestFile,
     ) -> Result<Self, ParseMarkerError> {
-        let group = match specifier.0 {
+        let group = match specifier.value {
             "title" => return Ok(Self::Title),
             "rustdoc" => return Ok(Self::Rustdoc),
-            "badge" => ("", (specifier.1.end..specifier.1.end).into()),
+            "badge" => specifier.end(),
             _ => specifier
                 .strip_prefix_str("badge:")
                 .context(UnknownReplaceSpecifierSnafu {
-                    specifier: specifier.0,
-                    span: specifier.1.to_span(),
+                    specifier: specifier.value,
+                    span: specifier.source_span(),
                 })?,
         };
         let badges = &manifest.value().config().badge.badges;
-        let (name, badges) = badges.get_key_value(group.0).ok_or_else(|| {
-            if group.0.is_empty() {
+        let (name, badges) = badges.get_key_value(group.value).ok_or_else(|| {
+            if group.value.is_empty() {
                 NoDefaultBadgeConfiguredSnafu {
-                    span: specifier.1.to_span(),
+                    span: specifier.source_span(),
                 }
                 .build()
             } else {
                 NoSuchBadgeGroupSnafu {
-                    group: group.0,
-                    span: group.1.to_span(),
+                    group: group.value,
+                    span: group.source_span(),
                 }
                 .build()
             }
@@ -129,9 +126,11 @@ pub(super) enum ParseMarkerError {
 
 impl Marker {
     pub(super) fn matches(
-        text: (&str, Range<usize>),
+        text: Spanned<&str>,
         manifest: &ManifestFile,
-    ) -> Result<Option<Marker>, ParseMarkerError> {
+    ) -> Result<Option<Spanned<Marker>>, ParseMarkerError> {
+        let span = text.span;
+
         let Some(body) = Self::matches_marker(text)? else {
             return Ok(None);
         };
@@ -140,46 +139,44 @@ impl Marker {
         if let Some(replace) = body.strip_suffix_str("[[") {
             let replace = replace.trim();
             let replace = ReplaceSpecifier::from_str(replace, manifest)?;
-            return Ok(Some(Marker::Start(replace)));
+            return Ok(Some(Spanned::new(Marker::Start(replace), span)));
         }
 
-        if body.0 == "]]" {
-            return Ok(Some(Marker::End));
+        if body == "]]" {
+            return Ok(Some(Spanned::new(Marker::End, span)));
         }
 
         let replace = ReplaceSpecifier::from_str(body, manifest)?;
-        Ok(Some(Marker::Replace(replace)))
+        Ok(Some(Spanned::new(Marker::Replace(replace), span)))
     }
 
-    fn matches_marker(
-        text: (&str, Range<usize>),
-    ) -> Result<Option<(&str, Range<usize>)>, ParseMarkerError> {
+    fn matches_marker(text: Spanned<&str>) -> Result<Option<Spanned<&str>>, ParseMarkerError> {
         // <!-- cargo-sync-rdme <body> -->
         let Some(text) = trim_comment(text) else {
             return Ok(None);
         };
 
         ensure!(
-            text.0 != MAGIC,
+            text != MAGIC,
             NoReplaceSpecifierSnafu {
-                span: text.1.to_span()
+                span: text.source_span(),
             }
         );
         let Some((head, body)) = text.split_once_fn(char::is_whitespace) else {
             return Ok(None);
         };
-        Ok((head.0 == MAGIC).then_some(body))
+        Ok((head == MAGIC).then_some(body))
     }
 }
 
-fn trim_comment(text: (&str, Range<usize>)) -> Option<(&str, Range<usize>)> {
-    let body = text
+fn trim_comment(text: Spanned<&str>) -> Option<Spanned<&str>> {
+    let text = text
         .trim()
         .strip_prefix_str("<!--")?
         .trim_start()
         .strip_suffix_str("-->")?
         .trim_end();
-    Some(body)
+    Some(text)
 }
 
 #[cfg(test)]
@@ -191,32 +188,37 @@ mod tests {
 
     #[test]
     fn matches() {
-        fn ok(s: &str) -> Option<Marker> {
+        fn ok(text: &str) -> Option<Marker> {
             let config = indoc::indoc! {"
                 [package.metadata.cargo-sync-rdme.badge.badges]
                 [package.metadata.cargo-sync-rdme.badge.badges-foo]
             "};
             let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
-            Marker::matches((s, (0..s.len()).into()), &manifest).unwrap()
+            let text = Spanned::new(text, (0..text.len()).into());
+            let marker = Marker::matches(text, &manifest).unwrap()?;
+            assert_eq!(marker.span, text.span);
+            Some(marker.value)
         }
-        fn err_kind(s: &str) -> String {
+        fn err_kind(text: &str) -> String {
             let config = indoc::indoc! {"
                 [package.metadata.cargo-sync-rdme.badge.badges]
                 [package.metadata.cargo-sync-rdme.badge.badges-foo]
             "};
             let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
-            match Marker::matches((s, (0..s.len()).into()), &manifest).unwrap_err() {
+            let text = Spanned::new(text, (0..text.len()).into());
+            match Marker::matches(text, &manifest).unwrap_err() {
                 ParseMarkerError::UnknownReplaceSpecifier { specifier: s, .. } => s,
                 e => panic!("unexpected: {e}"),
             }
         }
-        fn err_norep(s: &str) {
+        fn err_norep(text: &str) {
             let config = indoc::indoc! {"
                 [package.metadata.cargo-sync-rdme.badge.badges]
                 [package.metadata.cargo-sync-rdme.badge.badges-foo]
             "};
             let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
-            match Marker::matches((s, (0..s.len()).into()), &manifest).unwrap_err() {
+            let text = Spanned::new(text, (0..text.len()).into());
+            match Marker::matches(text, &manifest).unwrap_err() {
                 ParseMarkerError::NoReplaceSpecifier { .. } => {}
                 e => panic!("unexpected: {e}"),
             }

--- a/src/sync/marker/replace.rs
+++ b/src/sync/marker/replace.rs
@@ -1,16 +1,18 @@
 use std::{borrow::Cow, iter, range::Range};
 
+use crate::parse::Spanned;
+
 use super::{super::contents::Contents, Marker, ReplaceSpecifier};
 
 pub(in super::super) fn replace_all(
     text: &str,
-    markers: &[(ReplaceSpecifier, Range<usize>)],
+    markers: &[Spanned<ReplaceSpecifier>],
     contents: &[Contents],
 ) -> String {
     let pairs = markers
         .iter()
         .zip(contents)
-        .map(|((replace, range), contents)| ((replace.clone(), contents), *range));
+        .map(|(replace, contents)| ((replace.value.clone(), contents), replace.span));
 
     interpolate_ranges((0..text.len()).into(), pairs)
         .map(|(contents, range)| match contents {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -164,7 +164,7 @@ pub(crate) fn sync_all(
 
         // Create contents for each marker
         tracing::info!("creating replacement contents for markdown file: {path}");
-        let replaces = all_markers.iter().map(|x| x.0.clone());
+        let replaces = all_markers.iter().map(|x| x.value.clone());
         let all_contents = contents::create_all(replaces, &manifest, workspace, package, options)?;
 
         // Replace markers with content

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -33,23 +33,12 @@ pub(crate) trait StrExt {
     fn substr_range_shim(&self, substr: &str) -> Option<Range<usize>>;
 }
 
-pub(crate) trait StrSpanExt: Sized {
-    fn trim(&self) -> Self {
-        self.trim_start().trim_end()
-    }
-    fn trim_start(&self) -> Self;
-    fn trim_end(&self) -> Self;
-    fn strip_prefix_str(&self, prefix: &str) -> Option<Self>;
-    fn strip_suffix_str(&self, suffix: &str) -> Option<Self>;
-    fn split_once_fn(&self, f: impl Fn(char) -> bool) -> Option<(Self, Self)>;
-}
-
 mod imp {
     use std::{ops, range::Range};
 
     use miette::SourceSpan;
 
-    use crate::traits::{RangeExt, StrExt, StrSpanExt};
+    use crate::traits::{RangeExt, StrExt};
 
     impl RangeExt for Range<usize> {
         fn to_span(self) -> SourceSpan {
@@ -72,43 +61,6 @@ mod imp {
                 return None;
             }
             Some(((substr_start - start)..(substr_end - start)).into())
-        }
-    }
-
-    fn adjust_range(offset: usize, substr_range: Range<usize>) -> Range<usize> {
-        ((offset + substr_range.start)..(offset + substr_range.end)).into()
-    }
-
-    impl StrSpanExt for (&str, Range<usize>) {
-        fn trim_start(&self) -> Self {
-            let substr = self.0.trim_start();
-            let range = adjust_range(self.1.start, self.0.substr_range_shim(substr).unwrap());
-            (substr, range)
-        }
-
-        fn trim_end(&self) -> Self {
-            let substr = self.0.trim_end();
-            let range = adjust_range(self.1.start, self.0.substr_range_shim(substr).unwrap());
-            (substr, range)
-        }
-
-        fn strip_prefix_str(&self, prefix: &str) -> Option<Self> {
-            let substr = self.0.strip_prefix(prefix)?;
-            let range = adjust_range(self.1.start, self.0.substr_range_shim(substr).unwrap());
-            Some((substr, range))
-        }
-
-        fn strip_suffix_str(&self, suffix: &str) -> Option<Self> {
-            let substr = self.0.strip_suffix(suffix)?;
-            let range = adjust_range(self.1.start, self.0.substr_range_shim(substr).unwrap());
-            Some((substr, range))
-        }
-
-        fn split_once_fn(&self, f: impl Fn(char) -> bool) -> Option<(Self, Self)> {
-            let (head, tail) = self.0.split_once(f)?;
-            let head_range = adjust_range(self.1.start, self.0.substr_range_shim(head).unwrap());
-            let tail_range = adjust_range(self.1.start, self.0.substr_range_shim(tail).unwrap());
-            Some(((head, head_range), (tail, tail_range)))
         }
     }
 }


### PR DESCRIPTION
## Summary
- introduce a local `Spanned<T>` type for marker parsing span tracking
- replace ad-hoc `(T, Range<usize>)` pairs in marker parsing/replacement code with `Spanned<T>`
- move span-aware string helper methods from the tuple-based trait impl into `Spanned<&str>`

## Motivation
The marker parsing code was carrying values and source ranges as raw tuples, which made the API less explicit and spread span-aware string operations across trait extensions. This change consolidates that behavior into `Spanned<T>` and makes span propagation more intentional.

## Validation
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Impact
No user-visible behavior change is intended. This is a refactor of the internal marker parsing and replacement flow.
