### PR TITLE
Refactor marker parsing and narrow spans

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -45,16 +45,6 @@ impl<T> Spanned<T> {
     pub(crate) fn source_span(&self) -> SourceSpan {
         SourceSpan::from(std::range::legacy::Range::from(self.span))
     }
-
-    pub(crate) fn as_deref(&self) -> Spanned<&T::Target>
-    where
-        T: std::ops::Deref,
-    {
-        Spanned {
-            value: &self.value,
-            span: self.span,
-        }
-    }
 }
 
 impl<'a> Spanned<&'a str> {
@@ -95,6 +85,8 @@ impl<'a> Spanned<&'a str> {
     pub(crate) fn assert_spanned_str(&self, target: Spanned<&str>, expected: &str) {
         similar_asserts::assert_eq!(target.value, expected);
         self.assert_spanned(target, expected);
+        // ensure that the target is substring of self by pointer address comparison.
+        self.value.substr_range(target.value).unwrap();
     }
 
     pub(crate) fn prefix_of(&self, other: Self) -> Self {

--- a/src/sync/marker/parse.rs
+++ b/src/sync/marker/parse.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Display};
 
 use miette::{Diagnostic, SourceSpan};
+use pulldown_cmark::{Event, OffsetIter, Options};
 use snafu::{OptionExt as _, Snafu, ensure};
 
 use crate::{
@@ -38,6 +39,40 @@ pub(crate) enum ParseMarkerError {
     },
 }
 
+#[derive(Debug)]
+pub(super) struct MarkerParser<'a> {
+    markdown: &'a str,
+    parser: OffsetIter<'a>,
+}
+
+impl<'a> MarkerParser<'a> {
+    pub(super) fn new(markdown: &'a str) -> Self {
+        let parser = pulldown_cmark::Parser::new_ext(markdown, Options::all()).into_offset_iter();
+        Self { markdown, parser }
+    }
+
+    pub(super) fn try_next(&mut self) -> Result<Option<SpannedMarker<'a>>, ParseMarkerError> {
+        for (event, range) in self.parser.by_ref() {
+            if let Event::Html(_html) = event {
+                // Use the original markdown slice for this HTML event instead of the
+                // `Event::Html` payload. The payload may be normalized by pulldown-cmark,
+                // which would make the parsed marker text diverge from the original source span
+                // and break diagnostics.
+                //
+                // As of 2026-08-21, pulldown-cmark main contains an unreleased change that
+                // replaces `\0` with `\u{FFFD}` in `Event::Html`:
+                // <https://github.com/pulldown-cmark/pulldown-cmark/blob/07bae2459d90175b661d42b8acf207382e111ae5/pulldown-cmark/src/parse.rs#L2404-L2406>
+                let html = &self.markdown[range.clone()];
+                let html = Spanned::new(html, range);
+                if let Some(marker) = parse_marker(html)? {
+                    return Ok(Some(marker));
+                }
+            }
+        }
+        Ok(None)
+    }
+}
+
 type Input<'a> = Spanned<&'a str>;
 type SpannedMarker<'a> = Spanned<Marker<'a>>;
 type SpannedReplaceSpecifier<'a> = Spanned<ReplaceSpecifier<'a>>;
@@ -55,6 +90,7 @@ type SpannedToken<'a> = Spanned<Token<'a>>;
 // ident ::= [A-Za-z][-_A-Za-z0-9]*
 
 pub(super) fn parse_marker(html: Input<'_>) -> Result<Option<SpannedMarker<'_>>, ParseMarkerError> {
+    let html = html.trim();
     let html_span = html.span;
 
     let Some(comment_body) = trim_comment(html) else {
@@ -257,6 +293,7 @@ fn expect_end_of_marker(input: Input<'_>) -> Result<(), ParseMarkerError> {
 mod tests {
     use super::*;
 
+    use indoc::indoc;
     use similar_asserts::assert_eq;
 
     impl<'a> Marker<'a> {
@@ -535,5 +572,70 @@ mod tests {
         assert_eq!(token.value, Token::UnknownChar("@"));
         source.assert_spanned(token, "@");
         source.assert_spanned_str(rest, "#");
+    }
+
+    #[test]
+    fn parser_returns_substr_of_source() {
+        let source = indoc! {"
+            some text
+            <!-- cargo-sync-rdme kind:group [[ -->
+            more text
+            <!-- cargo-sync-rdme ]] -->
+            end text
+            <!-- cargo-sync-rdme kind:group -->
+        "};
+        let source = Spanned::from_str(source);
+        let mut parser = MarkerParser::new(source.value);
+
+        let marker = parser.try_next().unwrap().unwrap();
+        source.assert_spanned(marker, "<!-- cargo-sync-rdme kind:group [[ -->");
+        let specifier = marker.value.into_start();
+        source.assert_spanned(specifier, "kind:group");
+        source.assert_spanned_str(specifier.value.kind, "kind");
+        source.assert_spanned_str(specifier.value.group.unwrap(), "group");
+
+        let marker = parser.try_next().unwrap().unwrap();
+        source.assert_spanned(marker, "<!-- cargo-sync-rdme ]] -->");
+        marker.value.into_end();
+
+        let marker = parser.try_next().unwrap().unwrap();
+        source.assert_spanned(marker, "<!-- cargo-sync-rdme kind:group -->");
+        let specifier = marker.value.into_replace();
+        source.assert_spanned(specifier, "kind:group");
+        source.assert_spanned_str(specifier.value.kind, "kind");
+        source.assert_spanned_str(specifier.value.group.unwrap(), "group");
+
+        assert!(parser.try_next().unwrap().is_none());
+    }
+
+    #[test]
+    fn nul_character_conversion_does_not_affect_error_span() {
+        let source = indoc! {"
+            some text
+            <!-- cargo-sync-rdme kind:group [[ \0 -->
+            more text
+            <!-- cargo-sync-rdme ]] \0 -->
+            end text
+            <!-- cargo-sync-rdme kind:group \0 -->
+        "};
+        let source = Spanned::from_str(source);
+        let mut parser = MarkerParser::new(source.value);
+
+        let (token, expected, span) = parser.try_next().unwrap_err().into_unexpected_token();
+        assert_eq!(token, "\0");
+        assert_eq!(expected, "end of marker");
+        source.assert_source_span(span, "\0");
+
+        let (token, expected, span) = parser.try_next().unwrap_err().into_unexpected_token();
+        assert_eq!(token, "\0");
+        assert_eq!(expected, "end of marker");
+        source.assert_source_span(span, "\0");
+
+        let (token, expected, span) = parser.try_next().unwrap_err().into_unexpected_token();
+        assert_eq!(token, "\0");
+        assert_eq!(expected, "end of marker or `[[`");
+        source.assert_source_span(span, "\0");
+
+        assert!(parser.try_next().unwrap().is_none());
     }
 }

--- a/src/sync/marker/replace.rs
+++ b/src/sync/marker/replace.rs
@@ -18,10 +18,10 @@ pub(in super::super) fn replace_all(
         .map(|(contents, range)| match contents {
             Some((replace, contents)) => {
                 if contents.text().is_empty() {
-                    Cow::Owned(format!("{}\n", ResolvedMarker::Replace(replace)))
+                    Cow::Owned(format!("{}", ResolvedMarker::Replace(replace)))
                 } else {
                     Cow::Owned(format!(
-                        "{}\n{}{}\n",
+                        "{}\n{}{}",
                         ResolvedMarker::Start(replace),
                         contents.text(),
                         ResolvedMarker::End

--- a/src/sync/marker/scan.rs
+++ b/src/sync/marker/scan.rs
@@ -1,14 +1,17 @@
 use std::sync::Arc;
 
 use miette::{NamedSource, SourceSpan};
-use pulldown_cmark::{Event, OffsetIter, Options, Parser};
 use snafu::{OptionExt as _, Snafu, ensure};
 
 use crate::{
     parse::Spanned,
     sync::{
         ManifestFile, MarkdownPath,
-        marker::{MAGIC, ResolveMarkerError, parse, resolve},
+        marker::{
+            MAGIC, ResolveMarkerError,
+            parse::{self, MarkerParser},
+            resolve,
+        },
     },
     traits::RangeExt as _,
 };
@@ -93,8 +96,7 @@ enum ScanError {
 #[derive(Debug)]
 struct Scanner<'manifest, 'markdown> {
     manifest: &'manifest ManifestFile,
-    markdown: &'markdown str,
-    parser: OffsetIter<'markdown>,
+    parser: MarkerParser<'markdown>,
 }
 
 impl Iterator for Scanner<'_, '_> {
@@ -107,12 +109,8 @@ impl Iterator for Scanner<'_, '_> {
 
 impl<'manifest, 'markdown> Scanner<'manifest, 'markdown> {
     fn new(manifest: &'manifest ManifestFile, markdown: &'markdown str) -> Self {
-        let parser = Parser::new_ext(markdown, Options::all()).into_offset_iter();
-        Self {
-            manifest,
-            markdown,
-            parser,
-        }
+        let parser = MarkerParser::new(markdown);
+        Self { manifest, parser }
     }
 
     fn try_next(&mut self) -> Result<Option<Spanned<ResolvedReplaceSpecifier>>, ScanError> {
@@ -154,25 +152,11 @@ impl<'manifest, 'markdown> Scanner<'manifest, 'markdown> {
 
 impl Scanner<'_, '_> {
     fn next_marker(&mut self) -> Result<Option<Spanned<ResolvedMarker>>, ScanError> {
-        for (event, range) in self.parser.by_ref() {
-            if let Event::Html(_html) = event {
-                // Use the original markdown slice for this HTML event instead of the
-                // `Event::Html` payload. The payload may be normalized by pulldown-cmark,
-                // which would make the parsed marker text diverge from the original source span
-                // and break diagnostics.
-                //
-                // As of 2026-08-21, pulldown-cmark main contains an unreleased change that
-                // replaces `\0` with `\u{FFFD}` in `Event::Html`:
-                // <https://github.com/pulldown-cmark/pulldown-cmark/blob/07bae2459d90175b661d42b8acf207382e111ae5/pulldown-cmark/src/parse.rs#L2404-L2406>
-                let html = &self.markdown[range.clone()];
-                let html = Spanned::new(html, range);
-                if let Some(marker) = parse::parse_marker(html.as_deref())? {
-                    let marker = resolve::resolve_marker(marker, self.manifest)?;
-                    return Ok(Some(marker));
-                }
-            }
-        }
-        Ok(None)
+        let Some(marker) = self.parser.try_next()? else {
+            return Ok(None);
+        };
+        let marker = resolve::resolve_marker(marker, self.manifest)?;
+        Ok(Some(marker))
     }
 }
 
@@ -181,28 +165,19 @@ mod tests {
     use std::range::Range;
 
     use indoc::indoc;
+    use similar_asserts::assert_eq;
 
     use crate::config::Manifest;
 
     use super::*;
-
-    impl ScanError {
-        #[track_caller]
-        pub(crate) fn into_parse_marker(self) -> parse::ParseMarkerError {
-            let Self::ParseMarker { source } = self else {
-                panic!("unexpected error: {self:?}");
-            };
-            source
-        }
-    }
 
     fn line_ranges(lines: &[impl AsRef<str>]) -> Vec<Range<usize>> {
         lines
             .iter()
             .scan(0, |offset, line| {
                 let line = line.as_ref();
-                let range = Range::from(*offset..*offset + line.len() + 1);
-                *offset = range.end;
+                let range = Range::from(*offset..*offset + line.len());
+                *offset = range.end + 1; // +1 for the newline character
                 Some(range)
             })
             .collect()
@@ -282,56 +257,5 @@ mod tests {
                 ranges[1].start..ranges[4].end
             )]
         );
-    }
-
-    #[test]
-    fn nul_character_conversion() {
-        let lines = [
-            "Good morning, world!",
-            "<!-- cargo-sync-rdme title:\0 -->",
-            "<!-- cargo-sync-rdme title:\0 -->",
-            "Good afternoon, world!",
-            "# Heading!",
-            "<!-- cargo-sync-rdme title:\0 -->",
-            "Good evening, world!",
-        ];
-        let source = lines.join("\n");
-        let source = Spanned::from_str(&source);
-
-        let config = indoc! {"
-            [package.metadata.cargo-sync-rdme.badge.badges]
-        "};
-
-        let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
-        let mut errors = Scanner::new(&manifest, source.value).map(|res| res.unwrap_err());
-
-        let (token, expected, span) = errors
-            .next()
-            .unwrap()
-            .into_parse_marker()
-            .into_unexpected_token();
-        assert_eq!(token, "\0");
-        assert_eq!(expected, "group name");
-        source.assert_source_span(span, "\0");
-
-        let (token, expected, span) = errors
-            .next()
-            .unwrap()
-            .into_parse_marker()
-            .into_unexpected_token();
-        assert_eq!(token, "\0");
-        assert_eq!(expected, "group name");
-        source.assert_source_span(span, "\0");
-
-        let (token, expected, span) = errors
-            .next()
-            .unwrap()
-            .into_parse_marker()
-            .into_unexpected_token();
-        assert_eq!(token, "\0");
-        assert_eq!(expected, "group name");
-        source.assert_source_span(span, "\0");
-
-        assert!(errors.next().is_none());
     }
 }


### PR DESCRIPTION
## Summary
- move markdown-to-marker parsing responsibility into `sync::marker::parse::MarkerParser`
- continue reconstructing HTML event text from the original markdown source while keeping that logic local to parsing
- tighten marker spans so they exclude surrounding whitespace
- preserve existing surrounding line endings when replacing markers instead of unconditionally appending `\n`
- strengthen parser tests to verify parsed slices are true source substrings and move the NUL-span regression test into the parsing layer

## Background
The previous change made marker parsing use source slices instead of the `Event::Html` payload so diagnostics stay aligned with the original markdown when pulldown-cmark normalizes HTML event text.

This refactor moves that markdown parsing boundary into `parse`, where it naturally belongs, and makes the span behavior more precise by trimming surrounding whitespace before assigning the marker span.

With narrower marker spans, trailing newlines remain outside the replacement range. Replacement now preserves those existing line endings instead of re-adding `\n` unconditionally, which also avoids introducing new line breaks where the original markdown did not have them.

## Validation
- `cargo fmt --check`
- `cargo test`

## Impact
Behavior should stay the same apart from more precise marker spans in diagnostics and preserving the original line ending layout around replaced markers.