### PR TITLE
Rename marker find module to scan

### DIFF
--- a/src/sync/marker/mod.rs
+++ b/src/sync/marker/mod.rs
@@ -3,13 +3,13 @@ use std::{fmt, sync::Arc};
 use miette::SourceSpan;
 use snafu::{OptionExt as _, Snafu, ensure};
 
-pub(super) use self::{find::*, replace::*};
+pub(super) use self::{replace::*, scan::*};
 use crate::{config::metadata::BadgeItem, parse::Spanned};
 
 use super::ManifestFile;
 
-mod find;
 mod replace;
+mod scan;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ReplaceSpecifier {

--- a/src/sync/marker/scan.rs
+++ b/src/sync/marker/scan.rs
@@ -12,11 +12,11 @@ use crate::{
 
 use super::{super::MarkdownFile, Marker, ParseMarkerError, ReplaceSpecifier};
 
-pub(in super::super) fn find_all<'events>(
+pub(in super::super) fn scan_all<'events>(
     markdown: &MarkdownFile<'_>,
     manifest: &ManifestFile,
     events: impl IntoIterator<Item = (Event<'events>, Range<usize>)> + 'events,
-) -> Result<Vec<Spanned<ReplaceSpecifier>>, Box<FindAllError>> {
+) -> Result<Vec<Spanned<ReplaceSpecifier>>, Box<ScanAllError>> {
     let events = events.into_iter();
     let it = Iter { manifest, events };
     let mut markers = vec![];
@@ -30,7 +30,7 @@ pub(in super::super) fn find_all<'events>(
 
     ensure!(
         errors.is_empty(),
-        FindAllSnafu {
+        ScanAllSnafu {
             markdown,
             source_code: markdown.to_named_source(),
             errors
@@ -45,17 +45,17 @@ pub(in super::super) fn find_all<'events>(
     "failed to parse `<!-- cargo-sync-rdme ... -->` markers in markdown file for package `{package}`: {markdown}",
     package = markdown.package, markdown = markdown.path,
 ))]
-pub(crate) struct FindAllError {
+pub(crate) struct ScanAllError {
     markdown: MarkdownPath,
     #[source_code]
     source_code: NamedSource<Arc<str>>,
     #[related]
-    errors: Vec<FindError>,
+    errors: Vec<ScanError>,
 }
 
 #[expect(clippy::enum_variant_names)]
 #[derive(Debug, Snafu, miette::Diagnostic)]
-enum FindError {
+enum ScanError {
     #[snafu(transparent)]
     #[diagnostic(transparent)]
     ParseMarker {
@@ -92,7 +92,7 @@ impl<'event, I> Iterator for Iter<'_, I>
 where
     I: Iterator<Item = (Event<'event>, Range<usize>)>,
 {
-    type Item = Result<Spanned<ReplaceSpecifier>, FindError>;
+    type Item = Result<Spanned<ReplaceSpecifier>, ScanError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.try_next().transpose()
@@ -103,7 +103,7 @@ impl<'event, I> Iter<'_, I>
 where
     I: Iterator<Item = (Event<'event>, Range<usize>)>,
 {
-    fn try_next(&mut self) -> Result<Option<Spanned<ReplaceSpecifier>>, FindError> {
+    fn try_next(&mut self) -> Result<Option<Spanned<ReplaceSpecifier>>, ScanError> {
         let Some(start_marker) = self.next_marker()? else {
             return Ok(None);
         };
@@ -142,7 +142,7 @@ impl<'event, I> Iter<'_, I>
 where
     I: Iterator<Item = (Event<'event>, Range<usize>)>,
 {
-    fn next_marker(&mut self) -> Result<Option<Spanned<Marker>>, FindError> {
+    fn next_marker(&mut self) -> Result<Option<Spanned<Marker>>, ScanError> {
         for (event, range) in self.events.by_ref() {
             if let Event::Html(html) = event {
                 let html = Spanned::new(html, range);

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -56,10 +56,10 @@ pub(crate) enum SyncError {
     NoTargetFilesFound { package: PackageName },
     #[snafu(transparent)]
     #[diagnostic(transparent)]
-    FindMarkers {
+    ScanMarkers {
         #[snafu(source)]
         #[diagnostic_source]
-        source: Box<marker::FindAllError>,
+        source: Box<marker::ScanAllError>,
     },
     #[snafu(transparent)]
     #[diagnostic(transparent)]
@@ -110,8 +110,8 @@ impl From<with_source::ReadFileError> for Box<SyncError> {
     }
 }
 
-impl From<Box<marker::FindAllError>> for Box<SyncError> {
-    fn from(value: Box<marker::FindAllError>) -> Self {
+impl From<Box<marker::ScanAllError>> for Box<SyncError> {
+    fn from(value: Box<marker::ScanAllError>) -> Self {
         Box::new(value.into())
     }
 }
@@ -159,8 +159,8 @@ pub(crate) fn sync_all(
             .into_offset_iter()
             .map(|(event, range)| (event, Range::from(range)));
 
-        // Find replace markers from markdown file
-        let all_markers = marker::find_all(&markdown, &manifest, parser)?;
+        // Scan replace markers from markdown file
+        let all_markers = marker::scan_all(&markdown, &manifest, parser)?;
 
         // Create contents for each marker
         tracing::info!("creating replacement contents for markdown file: {path}");


### PR DESCRIPTION
## Summary
- rename `src/sync/marker/find.rs` to `src/sync/marker/scan.rs`
- rename the related APIs and error types from `find` to `scan`
- rename `SyncError::FindMarkers` to `SyncError::ScanMarkers` to keep naming consistent

## Motivation
This code scans the full markdown event stream and collects all markers,
rather than finding a single match, so `scan` is a better name than `find`.

## Validation
- `cargo test`

## Impact
- no behavioral change intended
- internal naming only