### PR TITLE
Restrict badge group names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* (Breaking) Restrict badge group names in Cargo metadata and `<!-- cargo-sync-rdme badge:... -->` markers to identifier-like names matching `[A-Za-z][-_A-Za-z0-9]*`.
 * Use the same styling for `--help` output as Cargo.
 * When `--color` is not specified, colored output now follows whether stderr is connected to a terminal and respects the `NO_COLOR` and `FORCE_COLOR` environment variables.
 * Respect the `CARGO` environment variable when invoking Cargo to build rustdoc output, except when `--toolchain` is specified.

--- a/src/config/metadata.rs
+++ b/src/config/metadata.rs
@@ -6,6 +6,8 @@ use serde::{
 };
 use void::Void;
 
+use crate::parse;
+
 use super::de;
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -233,7 +235,7 @@ impl<'de> Deserialize<'de> for Badge {
                 let mut data = Badge::default();
 
                 while let Some(key) = map.next_key::<String>()? {
-                    let expected = &["badges", "badges-*", "style"];
+                    let expected = &["badges", "badges-<group>", "style"];
                     if key.as_str() == "style" {
                         data.style = map.next_value()?;
                         continue;
@@ -246,9 +248,9 @@ impl<'de> Deserialize<'de> for Badge {
                         continue;
                     }
                     if let Some(rest) = key.strip_prefix("badges-") {
-                        if rest.is_empty() {
+                        if !parse::is_valid_ident(rest) {
                             return Err(M::Error::custom(format_args!(
-                                "invalid field name: `{key}` (expected `badges-*` where `*` is a non-empty string)"
+                                "invalid field name: `{key}` (expected `badges-<group>` where `<group>` matches `[A-Za-z][-_A-Za-z0-9]*`)"
                             )));
                         }
                         let group = rest.to_owned();

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -123,14 +123,32 @@ fn test_badge_groups() {
         "foo",
     );
     assert_matches!(*badges, [BadgeItem::License(_), BadgeItem::Maintenance]);
+
+    let badges = get_badge_group(
+        badge_manifest(indoc! {r"
+            badges-foo_123-bar = {
+              license = true,
+              maintenance = true,
+            }
+        "}),
+        "foo_123-bar",
+    );
+    assert_matches!(*badges, [BadgeItem::License(_), BadgeItem::Maintenance]);
 }
 
 #[test]
 fn test_invalid_badge_group_names() {
-    let err = badge_manifest_err(indoc! {r"
-        badges- = {}
-    "});
+    let err = badge_manifest_err("badges- = {}");
     assert!(err.to_string().contains("invalid field name: `badges-`"));
+
+    let err = badge_manifest_err("badges-123 = {}");
+    assert!(err.to_string().contains("invalid field name: `badges-123`"));
+
+    let err = badge_manifest_err(r#""badges-!" = {}"#);
+    assert!(err.to_string().contains("invalid field name: `badges-!`"));
+
+    let err = badge_manifest_err(r#""badges- " = {}"#);
+    assert!(err.to_string().contains("invalid field name: `badges- `"));
 }
 
 #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -7,6 +7,28 @@ use miette::SourceSpan;
 
 use crate::traits::StrExt as _;
 
+pub(crate) fn is_valid_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if is_ident_start(c) => (),
+        _ => return false,
+    }
+    for c in chars {
+        if !is_ident_continue(c) {
+            return false;
+        }
+    }
+    true
+}
+
+pub(crate) fn is_ident_start(c: char) -> bool {
+    c.is_ascii_alphabetic()
+}
+
+pub(crate) fn is_ident_continue(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '-'
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Spanned<T> {
     pub(crate) value: T,
@@ -14,7 +36,11 @@ pub(crate) struct Spanned<T> {
 }
 
 impl<T> Spanned<T> {
-    pub(crate) fn new(value: T, span: Range<usize>) -> Self {
+    pub(crate) fn new<R>(value: T, span: R) -> Self
+    where
+        R: Into<Range<usize>>,
+    {
+        let span = span.into();
         Self { value, span }
     }
 
@@ -67,6 +93,12 @@ impl<'a> Spanned<&'a str> {
         self.assert_span(target, expected);
     }
 
+    pub(crate) fn prefix_of(&self, other: Self) -> Self {
+        let end = other.span.start - self.span.start;
+        let prefix = &self.value[..end];
+        self.substr(prefix)
+    }
+
     pub(crate) fn end(&self) -> Self {
         let end = &self.value[self.value.len()..];
         self.substr(end)
@@ -102,12 +134,7 @@ impl<'a> Spanned<&'a str> {
         Some((self.substr(head), self.substr(tail)))
     }
 
-    pub(crate) fn split_once_char(&self, c: char) -> Option<(Self, Self)> {
-        let (head, tail) = self.value.split_once(c)?;
-        Some((self.substr(head), self.substr(tail)))
-    }
-
-    fn substr(&self, substr: &'a str) -> Self {
+    pub(crate) fn substr(&self, substr: &'a str) -> Self {
         let range = self.value.substr_range_shim(substr).unwrap();
         Spanned {
             value: substr,

--- a/src/sync/marker/parse.rs
+++ b/src/sync/marker/parse.rs
@@ -1,14 +1,17 @@
 use std::fmt::{self, Display};
 
 use miette::{Diagnostic, SourceSpan};
-use snafu::{Snafu, ensure};
+use snafu::{OptionExt as _, Snafu, ensure};
 
-use crate::{parse::Spanned, sync::marker::MAGIC, traits::RangeExt as _};
+use crate::{
+    parse::{self, Spanned},
+    sync::marker::MAGIC,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum Marker<'a> {
-    Replace(Spanned<ReplaceSpecifier<'a>>),
-    Start(Spanned<ReplaceSpecifier<'a>>),
+    Replace(SpannedReplaceSpecifier<'a>),
+    Start(SpannedReplaceSpecifier<'a>),
     End,
 }
 
@@ -31,26 +34,38 @@ impl Display for ReplaceSpecifier<'_> {
 
 #[derive(Debug, Snafu, Diagnostic)]
 pub(crate) enum ParseMarkerError {
-    #[snafu(display("no replacement specifier found"))]
-    NoReplaceSpecifier {
+    #[snafu(display("unexpected token: `{token}`, expected: {expected}"))]
+    UnexpectedToken {
+        token: String,
+        expected: String,
         #[label]
         span: SourceSpan,
     },
-    #[snafu(display("empty marker kind"))]
-    EmptyMarkerKind {
-        #[label]
-        span: SourceSpan,
-    },
-    #[snafu(display("empty group name"))]
-    EmptyGroupName {
+    #[snafu(display("unexpected end of marker, expected: {expected}"))]
+    UnexpectedEndOfMarker {
+        expected: String,
         #[label]
         span: SourceSpan,
     },
 }
 
-pub(super) fn parse_marker(
-    html: Spanned<&str>,
-) -> Result<Option<Spanned<Marker<'_>>>, ParseMarkerError> {
+type Input<'a> = Spanned<&'a str>;
+type SpannedMarker<'a> = Spanned<Marker<'a>>;
+type SpannedReplaceSpecifier<'a> = Spanned<ReplaceSpecifier<'a>>;
+type SpannedToken<'a> = Spanned<Token<'a>>;
+
+// Marker syntax:
+//
+// marker ::= replace-marker | start-marker | end-marker
+// replace-marker ::= "<!-- cargo-sync-rdme " specifier " -->"
+// start-marker ::= "<!-- cargo-sync-rdme " specifier " [[ -->"
+// end-marker ::= "<!-- cargo-sync-rdme ]] -->"
+// specifier ::= marker-kind [ ":" group-name ]
+// marker-kind ::= ident
+// group-name ::= ident
+// ident ::= [A-Za-z][-_A-Za-z0-9]*
+
+pub(super) fn parse_marker(html: Input<'_>) -> Result<Option<SpannedMarker<'_>>, ParseMarkerError> {
     let html_span = html.span;
 
     let Some(comment_body) = trim_comment(html) else {
@@ -60,72 +75,52 @@ pub(super) fn parse_marker(
         return Ok(None);
     };
 
-    ensure!(
-        !marker_body.value.is_empty(),
-        NoReplaceSpecifierSnafu {
-            span: html_span.to_span(),
-        }
-    );
-
-    if let Some(specifier) = marker_body.strip_suffix_str("[[") {
-        let Some(specifier) = parse_specifier(specifier)? else {
-            return Err(NoReplaceSpecifierSnafu {
-                span: html_span.to_span(),
-            }
-            .build());
-        };
-        return Ok(Some(Spanned::new(Marker::Start(specifier), html_span)));
-    }
-
-    if marker_body == "]]" {
+    let Some((specifier, rest)) = parse_specifier(marker_body)? else {
+        let (_, rest) = expect_token(marker_body, Token::EndMarkerSymbol, "marker kind or `]]`")?;
+        expect_end_of_marker(rest)?;
         return Ok(Some(Spanned::new(Marker::End, html_span)));
-    }
-
-    let Some(specifier) = parse_specifier(marker_body)? else {
-        return Err(NoReplaceSpecifierSnafu {
-            span: html_span.to_span(),
-        }
-        .build());
     };
-    Ok(Some(Spanned::new(Marker::Replace(specifier), html_span)))
+
+    if next_token(rest).is_none() {
+        return Ok(Some(Spanned::new(Marker::Replace(specifier), html_span)));
+    }
+    let (_token, rest) = expect_token(rest, Token::StartMarkerSymbol, "end of marker or `[[`")?;
+    expect_end_of_marker(rest)?;
+    Ok(Some(Spanned::new(Marker::Start(specifier), html_span)))
 }
 
 fn parse_specifier(
-    marker_body: Spanned<&str>,
-) -> Result<Option<Spanned<ReplaceSpecifier<'_>>>, ParseMarkerError> {
-    let specifier = marker_body.trim();
-
-    if specifier.value.is_empty() {
+    input: Input<'_>,
+) -> Result<Option<(SpannedReplaceSpecifier<'_>, Input<'_>)>, ParseMarkerError> {
+    let input = input.trim_start();
+    let Ok((kind, rest)) = expect_ident(input, "marker kind") else {
         return Ok(None);
-    }
-
-    let (kind, group) = match specifier.split_once_char(':') {
-        Some((kind, group)) => (kind, Some(group)),
-        None => (specifier, None),
     };
-    let kind = kind.trim();
-    let group = group.map(|g| g.trim());
 
-    if kind.value.is_empty() {
-        return Err(EmptyMarkerKindSnafu {
-            span: specifier.source_span(),
-        }
-        .build());
-    }
-    if group.is_some_and(|group| group.value.is_empty()) {
-        return Err(EmptyGroupNameSnafu {
-            span: specifier.source_span(),
-        }
-        .build());
-    }
+    let Ok((_colon, rest)) = expect_token(rest, Token::Colon, "`:`") else {
+        return Ok(Some((
+            Spanned::new(
+                ReplaceSpecifier { kind, group: None },
+                input.prefix_of(rest).span,
+            ),
+            rest,
+        )));
+    };
 
-    Ok(Some(Spanned::new(
-        ReplaceSpecifier { kind, group },
-        specifier.span,
+    let (group, rest) = expect_ident(rest, "group name")?;
+    Ok(Some((
+        Spanned::new(
+            ReplaceSpecifier {
+                kind,
+                group: Some(group),
+            },
+            input.prefix_of(rest).span,
+        ),
+        rest,
     )))
 }
 
-fn trim_magic(comment_body: Spanned<&str>) -> Option<Spanned<&str>> {
+fn trim_magic(comment_body: Input<'_>) -> Option<Input<'_>> {
     let (head, tail) = comment_body
         .split_once_fn(char::is_whitespace)
         .unwrap_or((comment_body, comment_body.end()));
@@ -135,7 +130,7 @@ fn trim_magic(comment_body: Spanned<&str>) -> Option<Spanned<&str>> {
     Some(tail.trim())
 }
 
-fn trim_comment(html: Spanned<&str>) -> Option<Spanned<&str>> {
+fn trim_comment(html: Input<'_>) -> Option<Input<'_>> {
     let comment_body = html
         .trim()
         .strip_prefix_str("<!--")?
@@ -145,9 +140,135 @@ fn trim_comment(html: Spanned<&str>) -> Option<Spanned<&str>> {
     Some(comment_body)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Token<'a> {
+    Ident(&'a str),
+    Colon,
+    UnknownChar(&'a str),
+    StartMarkerSymbol,
+    EndMarkerSymbol,
+}
+
+impl Display for Token<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Token::Ident(s) | Token::UnknownChar(s) => s.fmt(f),
+            Token::Colon => ":".fmt(f),
+            Token::StartMarkerSymbol => "[[".fmt(f),
+            Token::EndMarkerSymbol => "]]".fmt(f),
+        }
+    }
+}
+
+fn eat_str<'a>(input: Input<'a>, target: &str) -> Option<(Input<'a>, Input<'a>)> {
+    let rest = input.strip_prefix_str(target)?;
+    let token = input.prefix_of(rest);
+    Some((token, rest))
+}
+
+fn eat_ident(input: Input<'_>) -> Option<(Input<'_>, Input<'_>)> {
+    let mut it = input.value.chars();
+    if !it.as_str().starts_with(parse::is_ident_start) {
+        return None;
+    }
+    it.next();
+    while it.as_str().starts_with(parse::is_ident_continue) {
+        it.next();
+    }
+    let rest = input.substr(it.as_str());
+    let ident = input.prefix_of(rest);
+    Some((ident, rest))
+}
+
+fn eat_char(input: Input<'_>) -> Option<(Input<'_>, Input<'_>)> {
+    let mut it = input.value.chars();
+    let _ = it.next()?;
+    let rest = input.substr(it.as_str());
+    let token = input.prefix_of(rest);
+    Some((token, rest))
+}
+
+fn next_token(input: Input<'_>) -> Option<(SpannedToken<'_>, Input<'_>)> {
+    let input = input.trim_start();
+    if let Some((token, rest)) = eat_str(input, "[[") {
+        let token = Spanned::new(Token::StartMarkerSymbol, token.span);
+        return Some((token, rest));
+    }
+    if let Some((token, rest)) = eat_str(input, "]]") {
+        let token = Spanned::new(Token::EndMarkerSymbol, token.span);
+        return Some((token, rest));
+    }
+    if let Some((token, rest)) = eat_str(input, ":") {
+        let token = Spanned::new(Token::Colon, token.span);
+        return Some((token, rest));
+    }
+    if let Some((token, rest)) = eat_ident(input) {
+        let token = Spanned::new(Token::Ident(token.value), token.span);
+        return Some((token, rest));
+    }
+    if let Some((token, rest)) = eat_char(input) {
+        let token = Spanned::new(Token::UnknownChar(token.value), token.span);
+        return Some((token, rest));
+    }
+    None
+}
+
+fn expect_token<'a>(
+    input: Input<'a>,
+    expected_token: Token<'_>,
+    expected: &str,
+) -> Result<(SpannedToken<'a>, Input<'a>), ParseMarkerError> {
+    let (token, rest) = next_token(input).with_context(|| UnexpectedEndOfMarkerSnafu {
+        expected,
+        span: input.end().source_span(),
+    })?;
+    ensure!(
+        token.value == expected_token,
+        UnexpectedTokenSnafu {
+            token: token.value.to_string(),
+            expected,
+            span: token.source_span(),
+        }
+    );
+    Ok((token, rest))
+}
+
+fn expect_ident<'a>(
+    input: Input<'a>,
+    expected: &str,
+) -> Result<(Input<'a>, Input<'a>), ParseMarkerError> {
+    let (token, rest) = next_token(input).with_context(|| UnexpectedEndOfMarkerSnafu {
+        expected,
+        span: input.end().source_span(),
+    })?;
+    let Token::Ident(ident) = token.value else {
+        return Err(UnexpectedTokenSnafu {
+            token: token.value.to_string(),
+            expected,
+            span: token.source_span(),
+        }
+        .build());
+    };
+    Ok((Spanned::new(ident, token.span), rest))
+}
+
+fn expect_end_of_marker(input: Input<'_>) -> Result<(), ParseMarkerError> {
+    let Some((token, _rest)) = next_token(input) else {
+        return Ok(());
+    };
+    Err(UnexpectedTokenSnafu {
+        token: token.value.to_string(),
+        expected: "end of marker",
+        span: token.source_span(),
+    }
+    .build())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use similar_asserts::assert_eq;
 
     #[test]
     fn parse_marker_parses_markers() {
@@ -183,17 +304,54 @@ mod tests {
     fn parse_marker_rejects_invalid_markers() {
         let source = Spanned::from_str("<!-- cargo-sync-rdme -->");
         let err = parse_marker(source).unwrap_err();
-        let ParseMarkerError::NoReplaceSpecifier { span } = err else {
+        let ParseMarkerError::UnexpectedEndOfMarker { expected, span } = err else {
             panic!("unexpected error: {err:?}");
         };
-        source.assert_source_span(span, "<!-- cargo-sync-rdme -->");
+        assert_eq!(expected, "marker kind or `]]`");
+        source.assert_source_span(span, "");
+        assert_eq!(span.offset(), source.value.len() - " -->".len());
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme [[ -->");
         let err = parse_marker(source).unwrap_err();
-        let ParseMarkerError::NoReplaceSpecifier { span } = err else {
+        let ParseMarkerError::UnexpectedToken {
+            token,
+            expected,
+            span,
+        } = err
+        else {
             panic!("unexpected error: {err:?}");
         };
-        source.assert_source_span(span, "<!-- cargo-sync-rdme [[ -->");
+        assert_eq!(token, "[[");
+        assert_eq!(expected, "marker kind or `]]`");
+        source.assert_source_span(span, "[[");
+
+        let source = Spanned::from_str("<!-- cargo-sync-rdme badge:123 -->");
+        let err = parse_marker(source).unwrap_err();
+        let ParseMarkerError::UnexpectedToken {
+            token,
+            expected,
+            span,
+        } = err
+        else {
+            panic!("unexpected error: {err:?}");
+        };
+        assert_eq!(token, "1");
+        assert_eq!(expected, "group name");
+        source.assert_source_span(span, "1");
+
+        let source = Spanned::from_str("<!-- cargo-sync-rdme badge:bar xxx -->");
+        let err = parse_marker(source).unwrap_err();
+        let ParseMarkerError::UnexpectedToken {
+            token,
+            expected,
+            span,
+        } = err
+        else {
+            panic!("unexpected error: {err:?}");
+        };
+        assert_eq!(token, "xxx");
+        assert_eq!(expected, "end of marker or `[[`");
+        source.assert_source_span(span, "xxx");
     }
 
     #[test]
@@ -205,28 +363,32 @@ mod tests {
     #[test]
     fn parse_specifier_parses_kind_and_group() {
         let source = Spanned::from_str("kind:group");
-        let specifier = parse_specifier(source).unwrap().unwrap();
+        let (specifier, rest) = parse_specifier(source).unwrap().unwrap();
         source.assert_span(specifier, "kind:group");
         source.assert_spanned_str(specifier.value.kind, "kind");
         source.assert_spanned_str(specifier.value.group.unwrap(), "group");
+        source.assert_spanned_str(rest, "");
 
         let source = Spanned::from_str(" kind:group ");
-        let specifier = parse_specifier(source).unwrap().unwrap();
+        let (specifier, rest) = parse_specifier(source).unwrap().unwrap();
         source.assert_span(specifier, "kind:group");
         source.assert_spanned_str(specifier.value.kind, "kind");
         source.assert_spanned_str(specifier.value.group.unwrap(), "group");
+        source.assert_spanned_str(rest, " ");
 
-        let source = Spanned::from_str(" kind : group ");
-        let specifier = parse_specifier(source).unwrap().unwrap();
+        let source = Spanned::from_str(" kind : group xxx");
+        let (specifier, rest) = parse_specifier(source).unwrap().unwrap();
         source.assert_span(specifier, "kind : group");
         source.assert_spanned_str(specifier.value.kind, "kind");
         source.assert_spanned_str(specifier.value.group.unwrap(), "group");
+        source.assert_spanned_str(rest, " xxx");
 
         let source = Spanned::from_str(" kind ");
-        let specifier = parse_specifier(source).unwrap().unwrap();
+        let (specifier, rest) = parse_specifier(source).unwrap().unwrap();
         source.assert_span(specifier, "kind");
         source.assert_spanned_str(specifier.value.kind, "kind");
         assert!(specifier.value.group.is_none());
+        source.assert_spanned_str(rest, " ");
 
         let source = Spanned::from_str("  ");
         assert!(parse_specifier(source).unwrap().is_none());
@@ -236,17 +398,15 @@ mod tests {
     fn parse_specifier_rejects_invalid_specifiers() {
         let source = Spanned::from_str(" kind: ");
         let err = parse_specifier(source).unwrap_err();
-        let ParseMarkerError::EmptyGroupName { span } = err else {
+        let ParseMarkerError::UnexpectedEndOfMarker { expected, span } = err else {
             panic!("unexpected error: {err:?}");
         };
-        source.assert_source_span(span, "kind:");
+        assert_eq!(expected, "group name");
+        source.assert_source_span(span, "");
+        assert_eq!(span.offset(), source.value.len());
 
         let source = Spanned::from_str(" :group");
-        let err = parse_specifier(source).unwrap_err();
-        let ParseMarkerError::EmptyMarkerKind { span } = err else {
-            panic!("unexpected error: {err:?}");
-        };
-        source.assert_source_span(span, ":group");
+        assert!(parse_specifier(source).unwrap().is_none());
     }
 
     #[test]
@@ -280,5 +440,79 @@ mod tests {
         assert!(trim_comment(source).is_none());
         let source = Spanned::from_str("<!--test");
         assert!(trim_comment(source).is_none());
+    }
+
+    #[test]
+    fn next_token_parses_tokens() {
+        let source = Spanned::from_str("kind:group kind-x : group_y[[ ]]");
+        let (token, rest) = next_token(source).unwrap();
+        assert_eq!(token.value, Token::Ident("kind"));
+        source.assert_span(token, "kind");
+        source.assert_spanned_str(rest, ":group kind-x : group_y[[ ]]");
+
+        let (token, rest) = next_token(rest).unwrap();
+        assert_eq!(token.value, Token::Colon);
+        source.assert_span(token, ":");
+        source.assert_spanned_str(rest, "group kind-x : group_y[[ ]]");
+
+        let (token, rest) = next_token(rest).unwrap();
+        assert_eq!(token.value, Token::Ident("group"));
+        source.assert_span(token, "group");
+        source.assert_spanned_str(rest, " kind-x : group_y[[ ]]");
+
+        let (token, rest) = next_token(rest).unwrap();
+        assert_eq!(token.value, Token::Ident("kind-x"));
+        source.assert_span(token, "kind-x");
+        source.assert_spanned_str(rest, " : group_y[[ ]]");
+
+        let (token, rest) = next_token(rest).unwrap();
+        assert_eq!(token.value, Token::Colon);
+        source.assert_span(token, ":");
+        source.assert_spanned_str(rest, " group_y[[ ]]");
+
+        let (token, rest) = next_token(rest).unwrap();
+        assert_eq!(token.value, Token::Ident("group_y"));
+        source.assert_span(token, "group_y");
+        source.assert_spanned_str(rest, "[[ ]]");
+
+        let (token, rest) = next_token(rest).unwrap();
+        assert_eq!(token.value, Token::StartMarkerSymbol);
+        source.assert_span(token, "[[");
+        source.assert_spanned_str(rest, " ]]");
+
+        let (token, rest) = next_token(rest).unwrap();
+        assert_eq!(token.value, Token::EndMarkerSymbol);
+        source.assert_span(token, "]]");
+        source.assert_spanned_str(rest, "");
+    }
+
+    #[test]
+    fn next_token_returns_none_for_str_without_tokens() {
+        let source = Spanned::from_str("  ");
+        assert!(next_token(source).is_none());
+    }
+
+    #[test]
+    fn next_token_returns_unknown_tokens() {
+        let source = Spanned::from_str("1x x123@#");
+        let (token, rest) = next_token(source).unwrap();
+        assert_eq!(token.value, Token::UnknownChar("1"));
+        source.assert_span(token, "1");
+        source.assert_spanned_str(rest, "x x123@#");
+
+        let (token, rest) = next_token(rest).unwrap();
+        assert_eq!(token.value, Token::Ident("x"));
+        source.assert_span(token, "x");
+        source.assert_spanned_str(rest, " x123@#");
+
+        let (token, rest) = next_token(rest).unwrap();
+        assert_eq!(token.value, Token::Ident("x123"));
+        source.assert_span(token, "x123");
+        source.assert_spanned_str(rest, "@#");
+
+        let (token, rest) = next_token(rest).unwrap();
+        assert_eq!(token.value, Token::UnknownChar("@"));
+        source.assert_span(token, "@");
+        source.assert_spanned_str(rest, "#");
     }
 }

--- a/src/sync/marker/scan.rs
+++ b/src/sync/marker/scan.rs
@@ -139,7 +139,7 @@ where
         match end_marker.value {
             ResolvedMarker::End => Ok(Some(Spanned::new(
                 specifier,
-                (start_span.start..end_span.end).into(),
+                start_span.start..end_span.end,
             ))),
             _ => Err(NestedMarkerSnafu {
                 nested_span: end_span.to_span(),
@@ -277,7 +277,7 @@ mod tests {
             markers.next().unwrap().unwrap(),
             Spanned::new(
                 ResolvedReplaceSpecifier::Title,
-                (ranges[1].start..ranges[4].end).into()
+                ranges[1].start..ranges[4].end
             ),
         );
         assert!(markers.next().is_none());

--- a/tests/fixtures/snapshots/marker_parse_error/pkg-a.extra.stderr.term.svg
+++ b/tests/fixtures/snapshots/marker_parse_error/pkg-a.extra.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="848px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="830px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -39,81 +39,79 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> no replacement specifier found</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unexpected end of marker, expected: marker kind or `]]`</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:8:1</tspan><tspan>]</tspan>
+    <tspan x="10px" y="190px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:8:21</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed"> 7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
+    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="226px"><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>    · </tspan><tspan class="fg-magenta bold">─────────────────────────</tspan>
+    <tspan x="10px" y="244px"><tspan>   · </tspan><tspan class="fg-magenta bold">                    ▲</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="262px"><tspan> </tspan><tspan class="dimmed">9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+    <tspan x="10px" y="280px"><tspan>   ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px">
+    <tspan x="10px" y="316px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>Error: </tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
+    <tspan x="10px" y="352px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:9:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:9:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="370px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="388px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="406px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
+    <tspan x="10px" y="424px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+    <tspan x="10px" y="442px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="460px">
 </tspan>
-    <tspan x="10px" y="478px">
+    <tspan x="10px" y="478px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>Error: </tspan>
+    <tspan x="10px" y="496px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
+    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
+    <tspan x="10px" y="532px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:12:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:12:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="550px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
+    <tspan x="10px" y="568px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="586px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
+    <tspan x="10px" y="604px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="622px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="640px">
 </tspan>
-    <tspan x="10px" y="658px">
+    <tspan x="10px" y="658px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>Error: </tspan>
+    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
+    <tspan x="10px" y="694px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
+    <tspan x="10px" y="712px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:13:28</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:13:28</tspan><tspan>]</tspan>
+    <tspan x="10px" y="730px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="748px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="766px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
+    <tspan x="10px" y="784px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="802px">
 </tspan>
     <tspan x="10px" y="820px">
-</tspan>
-    <tspan x="10px" y="838px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/marker_parse_error/pkg-a.readme.stderr.term.svg
+++ b/tests/fixtures/snapshots/marker_parse_error/pkg-a.readme.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="794px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="776px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -33,81 +33,79 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> no replacement specifier found</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unexpected end of marker, expected: marker kind or `]]`</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:8:1</tspan><tspan>]</tspan>
+    <tspan x="10px" y="136px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:8:21</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed"> 7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="172px"><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>    · </tspan><tspan class="fg-magenta bold">─────────────────────────</tspan>
+    <tspan x="10px" y="190px"><tspan>   · </tspan><tspan class="fg-magenta bold">                    ▲</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed">9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+    <tspan x="10px" y="226px"><tspan>   ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="244px">
 </tspan>
-    <tspan x="10px" y="262px">
+    <tspan x="10px" y="262px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>Error: </tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
+    <tspan x="10px" y="298px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:9:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:9:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="316px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="334px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="352px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
+    <tspan x="10px" y="370px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+    <tspan x="10px" y="388px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px">
+    <tspan x="10px" y="424px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>Error: </tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
+    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
+    <tspan x="10px" y="478px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:12:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:12:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="496px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
+    <tspan x="10px" y="514px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="532px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
+    <tspan x="10px" y="550px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="568px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="586px">
 </tspan>
-    <tspan x="10px" y="604px">
+    <tspan x="10px" y="604px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>Error: </tspan>
+    <tspan x="10px" y="622px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
+    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
+    <tspan x="10px" y="658px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:13:28</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:13:28</tspan><tspan>]</tspan>
+    <tspan x="10px" y="676px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="694px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="712px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
+    <tspan x="10px" y="730px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="748px">
 </tspan>
     <tspan x="10px" y="766px">
-</tspan>
-    <tspan x="10px" y="784px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/marker_parse_error/root.extra.stderr.term.svg
+++ b/tests/fixtures/snapshots/marker_parse_error/root.extra.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="848px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="830px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -39,81 +39,79 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> no replacement specifier found</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unexpected end of marker, expected: marker kind or `]]`</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:8:1</tspan><tspan>]</tspan>
+    <tspan x="10px" y="190px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:8:21</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed"> 7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
+    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="226px"><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>    · </tspan><tspan class="fg-magenta bold">─────────────────────────</tspan>
+    <tspan x="10px" y="244px"><tspan>   · </tspan><tspan class="fg-magenta bold">                    ▲</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="262px"><tspan> </tspan><tspan class="dimmed">9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+    <tspan x="10px" y="280px"><tspan>   ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px">
+    <tspan x="10px" y="316px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>Error: </tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
+    <tspan x="10px" y="352px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:9:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:9:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="370px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="388px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="406px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
+    <tspan x="10px" y="424px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+    <tspan x="10px" y="442px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="460px">
 </tspan>
-    <tspan x="10px" y="478px">
+    <tspan x="10px" y="478px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>Error: </tspan>
+    <tspan x="10px" y="496px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
+    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
+    <tspan x="10px" y="532px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:12:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:12:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="550px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
+    <tspan x="10px" y="568px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="586px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
+    <tspan x="10px" y="604px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="622px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="640px">
 </tspan>
-    <tspan x="10px" y="658px">
+    <tspan x="10px" y="658px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>Error: </tspan>
+    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
+    <tspan x="10px" y="694px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
+    <tspan x="10px" y="712px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:13:28</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:13:28</tspan><tspan>]</tspan>
+    <tspan x="10px" y="730px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="748px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="766px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
+    <tspan x="10px" y="784px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="802px">
 </tspan>
     <tspan x="10px" y="820px">
-</tspan>
-    <tspan x="10px" y="838px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/marker_parse_error/root.readme.stderr.term.svg
+++ b/tests/fixtures/snapshots/marker_parse_error/root.readme.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="794px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="776px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -33,81 +33,79 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> no replacement specifier found</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unexpected end of marker, expected: marker kind or `]]`</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:8:1</tspan><tspan>]</tspan>
+    <tspan x="10px" y="136px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:8:21</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed"> 7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="172px"><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>    · </tspan><tspan class="fg-magenta bold">─────────────────────────</tspan>
+    <tspan x="10px" y="190px"><tspan>   · </tspan><tspan class="fg-magenta bold">                    ▲</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed">9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+    <tspan x="10px" y="226px"><tspan>   ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="244px">
 </tspan>
-    <tspan x="10px" y="262px">
+    <tspan x="10px" y="262px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>Error: </tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
+    <tspan x="10px" y="298px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:9:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:9:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="316px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="334px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="352px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
+    <tspan x="10px" y="370px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+    <tspan x="10px" y="388px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px">
+    <tspan x="10px" y="424px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>Error: </tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
+    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
+    <tspan x="10px" y="478px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:12:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:12:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="496px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
+    <tspan x="10px" y="514px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="532px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
+    <tspan x="10px" y="550px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="568px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="586px">
 </tspan>
-    <tspan x="10px" y="604px">
+    <tspan x="10px" y="604px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>Error: </tspan>
+    <tspan x="10px" y="622px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
+    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
+    <tspan x="10px" y="658px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:13:28</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:13:28</tspan><tspan>]</tspan>
+    <tspan x="10px" y="676px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="694px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="712px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
+    <tspan x="10px" y="730px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="748px">
 </tspan>
     <tspan x="10px" y="766px">
-</tspan>
-    <tspan x="10px" y="784px">
 </tspan>
   </text>
 


### PR DESCRIPTION
## Summary
- restrict badge group names in Cargo metadata and marker specifiers to identifier-like names matching `[A-Za-z][-_A-Za-z0-9]*`
- share identifier parsing logic between badge metadata validation and marker parsing
- refactor marker parsing around token-based parsing and refresh marker error snapshots
- document the new restriction in `CHANGELOG.md` as a breaking change

## Motivation
This tightens badge group handling so config parsing and marker parsing accept the same group syntax and prepares the parser for future cleanup around marker diagnostics.

## Validation
- `cargo test`

## Breaking change
Badge group names that were previously accepted but do not match `[A-Za-z][-_A-Za-z0-9]*` are now rejected in both Cargo metadata (`badges-<group>`) and `<!-- cargo-sync-rdme badge:<group> -->` markers.