### PR TITLE
Separate marker scanning and resolution

### DIFF
--- a/src/sync/marker/parse.rs
+++ b/src/sync/marker/parse.rs
@@ -114,7 +114,7 @@ pub(super) fn parse_marker(html: Input<'_>) -> Result<Option<SpannedMarker<'_>>,
     Ok(Some(Spanned::new(Marker::Start(specifier), html_span)))
 }
 
-fn parse_specifier(
+pub(super) fn parse_specifier(
     input: Input<'_>,
 ) -> Result<Option<(SpannedReplaceSpecifier<'_>, Input<'_>)>, ParseMarkerError> {
     let input = input.trim_start();

--- a/src/sync/marker/replace.rs
+++ b/src/sync/marker/replace.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, iter, range::Range};
 
-use crate::parse::Spanned;
+use crate::{parse::Spanned, sync::marker::MAGIC};
 
-use super::{super::contents::Contents, ResolvedMarker, ResolvedReplaceSpecifier};
+use super::{super::contents::Contents, ResolvedReplaceSpecifier};
 
 pub(in super::super) fn replace_all(
     text: &str,
@@ -16,15 +16,13 @@ pub(in super::super) fn replace_all(
 
     interpolate_ranges((0..text.len()).into(), pairs)
         .map(|(contents, range)| match contents {
-            Some((replace, contents)) => {
+            Some((specifier, contents)) => {
                 if contents.text().is_empty() {
-                    Cow::Owned(format!("{}", ResolvedMarker::Replace(replace)))
+                    Cow::Owned(format!("<!-- {MAGIC} {specifier} -->"))
                 } else {
                     Cow::Owned(format!(
-                        "{}\n{}{}",
-                        ResolvedMarker::Start(replace),
-                        contents.text(),
-                        ResolvedMarker::End
+                        "<!-- {MAGIC} {specifier} [[ -->\n{contents}<!-- {MAGIC} ]] -->",
+                        contents = contents.text(),
                     ))
                 }
             }

--- a/src/sync/marker/resolve.rs
+++ b/src/sync/marker/resolve.rs
@@ -6,22 +6,8 @@ use snafu::Snafu;
 use crate::{
     config::metadata::BadgeItem,
     parse::Spanned,
-    sync::{
-        ManifestFile,
-        marker::{
-            MAGIC,
-            parse::{Marker, ReplaceSpecifier},
-        },
-    },
-    traits::RangeExt as _,
+    sync::{ManifestFile, marker::parse::ReplaceSpecifier},
 };
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum ResolvedMarker {
-    Replace(ResolvedReplaceSpecifier),
-    Start(ResolvedReplaceSpecifier),
-    End,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in super::super) enum ResolvedReplaceSpecifier {
@@ -31,16 +17,6 @@ pub(in super::super) enum ResolvedReplaceSpecifier {
         badges: Arc<[BadgeItem]>,
     },
     Rustdoc,
-}
-
-impl fmt::Display for ResolvedMarker {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Replace(specifier) => write!(f, "<!-- {MAGIC} {specifier} -->"),
-            Self::Start(specifier) => write!(f, "<!-- {MAGIC} {specifier} [[ -->"),
-            Self::End => write!(f, "<!-- {MAGIC} ]] -->"),
-        }
-    }
 }
 
 impl fmt::Display for ResolvedReplaceSpecifier {
@@ -91,27 +67,7 @@ pub(super) enum ResolveMarkerError {
     },
 }
 
-pub(super) fn resolve_marker(
-    marker: Spanned<Marker<'_>>,
-    manifest: &ManifestFile,
-) -> Result<Spanned<ResolvedMarker>, ResolveMarkerError> {
-    match marker.value {
-        Marker::Replace(specifier) => {
-            let specifier = resolve_specifier(specifier, manifest)?;
-            Ok(Spanned::new(
-                ResolvedMarker::Replace(specifier),
-                marker.span,
-            ))
-        }
-        Marker::Start(specifier) => {
-            let specifier = resolve_specifier(specifier, manifest)?;
-            Ok(Spanned::new(ResolvedMarker::Start(specifier), marker.span))
-        }
-        Marker::End => Ok(Spanned::new(ResolvedMarker::End, marker.span)),
-    }
-}
-
-fn resolve_specifier(
+pub(super) fn resolve_specifier(
     specifier: Spanned<ReplaceSpecifier<'_>>,
     manifest: &ManifestFile,
 ) -> Result<ResolvedReplaceSpecifier, ResolveMarkerError> {
@@ -124,14 +80,14 @@ fn resolve_specifier(
             return Err(ResolveMarkerError::UnexpectedGroupForSpecifier {
                 kind: kind.value.to_string(),
                 group: group.value.to_string(),
-                span: specifier.span.to_span(),
+                span: specifier.source_span(),
             });
         }
         ("badge", _) => {}
         _ => {
             return Err(ResolveMarkerError::UnknownMarkerKind {
                 kind: kind.value.to_string(),
-                span: specifier.span.to_span(),
+                span: kind.source_span(),
             });
         }
     }
@@ -175,16 +131,6 @@ mod tests {
         [package.metadata.cargo-sync-rdme.badge.badges]
         [package.metadata.cargo-sync-rdme.badge.badges-foo]
     "};
-
-    impl ResolvedMarker {
-        #[track_caller]
-        pub(crate) fn into_replace(self) -> ResolvedReplaceSpecifier {
-            let Self::Replace(specifier) = self else {
-                panic!("unexpected marker: {self:?}");
-            };
-            specifier
-        }
-    }
 
     impl ResolvedReplaceSpecifier {
         #[track_caller]
@@ -246,47 +192,43 @@ mod tests {
     fn resolve(
         source: Spanned<&str>,
         config: &str,
-    ) -> Result<Spanned<ResolvedMarker>, ResolveMarkerError> {
+    ) -> Result<ResolvedReplaceSpecifier, ResolveMarkerError> {
         let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
-        let marker = parse::parse_marker(source).unwrap().unwrap();
-        resolve_marker(marker, &manifest)
+        let (specifier, _rest) = parse::parse_specifier(source).unwrap().unwrap();
+        resolve_specifier(specifier, &manifest)
     }
 
     #[test]
     fn resolve_marker_resolves_valid_markers() {
-        let source = Spanned::from_str("<!-- cargo-sync-rdme title -->");
+        let source = Spanned::from_str("title");
         let resolved = resolve(source, CONFIG).unwrap();
-        resolved.value.into_replace().into_title();
-        source.assert_span(resolved.span, "<!-- cargo-sync-rdme title -->");
+        resolved.into_title();
 
-        let source = Spanned::from_str("<!-- cargo-sync-rdme rustdoc -->");
+        let source = Spanned::from_str("rustdoc");
         let resolved = resolve(source, CONFIG).unwrap();
-        resolved.value.into_replace().into_rustdoc();
-        source.assert_span(resolved.span, "<!-- cargo-sync-rdme rustdoc -->");
+        resolved.into_rustdoc();
 
-        let source = Spanned::from_str("<!-- cargo-sync-rdme badge -->");
+        let source = Spanned::from_str("badge");
         let resolved = resolve(source, CONFIG).unwrap();
-        let (group, _badges) = resolved.value.into_replace().into_badge();
+        let (group, _badges) = resolved.into_badge();
         assert!(group.is_none());
-        source.assert_span(resolved.span, "<!-- cargo-sync-rdme badge -->");
 
-        let source = Spanned::from_str("<!-- cargo-sync-rdme badge:foo -->");
+        let source = Spanned::from_str("badge:foo");
         let resolved = resolve(source, CONFIG).unwrap();
-        let (group, _badges) = resolved.value.into_replace().into_badge();
+        let (group, _badges) = resolved.into_badge();
         assert_eq!(group.as_deref().unwrap(), "foo");
-        source.assert_span(resolved.span, "<!-- cargo-sync-rdme badge:foo -->");
     }
 
     #[test]
     fn resolve_marker_rejects_invalid_markers() {
-        let source = Spanned::from_str("<!-- cargo-sync-rdme unknown -->");
+        let source = Spanned::from_str("unknown");
         let (kind, span) = resolve(source, CONFIG)
             .unwrap_err()
             .into_unknown_marker_kind();
         assert_eq!(kind, "unknown");
         source.assert_source_span(span, "unknown");
 
-        let source = Spanned::from_str("<!-- cargo-sync-rdme title:foo -->");
+        let source = Spanned::from_str("title:foo");
         let (kind, group, span) = resolve(source, CONFIG)
             .unwrap_err()
             .into_unexpected_group_for_specifier();
@@ -294,7 +236,7 @@ mod tests {
         assert_eq!(group, "foo");
         source.assert_source_span(span, "title:foo");
 
-        let source = Spanned::from_str("<!-- cargo-sync-rdme rustdoc:foo -->");
+        let source = Spanned::from_str("rustdoc:foo");
         let (kind, group, span) = resolve(source, CONFIG)
             .unwrap_err()
             .into_unexpected_group_for_specifier();
@@ -302,14 +244,14 @@ mod tests {
         assert_eq!(group, "foo");
         source.assert_source_span(span, "rustdoc:foo");
 
-        let source = Spanned::from_str("<!-- cargo-sync-rdme badge:bar -->");
+        let source = Spanned::from_str("badge:bar");
         let (group, span) = resolve(source, CONFIG)
             .unwrap_err()
             .into_no_such_badge_group();
         assert_eq!(group, "bar");
         source.assert_source_span(span, "bar");
 
-        let source = Spanned::from_str("<!-- cargo-sync-rdme badge -->");
+        let source = Spanned::from_str("badge");
         let span = resolve(source, "")
             .unwrap_err()
             .into_no_default_badge_configured();

--- a/src/sync/marker/scan.rs
+++ b/src/sync/marker/scan.rs
@@ -8,26 +8,31 @@ use crate::{
     sync::{
         ManifestFile, MarkdownPath,
         marker::{
-            MAGIC, ResolveMarkerError,
-            parse::{self, MarkerParser},
+            MAGIC, ResolveMarkerError, ResolvedReplaceSpecifier,
+            parse::{self, Marker, MarkerParser, ReplaceSpecifier},
             resolve,
         },
     },
     traits::RangeExt as _,
 };
 
-use super::{super::MarkdownFile, ResolvedMarker, ResolvedReplaceSpecifier};
+use super::super::MarkdownFile;
 
 pub(in crate::sync) fn scan_all(
     markdown: &MarkdownFile<'_>,
     manifest: &ManifestFile,
 ) -> Result<Vec<Spanned<ResolvedReplaceSpecifier>>, Box<ScanAllError>> {
-    let scanner = Scanner::new(manifest, &markdown.text);
-    let mut markers = vec![];
+    let scanner = Scanner::new(&markdown.text);
+    let mut resolved_specifiers = vec![];
     let mut errors = vec![];
+
     for res in scanner {
+        let res = res.and_then(|chunk| {
+            let resolved = resolve::resolve_specifier(chunk.value.specifier, manifest)?;
+            Ok(Spanned::new(resolved, chunk.span))
+        });
         match res {
-            Ok(marker) => markers.push(marker),
+            Ok(resolved) => resolved_specifiers.push(resolved),
             Err(err) => errors.push(err),
         }
     }
@@ -41,7 +46,7 @@ pub(in crate::sync) fn scan_all(
         }
     );
 
-    Ok(markers)
+    Ok(resolved_specifiers)
 }
 
 #[derive(Debug, Snafu, miette::Diagnostic)]
@@ -94,36 +99,40 @@ enum ScanError {
 }
 
 #[derive(Debug)]
-struct Scanner<'manifest, 'markdown> {
-    manifest: &'manifest ManifestFile,
-    parser: MarkerParser<'markdown>,
+pub(super) struct Chunk<'a> {
+    pub(super) specifier: Spanned<ReplaceSpecifier<'a>>,
 }
 
-impl Iterator for Scanner<'_, '_> {
-    type Item = Result<Spanned<ResolvedReplaceSpecifier>, ScanError>;
+#[derive(Debug)]
+struct Scanner<'a> {
+    parser: MarkerParser<'a>,
+}
+
+impl<'a> Iterator for Scanner<'a> {
+    type Item = Result<Spanned<Chunk<'a>>, ScanError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.try_next().transpose()
     }
 }
 
-impl<'manifest, 'markdown> Scanner<'manifest, 'markdown> {
-    fn new(manifest: &'manifest ManifestFile, markdown: &'markdown str) -> Self {
+impl<'a> Scanner<'a> {
+    fn new(markdown: &'a str) -> Self {
         let parser = MarkerParser::new(markdown);
-        Self { manifest, parser }
+        Self { parser }
     }
 
-    fn try_next(&mut self) -> Result<Option<Spanned<ResolvedReplaceSpecifier>>, ScanError> {
+    fn try_next(&mut self) -> Result<Option<Spanned<Chunk<'a>>>, ScanError> {
         let Some(start_marker) = self.next_marker()? else {
             return Ok(None);
         };
         let start_span = start_marker.span;
         let specifier = match start_marker.value {
-            ResolvedMarker::Replace(specifier) => {
-                return Ok(Some(Spanned::new(specifier, start_span)));
+            Marker::Replace(specifier) => {
+                return Ok(Some(Spanned::new(Chunk { specifier }, start_span)));
             }
-            ResolvedMarker::Start(specifier) => specifier,
-            ResolvedMarker::End => {
+            Marker::Start(specifier) => specifier,
+            Marker::End => {
                 return Err(UnexpectedEndMarkerSnafu {
                     span: start_span.to_span(),
                 }
@@ -137,8 +146,8 @@ impl<'manifest, 'markdown> Scanner<'manifest, 'markdown> {
             })?;
         let end_span = end_marker.span;
         match end_marker.value {
-            ResolvedMarker::End => Ok(Some(Spanned::new(
-                specifier,
+            Marker::End => Ok(Some(Spanned::new(
+                Chunk { specifier },
                 start_span.start..end_span.end,
             ))),
             _ => Err(NestedMarkerSnafu {
@@ -150,12 +159,11 @@ impl<'manifest, 'markdown> Scanner<'manifest, 'markdown> {
     }
 }
 
-impl Scanner<'_, '_> {
-    fn next_marker(&mut self) -> Result<Option<Spanned<ResolvedMarker>>, ScanError> {
+impl<'a> Scanner<'a> {
+    fn next_marker(&mut self) -> Result<Option<Spanned<Marker<'a>>>, ScanError> {
         let Some(marker) = self.parser.try_next()? else {
             return Ok(None);
         };
-        let marker = resolve::resolve_marker(marker, self.manifest)?;
         Ok(Some(marker))
     }
 }
@@ -163,9 +171,6 @@ impl Scanner<'_, '_> {
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
-    use similar_asserts::assert_eq;
-
-    use crate::config::Manifest;
 
     use super::*;
 
@@ -202,8 +207,7 @@ mod tests {
     #[test]
     fn no_markers() {
         let input = "Hello, world!";
-        let manifest = ManifestFile::dummy(Manifest::default());
-        let mut markers = Scanner::new(&manifest, input);
+        let mut markers = Scanner::new(input);
         assert!(markers.next().is_none());
     }
 
@@ -219,25 +223,28 @@ mod tests {
             Good night, world!
         "};
         let source = Spanned::from_str(source);
-        let config = indoc! {"
-            [package.metadata.cargo-sync-rdme.badge.badges]
-        "};
-        let manifest = ManifestFile::dummy(toml::from_str(config).unwrap());
-        let mut scanner = Scanner::new(&manifest, source.value);
+        let mut scanner = Scanner::new(source.value);
 
-        let marker = scanner.try_next().unwrap().unwrap();
-        source.assert_span(marker.span, "<!-- cargo-sync-rdme title -->");
-        marker.value.into_title();
+        let chunk = scanner.try_next().unwrap().unwrap();
+        source.assert_span(chunk.span, "<!-- cargo-sync-rdme title -->");
+        let specifier = chunk.value.specifier;
+        source.assert_span(specifier.span, "title");
+        source.assert_spanned_str(specifier.value.kind, "title");
+        assert!(specifier.value.group.is_none());
 
-        let marker = scanner.try_next().unwrap().unwrap();
-        source.assert_span(marker.span, "<!--  cargo-sync-rdme badge  -->");
-        let (group, badges) = marker.value.into_badge();
-        assert!(group.is_none());
-        assert_eq!(*badges, []);
+        let chunk = scanner.try_next().unwrap().unwrap();
+        source.assert_span(chunk.span, "<!--  cargo-sync-rdme badge  -->");
+        let specifier = chunk.value.specifier;
+        source.assert_span(specifier.span, "badge");
+        source.assert_spanned_str(specifier.value.kind, "badge");
+        assert!(specifier.value.group.is_none());
 
-        let marker = scanner.try_next().unwrap().unwrap();
-        source.assert_span(marker.span, "<!--cargo-sync-rdme rustdoc  -->");
-        marker.value.into_rustdoc();
+        let chunk = scanner.try_next().unwrap().unwrap();
+        source.assert_span(chunk.span, "<!--cargo-sync-rdme rustdoc  -->");
+        let specifier = chunk.value.specifier;
+        source.assert_span(specifier.span, "rustdoc");
+        source.assert_spanned_str(specifier.value.kind, "rustdoc");
+        assert!(specifier.value.group.is_none());
 
         assert!(scanner.try_next().unwrap().is_none());
     }
@@ -253,14 +260,16 @@ mod tests {
             Good evening, world!
         "};
         let source = Spanned::from_str(source);
-        let manifest = ManifestFile::dummy(Manifest::default());
-        let mut scanner = Scanner::new(&manifest, source.value);
+        let mut scanner = Scanner::new(source.value);
 
-        let marker = scanner.try_next().unwrap().unwrap();
-        let span_source = &source.value[marker.span];
+        let chunk = scanner.try_next().unwrap().unwrap();
+        let span_source = &source.value[chunk.span];
         assert!(span_source.starts_with("<!-- cargo-sync-rdme rustdoc [[ -->"));
         assert!(span_source.ends_with("<!-- cargo-sync-rdme ]] -->"));
-        marker.value.into_rustdoc();
+        let specifier = chunk.value.specifier;
+        source.assert_span(specifier.span, "rustdoc");
+        source.assert_spanned_str(specifier.value.kind, "rustdoc");
+        assert!(specifier.value.group.is_none());
     }
 
     #[test]
@@ -272,8 +281,7 @@ mod tests {
         "};
 
         let source = Spanned::from_str(source);
-        let manifest = ManifestFile::dummy(Manifest::default());
-        let mut scanner = Scanner::new(&manifest, source.value);
+        let mut scanner = Scanner::new(source.value);
 
         let span = scanner.try_next().unwrap_err().into_unexpected_end_marker();
         source.assert_source_span(span, "<!-- cargo-sync-rdme ]] -->");
@@ -288,8 +296,7 @@ mod tests {
         "};
 
         let source = Spanned::from_str(source);
-        let manifest = ManifestFile::dummy(Manifest::default());
-        let mut scanner = Scanner::new(&manifest, source.value);
+        let mut scanner = Scanner::new(source.value);
 
         let span = scanner
             .try_next()
@@ -312,8 +319,7 @@ mod tests {
             Good night, world!
         "};
         let source = Spanned::from_str(source);
-        let manifest = ManifestFile::dummy(Manifest::default());
-        let mut scanner = Scanner::new(&manifest, source.value);
+        let mut scanner = Scanner::new(source.value);
 
         let (nested_span, previous_span) = scanner.try_next().unwrap_err().into_nested_marker();
         source.assert_source_span(nested_span, "<!-- cargo-sync-rdme title   [[ -->");


### PR DESCRIPTION
## Summary
- split marker scanning from specifier resolution in the sync pipeline
- make `scan` operate on parsed marker structure and move specifier-only resolution into `resolve`
- simplify replacement rendering so it formats marker comments directly from `ResolvedReplaceSpecifier`
- update unit tests to reflect the new separation of responsibilities

## Motivation
This refactor narrows each step's responsibility:
- `scan` is responsible for finding marker chunks and validating marker structure
- `resolve` is responsible for interpreting a parsed specifier against manifest configuration

That separation should make future changes to marker scanning easier to reason about and test.

## Validation
- `cargo test`

## Impact
No intended user-visible behavior change. This is an internal refactor of marker parsing and resolution.
