### PR TITLE
Refactor marker tests and cover edge cases

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -68,12 +68,18 @@ impl<'a> Spanned<&'a str> {
 
     #[cfg(test)]
     #[track_caller]
-    #[expect(clippy::needless_pass_by_value)]
-    pub(crate) fn assert_span<T>(&self, target: Spanned<T>, expected: &str) {
-        let start = target.span.start - self.span.start;
-        let end = target.span.end - self.span.start;
+    pub(crate) fn assert_span(&self, span: Range<usize>, expected: &str) {
+        let start = span.start - self.span.start;
+        let end = span.end - self.span.start;
         let actual = &self.value[start..end];
         similar_asserts::assert_eq!(actual, expected);
+    }
+
+    #[cfg(test)]
+    #[track_caller]
+    #[expect(clippy::needless_pass_by_value)]
+    pub(crate) fn assert_spanned<T>(&self, target: Spanned<T>, expected: &str) {
+        self.assert_span(target.span, expected);
     }
 
     #[cfg(test)]
@@ -88,7 +94,7 @@ impl<'a> Spanned<&'a str> {
     #[track_caller]
     pub(crate) fn assert_spanned_str(&self, target: Spanned<&str>, expected: &str) {
         similar_asserts::assert_eq!(target.value, expected);
-        self.assert_span(target, expected);
+        self.assert_spanned(target, expected);
     }
 
     pub(crate) fn prefix_of(&self, other: Self) -> Self {

--- a/src/sync/marker/parse.rs
+++ b/src/sync/marker/parse.rs
@@ -21,17 +21,6 @@ pub(super) struct ReplaceSpecifier<'a> {
     pub(super) group: Option<Spanned<&'a str>>,
 }
 
-impl Display for ReplaceSpecifier<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let kind = self.kind;
-        if let Some(group) = self.group {
-            write!(f, "{kind}:{group}")
-        } else {
-            write!(f, "{kind}")
-        }
-    }
-}
-
 #[derive(Debug, Snafu, Diagnostic)]
 pub(crate) enum ParseMarkerError {
     #[snafu(display("unexpected token: `{token}`, expected: {expected}"))]
@@ -270,34 +259,76 @@ mod tests {
 
     use similar_asserts::assert_eq;
 
+    impl<'a> Marker<'a> {
+        #[track_caller]
+        fn into_replace(self) -> SpannedReplaceSpecifier<'a> {
+            let Self::Replace(specifier) = self else {
+                panic!("unexpected marker: {self:?}");
+            };
+            specifier
+        }
+
+        #[track_caller]
+        fn into_start(self) -> SpannedReplaceSpecifier<'a> {
+            let Self::Start(specifier) = self else {
+                panic!("unexpected marker: {self:?}");
+            };
+            specifier
+        }
+
+        #[track_caller]
+        fn into_end(self) {
+            let Self::End = self else {
+                panic!("unexpected marker: {self:?}");
+            };
+        }
+    }
+
+    impl ParseMarkerError {
+        #[track_caller]
+        fn into_unexpected_token(self) -> (String, String, SourceSpan) {
+            let Self::UnexpectedToken {
+                token,
+                expected,
+                span,
+            } = self
+            else {
+                panic!("unexpected error: {self:?}");
+            };
+            (token, expected, span)
+        }
+
+        #[track_caller]
+        fn into_unexpected_eom(self) -> (String, SourceSpan) {
+            let Self::UnexpectedEndOfMarker { expected, span } = self else {
+                panic!("unexpected error: {self:?}");
+            };
+            (expected, span)
+        }
+    }
+
     #[test]
     fn parse_marker_parses_markers() {
         let source = Spanned::from_str("<!-- cargo-sync-rdme kind:group -->");
         let marker = parse_marker(source).unwrap().unwrap();
-        source.assert_span(marker, "<!-- cargo-sync-rdme kind:group -->");
-        let Marker::Replace(specifier) = marker.value else {
-            panic!("expected replace marker, got {marker:?}");
-        };
-        source.assert_span(specifier, "kind:group");
+        source.assert_spanned(marker, "<!-- cargo-sync-rdme kind:group -->");
+        let specifier = marker.value.into_replace();
+        source.assert_spanned(specifier, "kind:group");
         source.assert_spanned_str(specifier.value.kind, "kind");
         source.assert_spanned_str(specifier.value.group.unwrap(), "group");
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme kind:group [[ -->");
         let marker = parse_marker(source).unwrap().unwrap();
-        source.assert_span(marker, "<!-- cargo-sync-rdme kind:group [[ -->");
-        let Marker::Start(specifier) = marker.value else {
-            panic!("expected replace marker, got {marker:?}");
-        };
-        source.assert_span(specifier, "kind:group");
+        source.assert_spanned(marker, "<!-- cargo-sync-rdme kind:group [[ -->");
+        let specifier = marker.value.into_start();
+        source.assert_spanned(specifier, "kind:group");
         source.assert_spanned_str(specifier.value.kind, "kind");
         source.assert_spanned_str(specifier.value.group.unwrap(), "group");
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme ]] -->");
         let marker = parse_marker(source).unwrap().unwrap();
-        source.assert_span(marker, "<!-- cargo-sync-rdme ]] -->");
-        let Marker::End = marker.value else {
-            panic!("expected end marker, got {marker:?}");
-        };
+        source.assert_spanned(marker, "<!-- cargo-sync-rdme ]] -->");
+        marker.value.into_end();
     }
 
     #[test]
@@ -312,50 +343,41 @@ mod tests {
         assert_eq!(span.offset(), source.value.len() - " -->".len());
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme [[ -->");
-        let err = parse_marker(source).unwrap_err();
-        let ParseMarkerError::UnexpectedToken {
-            token,
-            expected,
-            span,
-        } = err
-        else {
-            panic!("unexpected error: {err:?}");
-        };
+        let (token, expected, span) = parse_marker(source).unwrap_err().into_unexpected_token();
         assert_eq!(token, "[[");
         assert_eq!(expected, "marker kind or `]]`");
         source.assert_source_span(span, "[[");
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme badge:123 -->");
-        let err = parse_marker(source).unwrap_err();
-        let ParseMarkerError::UnexpectedToken {
-            token,
-            expected,
-            span,
-        } = err
-        else {
-            panic!("unexpected error: {err:?}");
-        };
+        let (token, expected, span) = parse_marker(source).unwrap_err().into_unexpected_token();
         assert_eq!(token, "1");
         assert_eq!(expected, "group name");
         source.assert_source_span(span, "1");
 
+        let source = Spanned::from_str("<!-- cargo-sync-rdme ]] xxx -->");
+        let (token, expected, span) = parse_marker(source).unwrap_err().into_unexpected_token();
+        assert_eq!(token, "xxx");
+        assert_eq!(expected, "end of marker");
+        source.assert_source_span(span, "xxx");
+
         let source = Spanned::from_str("<!-- cargo-sync-rdme badge:bar xxx -->");
-        let err = parse_marker(source).unwrap_err();
-        let ParseMarkerError::UnexpectedToken {
-            token,
-            expected,
-            span,
-        } = err
-        else {
-            panic!("unexpected error: {err:?}");
-        };
+        let (token, expected, span) = parse_marker(source).unwrap_err().into_unexpected_token();
         assert_eq!(token, "xxx");
         assert_eq!(expected, "end of marker or `[[`");
+        source.assert_source_span(span, "xxx");
+
+        let source = Spanned::from_str("<!-- cargo-sync-rdme badge:bar [[ xxx -->");
+        let (token, expected, span) = parse_marker(source).unwrap_err().into_unexpected_token();
+        assert_eq!(token, "xxx");
+        assert_eq!(expected, "end of marker");
         source.assert_source_span(span, "xxx");
     }
 
     #[test]
     fn parse_marker_ignores_non_markers() {
+        let source = Spanned::from_str("<p>paragraph</p>");
+        assert!(parse_marker(source).unwrap().is_none());
+
         let source = Spanned::from_str("<!-- test -->");
         assert!(parse_marker(source).unwrap().is_none());
     }
@@ -364,28 +386,28 @@ mod tests {
     fn parse_specifier_parses_kind_and_group() {
         let source = Spanned::from_str("kind:group");
         let (specifier, rest) = parse_specifier(source).unwrap().unwrap();
-        source.assert_span(specifier, "kind:group");
+        source.assert_spanned(specifier, "kind:group");
         source.assert_spanned_str(specifier.value.kind, "kind");
         source.assert_spanned_str(specifier.value.group.unwrap(), "group");
         source.assert_spanned_str(rest, "");
 
         let source = Spanned::from_str(" kind:group ");
         let (specifier, rest) = parse_specifier(source).unwrap().unwrap();
-        source.assert_span(specifier, "kind:group");
+        source.assert_spanned(specifier, "kind:group");
         source.assert_spanned_str(specifier.value.kind, "kind");
         source.assert_spanned_str(specifier.value.group.unwrap(), "group");
         source.assert_spanned_str(rest, " ");
 
         let source = Spanned::from_str(" kind : group xxx");
         let (specifier, rest) = parse_specifier(source).unwrap().unwrap();
-        source.assert_span(specifier, "kind : group");
+        source.assert_spanned(specifier, "kind : group");
         source.assert_spanned_str(specifier.value.kind, "kind");
         source.assert_spanned_str(specifier.value.group.unwrap(), "group");
         source.assert_spanned_str(rest, " xxx");
 
         let source = Spanned::from_str(" kind ");
         let (specifier, rest) = parse_specifier(source).unwrap().unwrap();
-        source.assert_span(specifier, "kind");
+        source.assert_spanned(specifier, "kind");
         source.assert_spanned_str(specifier.value.kind, "kind");
         assert!(specifier.value.group.is_none());
         source.assert_spanned_str(rest, " ");
@@ -397,10 +419,7 @@ mod tests {
     #[test]
     fn parse_specifier_rejects_invalid_specifiers() {
         let source = Spanned::from_str(" kind: ");
-        let err = parse_specifier(source).unwrap_err();
-        let ParseMarkerError::UnexpectedEndOfMarker { expected, span } = err else {
-            panic!("unexpected error: {err:?}");
-        };
+        let (expected, span) = parse_specifier(source).unwrap_err().into_unexpected_eom();
         assert_eq!(expected, "group name");
         source.assert_source_span(span, "");
         assert_eq!(span.offset(), source.value.len());
@@ -440,6 +459,8 @@ mod tests {
         assert!(trim_comment(source).is_none());
         let source = Spanned::from_str("<!--test");
         assert!(trim_comment(source).is_none());
+        let source = Spanned::from_str("<p>paragraph</p>");
+        assert!(trim_comment(source).is_none());
     }
 
     #[test]
@@ -447,42 +468,42 @@ mod tests {
         let source = Spanned::from_str("kind:group kind-x : group_y[[ ]]");
         let (token, rest) = next_token(source).unwrap();
         assert_eq!(token.value, Token::Ident("kind"));
-        source.assert_span(token, "kind");
+        source.assert_spanned(token, "kind");
         source.assert_spanned_str(rest, ":group kind-x : group_y[[ ]]");
 
         let (token, rest) = next_token(rest).unwrap();
         assert_eq!(token.value, Token::Colon);
-        source.assert_span(token, ":");
+        source.assert_spanned(token, ":");
         source.assert_spanned_str(rest, "group kind-x : group_y[[ ]]");
 
         let (token, rest) = next_token(rest).unwrap();
         assert_eq!(token.value, Token::Ident("group"));
-        source.assert_span(token, "group");
+        source.assert_spanned(token, "group");
         source.assert_spanned_str(rest, " kind-x : group_y[[ ]]");
 
         let (token, rest) = next_token(rest).unwrap();
         assert_eq!(token.value, Token::Ident("kind-x"));
-        source.assert_span(token, "kind-x");
+        source.assert_spanned(token, "kind-x");
         source.assert_spanned_str(rest, " : group_y[[ ]]");
 
         let (token, rest) = next_token(rest).unwrap();
         assert_eq!(token.value, Token::Colon);
-        source.assert_span(token, ":");
+        source.assert_spanned(token, ":");
         source.assert_spanned_str(rest, " group_y[[ ]]");
 
         let (token, rest) = next_token(rest).unwrap();
         assert_eq!(token.value, Token::Ident("group_y"));
-        source.assert_span(token, "group_y");
+        source.assert_spanned(token, "group_y");
         source.assert_spanned_str(rest, "[[ ]]");
 
         let (token, rest) = next_token(rest).unwrap();
         assert_eq!(token.value, Token::StartMarkerSymbol);
-        source.assert_span(token, "[[");
+        source.assert_spanned(token, "[[");
         source.assert_spanned_str(rest, " ]]");
 
         let (token, rest) = next_token(rest).unwrap();
         assert_eq!(token.value, Token::EndMarkerSymbol);
-        source.assert_span(token, "]]");
+        source.assert_spanned(token, "]]");
         source.assert_spanned_str(rest, "");
     }
 
@@ -497,22 +518,22 @@ mod tests {
         let source = Spanned::from_str("1x x123@#");
         let (token, rest) = next_token(source).unwrap();
         assert_eq!(token.value, Token::UnknownChar("1"));
-        source.assert_span(token, "1");
+        source.assert_spanned(token, "1");
         source.assert_spanned_str(rest, "x x123@#");
 
         let (token, rest) = next_token(rest).unwrap();
         assert_eq!(token.value, Token::Ident("x"));
-        source.assert_span(token, "x");
+        source.assert_spanned(token, "x");
         source.assert_spanned_str(rest, " x123@#");
 
         let (token, rest) = next_token(rest).unwrap();
         assert_eq!(token.value, Token::Ident("x123"));
-        source.assert_span(token, "x123");
+        source.assert_spanned(token, "x123");
         source.assert_spanned_str(rest, "@#");
 
         let (token, rest) = next_token(rest).unwrap();
         assert_eq!(token.value, Token::UnknownChar("@"));
-        source.assert_span(token, "@");
+        source.assert_spanned(token, "@");
         source.assert_spanned_str(rest, "#");
     }
 }

--- a/src/sync/marker/resolve.rs
+++ b/src/sync/marker/resolve.rs
@@ -176,6 +176,73 @@ mod tests {
         [package.metadata.cargo-sync-rdme.badge.badges-foo]
     "};
 
+    impl ResolvedMarker {
+        #[track_caller]
+        fn into_replace(self) -> ResolvedReplaceSpecifier {
+            let Self::Replace(specifier) = self else {
+                panic!("unexpected marker: {self:?}");
+            };
+            specifier
+        }
+    }
+
+    impl ResolvedReplaceSpecifier {
+        #[track_caller]
+        fn into_title(self) {
+            let Self::Title = self else {
+                panic!("unexpected replace specifier: {self:?}");
+            };
+        }
+
+        #[track_caller]
+        fn into_rustdoc(self) {
+            let Self::Rustdoc = self else {
+                panic!("unexpected replace specifier: {self:?}");
+            };
+        }
+
+        #[track_caller]
+        fn into_badge(self) -> (Option<Arc<str>>, Arc<[BadgeItem]>) {
+            let Self::Badge { group, badges } = self else {
+                panic!("unexpected replace specifier: {self:?}");
+            };
+            (group, badges)
+        }
+    }
+
+    impl ResolveMarkerError {
+        #[track_caller]
+        fn into_unknown_marker_kind(self) -> (String, SourceSpan) {
+            let Self::UnknownMarkerKind { kind, span } = self else {
+                panic!("unexpected error: {self:?}");
+            };
+            (kind, span)
+        }
+        #[track_caller]
+        fn into_unexpected_group_for_specifier(self) -> (String, String, SourceSpan) {
+            let Self::UnexpectedGroupForSpecifier { kind, group, span } = self else {
+                panic!("unexpected error: {self:?}");
+            };
+            (kind, group, span)
+        }
+
+        #[track_caller]
+        fn into_no_default_badge_configured(self) -> SourceSpan {
+            let Self::NoDefaultBadgeConfigured { span } = self else {
+                panic!("unexpected error: {self:?}");
+            };
+            span
+        }
+
+        #[track_caller]
+        fn into_no_such_badge_group(self) -> (String, SourceSpan) {
+            let Self::NoSuchBadgeGroup { group, span } = self else {
+                panic!("unexpected error: {self:?}");
+            };
+            (group, span)
+        }
+    }
+
     fn resolve(
         source: Spanned<&str>,
         config: &str,
@@ -189,73 +256,63 @@ mod tests {
     fn resolve_marker_resolves_valid_markers() {
         let source = Spanned::from_str("<!-- cargo-sync-rdme title -->");
         let resolved = resolve(source, CONFIG).unwrap();
-        let ResolvedMarker::Replace(ResolvedReplaceSpecifier::Title) = resolved.value else {
-            panic!("unexpected: {resolved:?}");
-        };
-        source.assert_span(resolved, "<!-- cargo-sync-rdme title -->");
+        resolved.value.into_replace().into_title();
+        source.assert_span(resolved.span, "<!-- cargo-sync-rdme title -->");
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme rustdoc -->");
         let resolved = resolve(source, CONFIG).unwrap();
-        let ResolvedMarker::Replace(ResolvedReplaceSpecifier::Rustdoc) = resolved.value else {
-            panic!("unexpected: {resolved:?}");
-        };
-        source.assert_span(resolved, "<!-- cargo-sync-rdme rustdoc -->");
+        resolved.value.into_replace().into_rustdoc();
+        source.assert_span(resolved.span, "<!-- cargo-sync-rdme rustdoc -->");
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme badge -->");
         let resolved = resolve(source, CONFIG).unwrap();
-        let ResolvedMarker::Replace(ResolvedReplaceSpecifier::Badge { group, .. }) =
-            &resolved.value
-        else {
-            panic!("unexpected: {resolved:?}");
-        };
+        let (group, _badges) = resolved.value.into_replace().into_badge();
         assert!(group.is_none());
-        source.assert_span(resolved, "<!-- cargo-sync-rdme badge -->");
+        source.assert_span(resolved.span, "<!-- cargo-sync-rdme badge -->");
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme badge:foo -->");
         let resolved = resolve(source, CONFIG).unwrap();
-        let ResolvedMarker::Replace(ResolvedReplaceSpecifier::Badge { group, .. }) =
-            &resolved.value
-        else {
-            panic!("unexpected: {resolved:?}");
-        };
+        let (group, _badges) = resolved.value.into_replace().into_badge();
         assert_eq!(group.as_deref().unwrap(), "foo");
-        source.assert_span(resolved, "<!-- cargo-sync-rdme badge:foo -->");
+        source.assert_span(resolved.span, "<!-- cargo-sync-rdme badge:foo -->");
     }
 
     #[test]
     fn resolve_marker_rejects_invalid_markers() {
         let source = Spanned::from_str("<!-- cargo-sync-rdme unknown -->");
-        let err = resolve(source, CONFIG).unwrap_err();
-        let ResolveMarkerError::UnknownMarkerKind { kind, span } = err else {
-            panic!("unexpected: {err:?}");
-        };
+        let (kind, span) = resolve(source, CONFIG)
+            .unwrap_err()
+            .into_unknown_marker_kind();
         assert_eq!(kind, "unknown");
         source.assert_source_span(span, "unknown");
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme title:foo -->");
-        let err = resolve(source, CONFIG).unwrap_err();
-        let ResolveMarkerError::UnexpectedGroupForSpecifier { kind, group, span } = err else {
-            panic!("unexpected: {err:?}");
-        };
+        let (kind, group, span) = resolve(source, CONFIG)
+            .unwrap_err()
+            .into_unexpected_group_for_specifier();
         assert_eq!(kind, "title");
         assert_eq!(group, "foo");
         source.assert_source_span(span, "title:foo");
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme rustdoc:foo -->");
-        let err = resolve(source, CONFIG).unwrap_err();
-        let ResolveMarkerError::UnexpectedGroupForSpecifier { kind, group, span } = err else {
-            panic!("unexpected: {err:?}");
-        };
+        let (kind, group, span) = resolve(source, CONFIG)
+            .unwrap_err()
+            .into_unexpected_group_for_specifier();
         assert_eq!(kind, "rustdoc");
         assert_eq!(group, "foo");
         source.assert_source_span(span, "rustdoc:foo");
 
         let source = Spanned::from_str("<!-- cargo-sync-rdme badge:bar -->");
-        let err = resolve(source, CONFIG).unwrap_err();
-        let ResolveMarkerError::NoSuchBadgeGroup { group, span } = err else {
-            panic!("unexpected: {err:?}");
-        };
+        let (group, span) = resolve(source, CONFIG)
+            .unwrap_err()
+            .into_no_such_badge_group();
         assert_eq!(group, "bar");
         source.assert_source_span(span, "bar");
+
+        let source = Spanned::from_str("<!-- cargo-sync-rdme badge -->");
+        let span = resolve(source, "")
+            .unwrap_err()
+            .into_no_default_badge_configured();
+        source.assert_source_span(span, "badge");
     }
 }


### PR DESCRIPTION
## Summary
- refactor marker parser and resolver tests around small helper extractors and shared span assertions
- cover additional parser edge cases, including non-marker input and invalid trailing tokens
- add resolver coverage for the missing default badge configuration case

## Validation
- `cargo test`

## Notes
- no production behavior change intended
