### PR TITLE
Refactor sync replacement pipeline

### DIFF
--- a/src/sync/contents/mod.rs
+++ b/src/sync/contents/mod.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use cargo_metadata::{Metadata, Package};
 use snafu::{Snafu, ensure};
 
-use crate::sync::SyncOptions;
+use crate::{parse::Spanned, sync::SyncOptions};
 
 use super::{ManifestFile, marker::ResolvedReplaceSpecifier};
 
@@ -12,7 +12,7 @@ mod rustdoc;
 mod title;
 
 pub(super) fn create_all(
-    replaces: impl IntoIterator<Item = ResolvedReplaceSpecifier>,
+    specifiers: Vec<Spanned<ResolvedReplaceSpecifier>>,
     manifest: &ManifestFile,
     workspace: &Metadata,
     package: &Package,
@@ -20,8 +20,8 @@ pub(super) fn create_all(
 ) -> Result<Vec<Contents>, CreateAllContentsError> {
     let mut contents = vec![];
     let mut errors = vec![];
-    for replace in replaces {
-        let res = replace.create_content(manifest, workspace, package, options);
+    for specifier in specifiers {
+        let res = create_content(specifier, manifest, workspace, package, options);
         match res {
             Ok(c) => contents.push(c),
             Err(err) => errors.push(err),
@@ -60,34 +60,37 @@ pub(super) enum CreateContentsError {
 
 #[derive(Debug, Clone)]
 pub(super) struct Contents {
+    specifier: Spanned<ResolvedReplaceSpecifier>,
     text: String,
 }
 
-impl ResolvedReplaceSpecifier {
-    fn create_content(
-        self,
-        manifest: &ManifestFile,
-        workspace: &Metadata,
-        package: &Package,
-        options: &SyncOptions<'_>,
-    ) -> Result<Contents, CreateContentsError> {
-        let text = match self {
-            ResolvedReplaceSpecifier::Title => title::create(package),
-            ResolvedReplaceSpecifier::Badge { group: _, badges } => {
-                badge::create_all(&badges, manifest, workspace, package)?
-            }
-            ResolvedReplaceSpecifier::Rustdoc => {
-                rustdoc::create(manifest, workspace, package, options)?
-            }
-        };
+fn create_content(
+    specifier: Spanned<ResolvedReplaceSpecifier>,
+    manifest: &ManifestFile,
+    workspace: &Metadata,
+    package: &Package,
+    options: &SyncOptions<'_>,
+) -> Result<Contents, CreateContentsError> {
+    let text = match &specifier.value {
+        ResolvedReplaceSpecifier::Title => title::create(package),
+        ResolvedReplaceSpecifier::Badge { group: _, badges } => {
+            badge::create_all(badges, manifest, workspace, package)?
+        }
+        ResolvedReplaceSpecifier::Rustdoc => {
+            rustdoc::create(manifest, workspace, package, options)?
+        }
+    };
 
-        assert!(text.is_empty() || text.ends_with('\n'));
+    assert!(text.is_empty() || text.ends_with('\n'));
 
-        Ok(Contents { text })
-    }
+    Ok(Contents { specifier, text })
 }
 
 impl Contents {
+    pub(super) fn specifier(&self) -> &Spanned<ResolvedReplaceSpecifier> {
+        &self.specifier
+    }
+
     pub(super) fn text(&self) -> &str {
         &self.text
     }

--- a/src/sync/marker/mod.rs
+++ b/src/sync/marker/mod.rs
@@ -1,8 +1,96 @@
-pub(in crate::sync) use self::{replace::*, resolve::*, scan::*};
+use std::{fmt, sync::Arc};
+
+use miette::NamedSource;
+use snafu::{Snafu, ensure};
+
+use crate::{
+    config::metadata::BadgeItem,
+    parse::Spanned,
+    sync::{
+        ManifestFile, MarkdownFile, MarkdownPath,
+        contents::Contents,
+        marker::resolve::{ResolveMarkerError, Resolver},
+    },
+};
 
 mod parse;
-mod replace;
 mod resolve;
 mod scan;
 
 const MAGIC: &str = "cargo-sync-rdme";
+
+#[derive(Debug, Snafu, miette::Diagnostic)]
+#[snafu(display(
+    "failed to parse `<!-- {MAGIC} ... -->` markers in markdown file for package `{package}`: {markdown}",
+    package = markdown.package, markdown = markdown.path,
+))]
+pub(crate) struct ParseMarkersError {
+    markdown: MarkdownPath,
+    #[source_code]
+    source_code: NamedSource<Arc<str>>,
+    #[related]
+    errors: Vec<ResolveMarkerError>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ResolvedReplaceSpecifier {
+    Title,
+    Badge {
+        group: Option<Arc<str>>,
+        badges: Arc<[BadgeItem]>,
+    },
+    Rustdoc,
+}
+
+impl fmt::Display for ResolvedReplaceSpecifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Title => write!(f, "title"),
+            Self::Badge { group, .. } => {
+                if let Some(name) = group {
+                    write!(f, "badge:{name}")
+                } else {
+                    write!(f, "badge")
+                }
+            }
+            Self::Rustdoc => write!(f, "rustdoc"),
+        }
+    }
+}
+
+pub(super) fn parse_markers(
+    markdown: &MarkdownFile<'_>,
+    manifest: &ManifestFile,
+) -> Result<Vec<Spanned<ResolvedReplaceSpecifier>>, Box<ParseMarkersError>> {
+    let mut resolver = Resolver::new(&markdown.text, manifest);
+    let mut specifiers = vec![];
+    let mut errors = vec![];
+
+    while let Some(res) = resolver.try_next().transpose() {
+        match res {
+            Ok(specifier) => specifiers.push(specifier),
+            Err(err) => errors.push(err),
+        }
+    }
+
+    ensure!(
+        errors.is_empty(),
+        ParseMarkersSnafu {
+            markdown,
+            source_code: markdown.to_named_source(),
+            errors
+        }
+    );
+
+    Ok(specifiers)
+}
+
+pub(super) fn make_marked_contents(contents: &Contents) -> String {
+    let specifier = contents.specifier();
+    let text = contents.text();
+    if text.is_empty() {
+        format!("<!-- {MAGIC} {specifier} -->")
+    } else {
+        format!("<!-- {MAGIC} {specifier} [[ -->\n{text}<!-- {MAGIC} ]] -->")
+    }
+}

--- a/src/sync/marker/resolve.rs
+++ b/src/sync/marker/resolve.rs
@@ -1,42 +1,29 @@
-use std::{fmt, sync::Arc};
+use std::sync::Arc;
 
 use miette::{Diagnostic, SourceSpan};
 use snafu::Snafu;
 
 use crate::{
-    config::metadata::BadgeItem,
     parse::Spanned,
-    sync::{ManifestFile, marker::parse::ReplaceSpecifier},
-};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(in super::super) enum ResolvedReplaceSpecifier {
-    Title,
-    Badge {
-        group: Option<Arc<str>>,
-        badges: Arc<[BadgeItem]>,
+    sync::{
+        ManifestFile,
+        marker::{
+            ResolvedReplaceSpecifier,
+            parse::ReplaceSpecifier,
+            scan::{ScanError, Scanner},
+        },
     },
-    Rustdoc,
-}
-
-impl fmt::Display for ResolvedReplaceSpecifier {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Title => write!(f, "title"),
-            Self::Badge { group, .. } => {
-                if let Some(name) = group {
-                    write!(f, "badge:{name}")
-                } else {
-                    write!(f, "badge")
-                }
-            }
-            Self::Rustdoc => write!(f, "rustdoc"),
-        }
-    }
-}
+};
 
 #[derive(Debug, Snafu, Diagnostic)]
 pub(super) enum ResolveMarkerError {
+    #[snafu(transparent)]
+    #[diagnostic(transparent)]
+    Scan {
+        #[snafu(source)]
+        #[diagnostic_source]
+        source: ScanError,
+    },
     #[snafu(display("unknown marker kind: {kind}"))]
     UnknownMarkerKind {
         kind: String,
@@ -65,6 +52,31 @@ pub(super) enum ResolveMarkerError {
         #[label]
         span: SourceSpan,
     },
+}
+
+#[derive(Debug)]
+pub(super) struct Resolver<'markdown, 'manifest> {
+    manifest: &'manifest ManifestFile,
+    scanner: Scanner<'markdown>,
+}
+
+impl<'markdown, 'manifest> Resolver<'markdown, 'manifest> {
+    pub(super) fn new(markdown: &'markdown str, manifest: &'manifest ManifestFile) -> Self {
+        Self {
+            manifest,
+            scanner: Scanner::new(markdown),
+        }
+    }
+
+    pub(super) fn try_next(
+        &mut self,
+    ) -> Result<Option<Spanned<ResolvedReplaceSpecifier>>, ResolveMarkerError> {
+        let Some(chunk) = self.scanner.try_next()? else {
+            return Ok(None);
+        };
+        let resolved = resolve_specifier(chunk.value.specifier, self.manifest)?;
+        Ok(Some(Spanned::new(resolved, chunk.span)))
+    }
 }
 
 pub(super) fn resolve_specifier(
@@ -123,7 +135,7 @@ pub(super) fn resolve_specifier(
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::sync::marker::parse;
+    use crate::{config::metadata::BadgeItem, sync::marker::parse};
 
     use super::*;
 

--- a/src/sync/marker/scan.rs
+++ b/src/sync/marker/scan.rs
@@ -1,83 +1,21 @@
-use std::sync::Arc;
-
-use miette::{NamedSource, SourceSpan};
-use snafu::{OptionExt as _, Snafu, ensure};
+use miette::SourceSpan;
+use snafu::{OptionExt as _, Snafu};
 
 use crate::{
     parse::Spanned,
-    sync::{
-        ManifestFile, MarkdownPath,
-        marker::{
-            MAGIC, ResolveMarkerError, ResolvedReplaceSpecifier,
-            parse::{self, Marker, MarkerParser, ReplaceSpecifier},
-            resolve,
-        },
-    },
+    sync::marker::parse::{self, Marker, MarkerParser, ReplaceSpecifier},
     traits::RangeExt as _,
 };
 
-use super::super::MarkdownFile;
-
-pub(in crate::sync) fn scan_all(
-    markdown: &MarkdownFile<'_>,
-    manifest: &ManifestFile,
-) -> Result<Vec<Spanned<ResolvedReplaceSpecifier>>, Box<ScanAllError>> {
-    let scanner = Scanner::new(&markdown.text);
-    let mut resolved_specifiers = vec![];
-    let mut errors = vec![];
-
-    for res in scanner {
-        let res = res.and_then(|chunk| {
-            let resolved = resolve::resolve_specifier(chunk.value.specifier, manifest)?;
-            Ok(Spanned::new(resolved, chunk.span))
-        });
-        match res {
-            Ok(resolved) => resolved_specifiers.push(resolved),
-            Err(err) => errors.push(err),
-        }
-    }
-
-    ensure!(
-        errors.is_empty(),
-        ScanAllSnafu {
-            markdown,
-            source_code: markdown.to_named_source(),
-            errors
-        }
-    );
-
-    Ok(resolved_specifiers)
-}
-
-#[derive(Debug, Snafu, miette::Diagnostic)]
-#[snafu(display(
-    "failed to parse `<!-- {MAGIC} ... -->` markers in markdown file for package `{package}`: {markdown}",
-    package = markdown.package, markdown = markdown.path,
-))]
-pub(crate) struct ScanAllError {
-    markdown: MarkdownPath,
-    #[source_code]
-    source_code: NamedSource<Arc<str>>,
-    #[related]
-    errors: Vec<ScanError>,
-}
-
 #[expect(clippy::enum_variant_names)]
 #[derive(Debug, Snafu, miette::Diagnostic)]
-enum ScanError {
+pub(super) enum ScanError {
     #[snafu(transparent)]
     #[diagnostic(transparent)]
     ParseMarker {
         #[snafu(source)]
         #[diagnostic_source]
         source: parse::ParseMarkerError,
-    },
-    #[snafu(transparent)]
-    #[diagnostic(transparent)]
-    ResolveMarker {
-        #[snafu(source)]
-        #[diagnostic_source]
-        source: ResolveMarkerError,
     },
     #[snafu(display("unexpected end marker"))]
     UnexpectedEndMarker {
@@ -104,25 +42,17 @@ pub(super) struct Chunk<'a> {
 }
 
 #[derive(Debug)]
-struct Scanner<'a> {
+pub(super) struct Scanner<'a> {
     parser: MarkerParser<'a>,
 }
 
-impl<'a> Iterator for Scanner<'a> {
-    type Item = Result<Spanned<Chunk<'a>>, ScanError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.try_next().transpose()
-    }
-}
-
 impl<'a> Scanner<'a> {
-    fn new(markdown: &'a str) -> Self {
+    pub(super) fn new(markdown: &'a str) -> Self {
         let parser = MarkerParser::new(markdown);
         Self { parser }
     }
 
-    fn try_next(&mut self) -> Result<Option<Spanned<Chunk<'a>>>, ScanError> {
+    pub(super) fn try_next(&mut self) -> Result<Option<Spanned<Chunk<'a>>>, ScanError> {
         let Some(start_marker) = self.next_marker()? else {
             return Ok(None);
         };
@@ -208,7 +138,7 @@ mod tests {
     fn no_markers() {
         let input = "Hello, world!";
         let mut markers = Scanner::new(input);
-        assert!(markers.next().is_none());
+        assert!(markers.try_next().unwrap().is_none());
     }
 
     #[test]

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -26,6 +26,7 @@ use crate::{
 
 mod contents;
 mod marker;
+mod replace;
 
 #[derive(Debug, Snafu, miette::Diagnostic)]
 pub(crate) enum SyncError {
@@ -54,10 +55,10 @@ pub(crate) enum SyncError {
     NoTargetFilesFound { package: PackageName },
     #[snafu(transparent)]
     #[diagnostic(transparent)]
-    ScanMarkers {
+    ParseMarkers {
         #[snafu(source)]
         #[diagnostic_source]
-        source: Box<marker::ScanAllError>,
+        source: Box<marker::ParseMarkersError>,
     },
     #[snafu(transparent)]
     #[diagnostic(transparent)]
@@ -108,8 +109,8 @@ impl From<with_source::ReadFileError> for Box<SyncError> {
     }
 }
 
-impl From<Box<marker::ScanAllError>> for Box<SyncError> {
-    fn from(value: Box<marker::ScanAllError>) -> Self {
+impl From<Box<marker::ParseMarkersError>> for Box<SyncError> {
+    fn from(value: Box<marker::ParseMarkersError>) -> Self {
         Box::new(value.into())
     }
 }
@@ -152,18 +153,14 @@ pub(crate) fn sync_all(
 
         let mut markdown = MarkdownFile::new(workspace, package, path)?;
 
-        // Scan replace markers from markdown file
-        let all_markers = marker::scan_all(&markdown, &manifest)?;
+        let all_markers = marker::parse_markers(&markdown, &manifest)?;
 
-        // Create contents for each marker
         tracing::info!("creating replacement contents for markdown file: {path}");
-        let replaces = all_markers.iter().map(|x| x.value.clone());
-        let all_contents = contents::create_all(replaces, &manifest, workspace, package, options)?;
+        let all_contents =
+            contents::create_all(all_markers, &manifest, workspace, package, options)?;
 
-        // Replace markers with content
-        let new_text = marker::replace_all(&markdown.text, &all_markers, &all_contents);
+        let new_text = replace::replace_all(&markdown.text, &all_contents);
 
-        // Compare new markdown file with old one
         let changed = new_text.as_str() != &*markdown.text;
         if !changed {
             tracing::info!("markdown file is already up to date: {path}");

--- a/src/sync/replace.rs
+++ b/src/sync/replace.rs
@@ -1,31 +1,15 @@
 use std::{borrow::Cow, iter, range::Range};
 
-use crate::{parse::Spanned, sync::marker::MAGIC};
+use crate::sync::{contents::Contents, marker};
 
-use super::{super::contents::Contents, ResolvedReplaceSpecifier};
-
-pub(in super::super) fn replace_all(
-    text: &str,
-    markers: &[Spanned<ResolvedReplaceSpecifier>],
-    contents: &[Contents],
-) -> String {
-    let pairs = markers
+pub(in super::super) fn replace_all(text: &str, contents: &[Contents]) -> String {
+    let pairs = contents
         .iter()
-        .zip(contents)
-        .map(|(replace, contents)| ((replace.value.clone(), contents), replace.span));
+        .map(|contents| (contents, contents.specifier().span));
 
     interpolate_ranges((0..text.len()).into(), pairs)
         .map(|(contents, range)| match contents {
-            Some((specifier, contents)) => {
-                if contents.text().is_empty() {
-                    Cow::Owned(format!("<!-- {MAGIC} {specifier} -->"))
-                } else {
-                    Cow::Owned(format!(
-                        "<!-- {MAGIC} {specifier} [[ -->\n{contents}<!-- {MAGIC} ]] -->",
-                        contents = contents.text(),
-                    ))
-                }
-            }
+            Some(contents) => marker::make_marked_contents(contents).into(),
             None => Cow::Borrowed(&text[range]),
         })
         .collect()


### PR DESCRIPTION
## Summary
- move replacement rendering into `src/sync/replace.rs`
- let marker parsing own the scan + resolve flow and aggregate related errors in one place
- carry each marker's spanned specifier in `Contents` so replacement no longer has to zip markers and generated contents separately
- simplify `sync_all` into a clearer parse -> create -> replace pipeline

## Motivation
This is a structural refactor intended to make the sync pipeline easier to follow and reduce coupling between stages. No behavior change is intended.

## Validation
- `cargo test sync`
- user reported the full test suite passes
- user reported `clippy` is clean

## Impact
- no intended user-visible behavior change
- risk should be low because the change is limited to internal sync pipeline organization