### PR TITLE
Use source text for HTML marker parsing

### DIFF
--- a/src/sync/marker/parse.rs
+++ b/src/sync/marker/parse.rs
@@ -261,7 +261,7 @@ mod tests {
 
     impl<'a> Marker<'a> {
         #[track_caller]
-        fn into_replace(self) -> SpannedReplaceSpecifier<'a> {
+        pub(crate) fn into_replace(self) -> SpannedReplaceSpecifier<'a> {
             let Self::Replace(specifier) = self else {
                 panic!("unexpected marker: {self:?}");
             };
@@ -269,7 +269,7 @@ mod tests {
         }
 
         #[track_caller]
-        fn into_start(self) -> SpannedReplaceSpecifier<'a> {
+        pub(crate) fn into_start(self) -> SpannedReplaceSpecifier<'a> {
             let Self::Start(specifier) = self else {
                 panic!("unexpected marker: {self:?}");
             };
@@ -277,7 +277,7 @@ mod tests {
         }
 
         #[track_caller]
-        fn into_end(self) {
+        pub(crate) fn into_end(self) {
             let Self::End = self else {
                 panic!("unexpected marker: {self:?}");
             };
@@ -286,7 +286,7 @@ mod tests {
 
     impl ParseMarkerError {
         #[track_caller]
-        fn into_unexpected_token(self) -> (String, String, SourceSpan) {
+        pub(crate) fn into_unexpected_token(self) -> (String, String, SourceSpan) {
             let Self::UnexpectedToken {
                 token,
                 expected,
@@ -299,7 +299,7 @@ mod tests {
         }
 
         #[track_caller]
-        fn into_unexpected_eom(self) -> (String, SourceSpan) {
+        pub(crate) fn into_unexpected_eom(self) -> (String, SourceSpan) {
             let Self::UnexpectedEndOfMarker { expected, span } = self else {
                 panic!("unexpected error: {self:?}");
             };

--- a/src/sync/marker/resolve.rs
+++ b/src/sync/marker/resolve.rs
@@ -178,7 +178,7 @@ mod tests {
 
     impl ResolvedMarker {
         #[track_caller]
-        fn into_replace(self) -> ResolvedReplaceSpecifier {
+        pub(crate) fn into_replace(self) -> ResolvedReplaceSpecifier {
             let Self::Replace(specifier) = self else {
                 panic!("unexpected marker: {self:?}");
             };
@@ -188,21 +188,21 @@ mod tests {
 
     impl ResolvedReplaceSpecifier {
         #[track_caller]
-        fn into_title(self) {
+        pub(crate) fn into_title(self) {
             let Self::Title = self else {
                 panic!("unexpected replace specifier: {self:?}");
             };
         }
 
         #[track_caller]
-        fn into_rustdoc(self) {
+        pub(crate) fn into_rustdoc(self) {
             let Self::Rustdoc = self else {
                 panic!("unexpected replace specifier: {self:?}");
             };
         }
 
         #[track_caller]
-        fn into_badge(self) -> (Option<Arc<str>>, Arc<[BadgeItem]>) {
+        pub(crate) fn into_badge(self) -> (Option<Arc<str>>, Arc<[BadgeItem]>) {
             let Self::Badge { group, badges } = self else {
                 panic!("unexpected replace specifier: {self:?}");
             };
@@ -212,14 +212,14 @@ mod tests {
 
     impl ResolveMarkerError {
         #[track_caller]
-        fn into_unknown_marker_kind(self) -> (String, SourceSpan) {
+        pub(crate) fn into_unknown_marker_kind(self) -> (String, SourceSpan) {
             let Self::UnknownMarkerKind { kind, span } = self else {
                 panic!("unexpected error: {self:?}");
             };
             (kind, span)
         }
         #[track_caller]
-        fn into_unexpected_group_for_specifier(self) -> (String, String, SourceSpan) {
+        pub(crate) fn into_unexpected_group_for_specifier(self) -> (String, String, SourceSpan) {
             let Self::UnexpectedGroupForSpecifier { kind, group, span } = self else {
                 panic!("unexpected error: {self:?}");
             };
@@ -227,7 +227,7 @@ mod tests {
         }
 
         #[track_caller]
-        fn into_no_default_badge_configured(self) -> SourceSpan {
+        pub(crate) fn into_no_default_badge_configured(self) -> SourceSpan {
             let Self::NoDefaultBadgeConfigured { span } = self else {
                 panic!("unexpected error: {self:?}");
             };
@@ -235,7 +235,7 @@ mod tests {
         }
 
         #[track_caller]
-        fn into_no_such_badge_group(self) -> (String, SourceSpan) {
+        pub(crate) fn into_no_such_badge_group(self) -> (String, SourceSpan) {
             let Self::NoSuchBadgeGroup { group, span } = self else {
                 panic!("unexpected error: {self:?}");
             };

--- a/src/sync/marker/scan.rs
+++ b/src/sync/marker/scan.rs
@@ -19,11 +19,10 @@ pub(in crate::sync) fn scan_all(
     markdown: &MarkdownFile<'_>,
     manifest: &ManifestFile,
 ) -> Result<Vec<Spanned<ResolvedReplaceSpecifier>>, Box<ScanAllError>> {
-    let parser = Parser::new_ext(&markdown.text, Options::all()).into_offset_iter();
-    let it = Scanner { manifest, parser };
+    let scanner = Scanner::new(manifest, &markdown.text);
     let mut markers = vec![];
     let mut errors = vec![];
-    for res in it {
+    for res in scanner {
         match res {
             Ok(marker) => markers.push(marker),
             Err(err) => errors.push(err),
@@ -94,6 +93,7 @@ enum ScanError {
 #[derive(Debug)]
 struct Scanner<'manifest, 'markdown> {
     manifest: &'manifest ManifestFile,
+    markdown: &'markdown str,
     parser: OffsetIter<'markdown>,
 }
 
@@ -105,7 +105,16 @@ impl Iterator for Scanner<'_, '_> {
     }
 }
 
-impl Scanner<'_, '_> {
+impl<'manifest, 'markdown> Scanner<'manifest, 'markdown> {
+    fn new(manifest: &'manifest ManifestFile, markdown: &'markdown str) -> Self {
+        let parser = Parser::new_ext(markdown, Options::all()).into_offset_iter();
+        Self {
+            manifest,
+            markdown,
+            parser,
+        }
+    }
+
     fn try_next(&mut self) -> Result<Option<Spanned<ResolvedReplaceSpecifier>>, ScanError> {
         let Some(start_marker) = self.next_marker()? else {
             return Ok(None);
@@ -146,7 +155,16 @@ impl Scanner<'_, '_> {
 impl Scanner<'_, '_> {
     fn next_marker(&mut self) -> Result<Option<Spanned<ResolvedMarker>>, ScanError> {
         for (event, range) in self.parser.by_ref() {
-            if let Event::Html(html) = event {
+            if let Event::Html(_html) = event {
+                // Use the original markdown slice for this HTML event instead of the
+                // `Event::Html` payload. The payload may be normalized by pulldown-cmark,
+                // which would make the parsed marker text diverge from the original source span
+                // and break diagnostics.
+                //
+                // As of 2026-08-21, pulldown-cmark main contains an unreleased change that
+                // replaces `\0` with `\u{FFFD}` in `Event::Html`:
+                // <https://github.com/pulldown-cmark/pulldown-cmark/blob/07bae2459d90175b661d42b8acf207382e111ae5/pulldown-cmark/src/parse.rs#L2404-L2406>
+                let html = &self.markdown[range.clone()];
                 let html = Spanned::new(html, range);
                 if let Some(marker) = parse::parse_marker(html.as_deref())? {
                     let marker = resolve::resolve_marker(marker, self.manifest)?;
@@ -162,11 +180,21 @@ impl Scanner<'_, '_> {
 mod tests {
     use std::range::Range;
 
-    use similar_asserts::assert_eq;
+    use indoc::indoc;
 
     use crate::config::Manifest;
 
     use super::*;
+
+    impl ScanError {
+        #[track_caller]
+        pub(crate) fn into_parse_marker(self) -> parse::ParseMarkerError {
+            let Self::ParseMarker { source } = self else {
+                panic!("unexpected error: {self:?}");
+            };
+            source
+        }
+    }
 
     fn line_ranges(lines: &[impl AsRef<str>]) -> Vec<Range<usize>> {
         lines
@@ -183,88 +211,127 @@ mod tests {
     #[test]
     fn no_markers() {
         let input = "Hello, world!";
-        let mut markers = Scanner {
-            manifest: &ManifestFile::dummy(Manifest::default()),
-            parser: Parser::new(input).into_offset_iter(),
-        };
+        let manifest = ManifestFile::dummy(Manifest::default());
+        let mut markers = Scanner::new(&manifest, input);
         assert!(markers.next().is_none());
     }
 
     #[test]
     fn replace_marker() {
         let lines = [
-            "Good morning, world!".to_string(),
-            ResolvedMarker::Replace(ResolvedReplaceSpecifier::Title).to_string(),
-            "Good afternoon, world!".to_string(),
-            ResolvedMarker::Replace(ResolvedReplaceSpecifier::Badge {
-                group: None,
-                badges: vec![].into(),
-            })
-            .to_string(),
-            "Good evening, world!".to_string(),
-            ResolvedMarker::Replace(ResolvedReplaceSpecifier::Rustdoc).to_string(),
-            "Good night, world!".to_string(),
+            "Good morning, world!",
+            "<!-- cargo-sync-rdme title -->",
+            "Good afternoon, world!",
+            "<!--  cargo-sync-rdme badge  -->",
+            "Good evening, world!",
+            "<!--cargo-sync-rdme rustdoc  -->",
+            "Good night, world!",
         ];
         let ranges = line_ranges(&lines);
         let input = lines.join("\n");
 
-        let config = indoc::indoc! {"
+        let config = indoc! {"
             [package.metadata.cargo-sync-rdme.badge.badges]
         "};
+        let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
 
-        let mut markers = Scanner {
-            manifest: &ManifestFile::dummy(toml::from_str(config).unwrap()),
-            parser: Parser::new(&input).into_offset_iter(),
-        };
+        let markers = Scanner::new(&manifest, &input)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
         assert_eq!(
-            markers.next().unwrap().unwrap(),
-            Spanned::new(ResolvedReplaceSpecifier::Title, ranges[1])
+            markers,
+            [
+                Spanned::new(ResolvedReplaceSpecifier::Title, ranges[1]),
+                Spanned::new(
+                    ResolvedReplaceSpecifier::Badge {
+                        group: None,
+                        badges: vec![].into()
+                    },
+                    ranges[3],
+                ),
+                Spanned::new(ResolvedReplaceSpecifier::Rustdoc, ranges[5])
+            ]
         );
-        assert_eq!(
-            markers.next().unwrap().unwrap(),
-            Spanned::new(
-                ResolvedReplaceSpecifier::Badge {
-                    group: None,
-                    badges: vec![].into()
-                },
-                ranges[3],
-            )
-        );
-        assert_eq!(
-            markers.next().unwrap().unwrap(),
-            Spanned::new(ResolvedReplaceSpecifier::Rustdoc, ranges[5])
-        );
-        assert!(markers.next().is_none());
     }
 
     #[test]
-    fn replace_region() {
+    fn start_and_end_marker() {
         let lines = [
-            "Good morning, world!".to_string(),
-            ResolvedMarker::Start(ResolvedReplaceSpecifier::Title).to_string(),
-            "Good afternoon, world!".to_string(),
-            "# Heading!".to_string(),
-            ResolvedMarker::End.to_string(),
-            "Good evening, world!".to_string(),
+            "Good morning, world!",
+            "<!-- cargo-sync-rdme title [[ -->",
+            "Good afternoon, world!",
+            "# Heading!",
+            "<!-- cargo-sync-rdme ]] -->",
+            "Good evening, world!",
         ];
         let ranges = line_ranges(&lines);
         let input = lines.join("\n");
 
-        let config = indoc::indoc! {"
+        let config = indoc! {"
             [package.metadata.cargo-sync-rdme.badge.badges]
         "};
 
-        let mut markers = Scanner {
-            manifest: &ManifestFile::dummy(toml::from_str(config).unwrap()),
-            parser: Parser::new(&input).into_offset_iter(),
-        };
+        let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
+        let markers = Scanner::new(&manifest, &input)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
         assert_eq!(
-            markers.next().unwrap().unwrap(),
-            Spanned::new(
+            markers,
+            [Spanned::new(
                 ResolvedReplaceSpecifier::Title,
                 ranges[1].start..ranges[4].end
-            ),
+            )]
         );
-        assert!(markers.next().is_none());
+    }
+
+    #[test]
+    fn nul_character_conversion() {
+        let lines = [
+            "Good morning, world!",
+            "<!-- cargo-sync-rdme title:\0 -->",
+            "<!-- cargo-sync-rdme title:\0 -->",
+            "Good afternoon, world!",
+            "# Heading!",
+            "<!-- cargo-sync-rdme title:\0 -->",
+            "Good evening, world!",
+        ];
+        let source = lines.join("\n");
+        let source = Spanned::from_str(&source);
+
+        let config = indoc! {"
+            [package.metadata.cargo-sync-rdme.badge.badges]
+        "};
+
+        let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
+        let mut errors = Scanner::new(&manifest, source.value).map(|res| res.unwrap_err());
+
+        let (token, expected, span) = errors
+            .next()
+            .unwrap()
+            .into_parse_marker()
+            .into_unexpected_token();
+        assert_eq!(token, "\0");
+        assert_eq!(expected, "group name");
+        source.assert_source_span(span, "\0");
+
+        let (token, expected, span) = errors
+            .next()
+            .unwrap()
+            .into_parse_marker()
+            .into_unexpected_token();
+        assert_eq!(token, "\0");
+        assert_eq!(expected, "group name");
+        source.assert_source_span(span, "\0");
+
+        let (token, expected, span) = errors
+            .next()
+            .unwrap()
+            .into_parse_marker()
+            .into_unexpected_token();
+        assert_eq!(token, "\0");
+        assert_eq!(expected, "group name");
+        source.assert_source_span(span, "\0");
+
+        assert!(errors.next().is_none());
     }
 }


### PR DESCRIPTION
## Summary
- reconstruct HTML marker text from the original markdown source using the parser-provided byte range
- avoid relying on the `Event::Html` payload, which may be normalized by `pulldown-cmark`
- refactor marker scanner tests to assert against explicit markdown input and add coverage for NUL-containing markers

## Background
A change currently present on `pulldown-cmark` main (but unreleased as of 2026-08-21) replaces NUL bytes in `Event::Html` with `\u{FFFD}`. That would make the marker text diverge from the original markdown source while keeping the same source range, leading to incorrect span-based diagnostics.

This change uses the original markdown slice for marker parsing so diagnostics continue to point at the exact source text.

## Validation
- `cargo fmt --check`
- `cargo test`

## Impact
This is a preventive compatibility fix for a future `pulldown-cmark` update. Current behavior should be unchanged except that diagnostics remain accurate if the upstream normalization lands in a release.