### PR TITLE
Refactor badge group parsing

### DIFF
--- a/src/config/metadata.rs
+++ b/src/config/metadata.rs
@@ -29,7 +29,8 @@ pub(crate) struct CargoSyncRdme {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct Badge {
     pub(crate) style: Option<BadgeStyle>,
-    pub(crate) badges: HashMap<Arc<str>, Arc<[BadgeItem]>>,
+    pub(crate) default: Option<Arc<[BadgeItem]>>,
+    pub(crate) groups: HashMap<Arc<str>, Arc<[BadgeItem]>>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -235,17 +236,27 @@ impl<'de> Deserialize<'de> for Badge {
                     let expected = &["badges", "badges-*", "style"];
                     if key.as_str() == "style" {
                         data.style = map.next_value()?;
-                    } else {
-                        let key = if key == "badges" {
-                            String::new()
-                        } else if let Some(rest) = key.strip_prefix("badges-") {
-                            rest.to_owned()
-                        } else {
-                            return Err(M::Error::unknown_field(&key, expected));
-                        };
-                        let value = map.next_value::<BadgeList>()?;
-                        data.badges.entry(key.into()).or_insert(value.0);
+                        continue;
                     }
+                    if key == "badges" {
+                        let value = map.next_value::<BadgeList>()?;
+                        if data.default.replace(value.0).is_some() {
+                            return Err(M::Error::duplicate_field("badges"));
+                        }
+                        continue;
+                    }
+                    if let Some(rest) = key.strip_prefix("badges-") {
+                        if rest.is_empty() {
+                            return Err(M::Error::custom(format_args!(
+                                "invalid field name: `{key}` (expected `badges-*` where `*` is a non-empty string)"
+                            )));
+                        }
+                        let group = rest.to_owned();
+                        let value = map.next_value::<BadgeList>()?;
+                        data.groups.entry(group.into()).or_insert(value.0);
+                        continue;
+                    }
+                    return Err(M::Error::unknown_field(&key, expected));
                 }
 
                 Ok(data)

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4,7 +4,7 @@ use indoc::{formatdoc, indoc};
 use similar_asserts::assert_eq;
 
 use crate::config::metadata::{
-    BadgeItem, Codecov, GithubActions, GithubActionsWorkflow, License, Rustdoc,
+    Badge, BadgeItem, Codecov, GithubActions, GithubActionsWorkflow, License, Rustdoc,
 };
 
 use super::*;
@@ -17,6 +17,14 @@ fn badge_manifest(config: &str) -> Manifest {
     .unwrap()
 }
 
+fn badge_manifest_err(config: &str) -> toml::de::Error {
+    toml::from_str::<Manifest>(&formatdoc! {r"
+        [package.metadata.cargo-sync-rdme.badge]
+        {config}
+    "})
+    .unwrap_err()
+}
+
 fn rustdoc_manifest(config: &str) -> Manifest {
     toml::from_str(&formatdoc! {r"
         [package.metadata.cargo-sync-rdme.rustdoc]
@@ -25,8 +33,8 @@ fn rustdoc_manifest(config: &str) -> Manifest {
     .unwrap()
 }
 
-fn get_badge_group(manifest: Manifest, group: &str) -> Arc<[BadgeItem]> {
-    let badges = &manifest
+fn get_badge_table(manifest: Manifest) -> Badge {
+    manifest
         .package
         .unwrap()
         .into_inner()
@@ -35,12 +43,14 @@ fn get_badge_group(manifest: Manifest, group: &str) -> Arc<[BadgeItem]> {
         .into_inner()
         .cargo_sync_rdme
         .badge
-        .badges[group];
-    Arc::clone(badges)
 }
 
-fn get_badges(manifest: Manifest) -> Arc<[BadgeItem]> {
-    get_badge_group(manifest, "")
+fn get_badge_group(manifest: Manifest, group: &str) -> Arc<[BadgeItem]> {
+    Arc::clone(&get_badge_table(manifest).groups[group])
+}
+
+fn get_default_badges(manifest: Manifest) -> Arc<[BadgeItem]> {
+    Arc::clone(&get_badge_table(manifest).default.unwrap())
 }
 
 fn get_rustdoc(manifest: Manifest) -> Rustdoc {
@@ -57,7 +67,7 @@ fn get_rustdoc(manifest: Manifest) -> Rustdoc {
 
 #[test]
 fn test_badges_order() {
-    let badges = get_badges(badge_manifest(indoc! {r"
+    let badges = get_default_badges(badge_manifest(indoc! {r"
         badges = {
           license = true,
           maintenance = true,
@@ -82,7 +92,7 @@ fn test_badges_order() {
 
 #[test]
 fn test_duplicated_badges() {
-    let badges = get_badges(badge_manifest(indoc! {r"
+    let badges = get_default_badges(badge_manifest(indoc! {r"
         badges = {
           license = true,
           license-x = true,
@@ -116,8 +126,16 @@ fn test_badge_groups() {
 }
 
 #[test]
+fn test_invalid_badge_group_names() {
+    let err = badge_manifest_err(indoc! {r"
+        badges- = {}
+    "});
+    assert!(err.to_string().contains("invalid field name: `badges-`"));
+}
+
+#[test]
 fn test_old_badge_table_syntax_still_parses() {
-    let badges = get_badges(
+    let badges = get_default_badges(
         toml::from_str(indoc! {r"
             [package.metadata.cargo-sync-rdme.badge.badges]
             license = true
@@ -129,28 +147,28 @@ fn test_old_badge_table_syntax_still_parses() {
 
 #[test]
 fn test_license() {
-    let badges = get_badges(badge_manifest(indoc! {r"
+    let badges = get_default_badges(badge_manifest(indoc! {r"
         badges = {
           license = true,
         }
     "}));
     assert_matches!(&*badges, [BadgeItem::License(License { link: None })]);
 
-    let badges = get_badges(badge_manifest(indoc! {r"
+    let badges = get_default_badges(badge_manifest(indoc! {r"
         badges = {
           license = false,
         }
     "}));
     assert_matches!(&*badges, []);
 
-    let badges = get_badges(badge_manifest(indoc! {r"
+    let badges = get_default_badges(badge_manifest(indoc! {r"
         badges = {
           license = {},
         }
     "}));
     assert_matches!(&*badges, [BadgeItem::License(License { link: None })]);
 
-    let badges = get_badges(badge_manifest(indoc! {r#"
+    let badges = get_default_badges(badge_manifest(indoc! {r#"
         badges = {
           license = { link = "foo" },
         }
@@ -163,7 +181,7 @@ fn test_license() {
 
 #[test]
 fn test_github_actions() {
-    let badges = get_badges(badge_manifest(indoc! {r"
+    let badges = get_default_badges(badge_manifest(indoc! {r"
         badges = {
           github-actions = true,
         }
@@ -173,14 +191,14 @@ fn test_github_actions() {
         [BadgeItem::GithubActions(GithubActions { workflows })] if matches!(workflows.as_slice(), &[])
     );
 
-    let badges = get_badges(badge_manifest(indoc! {r"
+    let badges = get_default_badges(badge_manifest(indoc! {r"
         badges = {
           github-actions = false,
         }
     "}));
     assert_matches!(*badges, []);
 
-    let badges = get_badges(badge_manifest(indoc! {r"
+    let badges = get_default_badges(badge_manifest(indoc! {r"
         badges = {
           github-actions = {},
         }
@@ -190,7 +208,7 @@ fn test_github_actions() {
         [BadgeItem::GithubActions(GithubActions { workflows })] if matches!(workflows.as_slice(), &[])
     );
 
-    let badges = get_badges(badge_manifest(indoc! {r#"
+    let badges = get_default_badges(badge_manifest(indoc! {r#"
         badges = {
           github-actions = { workflows = "foo.yml" },
         }
@@ -206,7 +224,7 @@ fn test_github_actions() {
         )
     );
 
-    let badges = get_badges(badge_manifest(indoc! {r#"
+    let badges = get_default_badges(badge_manifest(indoc! {r#"
         badges = {
           github-actions = { workflows = { file = "foo.yml" } },
         }
@@ -222,7 +240,7 @@ fn test_github_actions() {
         )
     );
 
-    let badges = get_badges(badge_manifest(indoc! {r#"
+    let badges = get_default_badges(badge_manifest(indoc! {r#"
         badges = {
           github-actions = { workflows = [ "foo.yml", { file = "bar.yml" } ] },
         }
@@ -240,7 +258,7 @@ fn test_github_actions() {
 
 #[test]
 fn test_codecov() {
-    let badges = get_badges(badge_manifest(indoc! {r"
+    let badges = get_default_badges(badge_manifest(indoc! {r"
         badges = {
           codecov = true,
         }
@@ -253,14 +271,14 @@ fn test_codecov() {
         })]
     );
 
-    let badges = get_badges(badge_manifest(indoc! {r"
+    let badges = get_default_badges(badge_manifest(indoc! {r"
         badges = {
           codecov = false,
         }
     "}));
     assert_matches!(*badges, []);
 
-    let badges = get_badges(badge_manifest(indoc! {r"
+    let badges = get_default_badges(badge_manifest(indoc! {r"
         badges = {
           codecov = {},
         }
@@ -273,7 +291,7 @@ fn test_codecov() {
         })]
     );
 
-    let badges = get_badges(badge_manifest(indoc! {r#"
+    let badges = get_default_badges(badge_manifest(indoc! {r#"
         badges = {
           codecov = { component = "core" },
         }
@@ -286,7 +304,7 @@ fn test_codecov() {
         })] if component == "core"
     );
 
-    let badges = get_badges(badge_manifest(indoc! {r#"
+    let badges = get_default_badges(badge_manifest(indoc! {r#"
         badges = {
           codecov = { flag = "unit" },
         }
@@ -299,7 +317,7 @@ fn test_codecov() {
         })] if flag == "unit"
     );
 
-    let badges = get_badges(badge_manifest(indoc! {r#"
+    let badges = get_default_badges(badge_manifest(indoc! {r#"
         badges = {
           codecov = { component = "core", flag = "unit" },
         }

--- a/src/sync/contents/mod.rs
+++ b/src/sync/contents/mod.rs
@@ -73,7 +73,7 @@ impl ResolvedReplaceSpecifier {
     ) -> Result<Contents, CreateContentsError> {
         let text = match self {
             ResolvedReplaceSpecifier::Title => title::create(package),
-            ResolvedReplaceSpecifier::Badge { name: _, badges } => {
+            ResolvedReplaceSpecifier::Badge { group: _, badges } => {
                 badge::create_all(&badges, manifest, workspace, package)?
             }
             ResolvedReplaceSpecifier::Rustdoc => {

--- a/src/sync/marker/resolve.rs
+++ b/src/sync/marker/resolve.rs
@@ -27,7 +27,7 @@ pub(super) enum ResolvedMarker {
 pub(in super::super) enum ResolvedReplaceSpecifier {
     Title,
     Badge {
-        name: Arc<str>,
+        group: Option<Arc<str>>,
         badges: Arc<[BadgeItem]>,
     },
     Rustdoc,
@@ -47,11 +47,11 @@ impl fmt::Display for ResolvedReplaceSpecifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Title => write!(f, "title"),
-            Self::Badge { name, .. } => {
-                if name.is_empty() {
-                    write!(f, "badge")
-                } else {
+            Self::Badge { group, .. } => {
+                if let Some(name) = group {
                     write!(f, "badge:{name}")
+                } else {
+                    write!(f, "badge")
                 }
             }
             Self::Rustdoc => write!(f, "rustdoc"),
@@ -136,28 +136,31 @@ fn resolve_specifier(
         }
     }
 
-    let badges = &manifest.value().config().badge.badges;
-    let (name, badges) = if let Some(group) = group {
-        badges.get_key_value(group.value).ok_or_else(|| {
+    let badge = &manifest.value().config().badge;
+    if let Some(group) = group {
+        let (group, badges) = badge.groups.get_key_value(group.value).ok_or_else(|| {
             NoSuchBadgeGroupSnafu {
                 group: group.value,
                 span: group.source_span(),
             }
             .build()
-        })?
+        })?;
+        Ok(ResolvedReplaceSpecifier::Badge {
+            group: Some(Arc::clone(group)),
+            badges: Arc::clone(badges),
+        })
     } else {
-        badges.get_key_value("").ok_or_else(|| {
+        let badges = badge.default.as_ref().ok_or_else(|| {
             NoDefaultBadgeConfiguredSnafu {
                 span: specifier.source_span(),
             }
             .build()
-        })?
-    };
-
-    Ok(ResolvedReplaceSpecifier::Badge {
-        name: Arc::clone(name),
-        badges: Arc::clone(badges),
-    })
+        })?;
+        Ok(ResolvedReplaceSpecifier::Badge {
+            group: None,
+            badges: Arc::clone(badges),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -200,20 +203,22 @@ mod tests {
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme badge -->");
         let resolved = resolve(source, CONFIG).unwrap();
-        let ResolvedMarker::Replace(ResolvedReplaceSpecifier::Badge { name, .. }) = &resolved.value
+        let ResolvedMarker::Replace(ResolvedReplaceSpecifier::Badge { group, .. }) =
+            &resolved.value
         else {
             panic!("unexpected: {resolved:?}");
         };
-        assert!(name.is_empty());
+        assert!(group.is_none());
         source.assert_span(resolved, "<!-- cargo-sync-rdme badge -->");
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme badge:foo -->");
         let resolved = resolve(source, CONFIG).unwrap();
-        let ResolvedMarker::Replace(ResolvedReplaceSpecifier::Badge { name, .. }) = &resolved.value
+        let ResolvedMarker::Replace(ResolvedReplaceSpecifier::Badge { group, .. }) =
+            &resolved.value
         else {
             panic!("unexpected: {resolved:?}");
         };
-        assert_eq!(name.as_ref(), "foo");
+        assert_eq!(group.as_deref().unwrap(), "foo");
         source.assert_span(resolved, "<!-- cargo-sync-rdme badge:foo -->");
     }
 

--- a/src/sync/marker/scan.rs
+++ b/src/sync/marker/scan.rs
@@ -208,7 +208,7 @@ mod tests {
             ResolvedMarker::Replace(ResolvedReplaceSpecifier::Title).to_string(),
             "Good afternoon, world!".to_string(),
             ResolvedMarker::Replace(ResolvedReplaceSpecifier::Badge {
-                name: "".into(),
+                group: None,
                 badges: vec![].into(),
             })
             .to_string(),
@@ -237,7 +237,7 @@ mod tests {
             markers.next().unwrap().unwrap(),
             Spanned::new(
                 ResolvedReplaceSpecifier::Badge {
-                    name: "".into(),
+                    group: None,
                     badges: vec![].into()
                 },
                 ranges[3],


### PR DESCRIPTION
## Summary
- refactor badge metadata parsing to split default badges from named badge groups
- replace the empty-string default-group sentinel with an explicit optional badge group
- reject `badges-` so empty badge group names are no longer accepted

## Motivation
This is a parsing-focused cleanup to make the badge structure easier to reason about and to prepare for stricter badge group name validation in follow-up changes.

## Validation
- `cargo test`

## Impact
No intended user-visible behavior change beyond rejecting the invalid `badges-` field name.