### PR TITLE
Extract rustdoc build module

### DIFF
--- a/src/sync/contents/mod.rs
+++ b/src/sync/contents/mod.rs
@@ -76,7 +76,9 @@ fn create_content(
         ResolvedReplaceSpecifier::Badge { group: _, badges } => {
             badge::create_all(badges, manifest, workspace, package)?
         }
-        ResolvedReplaceSpecifier::Rustdoc => rustdoc::create(manifest, package, options)?,
+        ResolvedReplaceSpecifier::Rustdoc => {
+            rustdoc::create(manifest, workspace, package, options)?
+        }
     };
 
     assert!(text.is_empty() || text.ends_with('\n'));

--- a/src/sync/contents/rustdoc/build.rs
+++ b/src/sync/contents/rustdoc/build.rs
@@ -1,0 +1,213 @@
+use std::{
+    ffi::OsString,
+    fs,
+    io::{self, BufReader},
+    process::{ExitStatus, Stdio},
+    sync::Arc,
+};
+
+use cargo_metadata::{
+    Message, Metadata, Package,
+    camino::{Utf8Path, Utf8PathBuf},
+};
+use miette::{Diagnostic, NamedSource, SourceOffset, SourceSpan};
+use rustdoc_types::Crate;
+use snafu::{ResultExt as _, Snafu, ensure};
+use tracing::Level;
+
+use crate::{
+    cargo,
+    sync::{SyncOptions, contents::rustdoc::document::RustdocDocument},
+    traits::CommandExt as _,
+};
+
+#[derive(Debug, Snafu, Diagnostic)]
+pub(in crate::sync) enum BuildRustdocError {
+    #[snafu(display("failed to start rustdoc: {}", commandline.display()))]
+    StartRustdocProcess {
+        commandline: OsString,
+        #[snafu(source)]
+        source: io::Error,
+    },
+    #[snafu(display("failed to read rustdoc output: {}", source))]
+    ReadRustdocOutput {
+        commandline: OsString,
+        #[snafu(source)]
+        source: io::Error,
+    },
+    #[snafu(display("failed to wait for rustdoc completion: {}", commandline.display()))]
+    WaitRustdocProcess {
+        commandline: OsString,
+        #[snafu(source)]
+        source: io::Error,
+    },
+    #[snafu(display("rustdoc exited with status `{status}`: {}", commandline.display()))]
+    NonZeroExitStatus {
+        commandline: OsString,
+        status: ExitStatus,
+    },
+    #[snafu(display("rustdoc did not produce any JSON output files: {}", commandline.display()))]
+    NoRustdocJsonFiles { commandline: OsString },
+    #[snafu(display("rustdoc produced multiple JSON output files: {}\nfiles: {files:?}", commandline.display()))]
+    MultipleRustdocJsonFiles {
+        commandline: OsString,
+        files: Vec<Utf8PathBuf>,
+    },
+    #[snafu(display("failed to read rustdoc JSON output file: {path}"))]
+    ReadRustdocJson {
+        path: Utf8PathBuf,
+        #[snafu(source)]
+        source: io::Error,
+    },
+    #[snafu(display("failed to parse rustdoc JSON output file: {path}"))]
+    ParseRustdocJson {
+        path: Utf8PathBuf,
+        #[snafu(source)]
+        source: serde_json::Error,
+        #[source_code]
+        source_code: NamedSource<Arc<str>>,
+        #[label]
+        label: SourceSpan,
+    },
+}
+
+pub(super) fn build_rustdoc(
+    workspace: &Metadata,
+    package: &Package,
+    options: &SyncOptions<'_>,
+) -> Result<RustdocDocument, BuildRustdocError> {
+    let json_path = run_rustdoc(package, options)?;
+    let json_file = JsonFile::new(workspace, &json_path)?;
+    let doc = json_file.parse()?;
+    let doc = RustdocDocument::new(doc);
+    Ok(doc)
+}
+
+fn run_rustdoc(
+    package: &Package,
+    options: &SyncOptions<'_>,
+) -> Result<Utf8PathBuf, BuildRustdocError> {
+    let mut command = cargo::command_for_build_doc(options.toolchain);
+    match options.verbosity {
+        Some(Level::TRACE) => _ = command.arg("-v"),
+        Some(Level::DEBUG) => {}
+        _ => _ = command.arg("-q"),
+    }
+    command
+        .args(["rustdoc", "--package", &package.name])
+        .args(cargo::feature_args(options.feature))
+        .args([
+            "--message-format=json-render-diagnostics",
+            "-Zunstable-options",
+            // `--output-format=json` must be passed to Cargo, not forwarded to rustdoc.
+            // Put it before `--`.
+            // If passed after `--`, rustdoc still writes the JSON file, but Cargo does not
+            // treat it as the documented artifact, so `compiler-artifact.filenames` is
+            // empty and the output path cannot be discovered from the message stream.
+            "--output-format=json",
+            // Pass `-Zrustdoc-map` so Cargo provides documentation URLs for
+            // external crates that do not define `#![doc(html_root_url = ...)]`.
+            // `cargo-sync-rdme` reads those URLs from
+            // `external_crates[*].html_root_url` when generating links to
+            // external items.
+            "-Zrustdoc-map",
+            "--",
+            "--document-private-items",
+        ])
+        .stdout(Stdio::piped());
+
+    let commandline = command.commandline();
+    tracing::debug!("executing rustdoc command: {}", commandline.display());
+    let mut child = command
+        .spawn()
+        .with_context(|_source| StartRustdocProcessSnafu {
+            commandline: &commandline,
+        })?;
+
+    let stdout = BufReader::new(child.stdout.take().unwrap());
+    let mut json_filenames = vec![];
+    for message in Message::parse_stream(stdout) {
+        let message = message.context(ReadRustdocOutputSnafu {
+            commandline: &commandline,
+        })?;
+        if let Message::CompilerArtifact(artifact) = message
+            && artifact.package_id == package.id
+        {
+            json_filenames.extend(
+                artifact
+                    .filenames
+                    .into_iter()
+                    .filter(|f| f.extension().is_some_and(|e| e == "json")),
+            );
+        }
+    }
+    let status = child.wait().context(WaitRustdocProcessSnafu {
+        commandline: &commandline,
+    })?;
+    ensure!(
+        status.success(),
+        NonZeroExitStatusSnafu {
+            commandline: &commandline,
+            status,
+        }
+    );
+
+    ensure!(
+        json_filenames.len() <= 1,
+        MultipleRustdocJsonFilesSnafu {
+            commandline: &commandline,
+            files: json_filenames.clone(),
+        }
+    );
+    let Some(output_file) = json_filenames.pop() else {
+        return Err(NoRustdocJsonFilesSnafu {
+            commandline: &commandline,
+        }
+        .build());
+    };
+
+    Ok(output_file)
+}
+
+#[derive(Debug)]
+struct JsonFile {
+    relative_path: Utf8PathBuf,
+    text: Arc<str>,
+}
+
+impl JsonFile {
+    fn new(workspace: &Metadata, path: &Utf8Path) -> Result<Self, BuildRustdocError> {
+        let relative_path = path
+            .strip_prefix(&workspace.workspace_root)
+            .unwrap_or(path)
+            .to_owned();
+        let text = fs::read_to_string(path)
+            .with_context(|_source| ReadRustdocJsonSnafu {
+                path: &relative_path,
+            })?
+            .into();
+        Ok(Self {
+            relative_path,
+            text,
+        })
+    }
+
+    fn parse(&self) -> Result<Crate, BuildRustdocError> {
+        let doc = serde_json::from_str(&self.text).with_context(|source| {
+            let path = &self.relative_path;
+            let source_code = self.to_named_source();
+            let offset = SourceOffset::from_location(&self.text, source.line(), source.column());
+            let label = SourceSpan::new(offset, 1);
+            ParseRustdocJsonSnafu {
+                path,
+                source_code,
+                label,
+            }
+        })?;
+        Ok(doc)
+    }
+
+    fn to_named_source(&self) -> NamedSource<Arc<str>> {
+        NamedSource::new(&self.relative_path, Arc::clone(&self.text))
+    }
+}

--- a/src/sync/contents/rustdoc/document.rs
+++ b/src/sync/contents/rustdoc/document.rs
@@ -26,7 +26,7 @@ impl RustdocDocument {
 
     pub(super) fn intra_link_resolver<'doc>(
         &'doc self,
-        options: &BuildUrlOptions<'doc>,
+        options: &UrlOptions<'doc>,
     ) -> IntraLinkResolver<'doc> {
         IntraLinkResolver::new(&self.doc, options)
     }
@@ -79,7 +79,7 @@ pub(super) struct IntraLinkResolver<'doc> {
 
 fn create_crate_map<'doc>(
     doc: &'doc Crate,
-    options: &BuildUrlOptions<'doc>,
+    options: &UrlOptions<'doc>,
 ) -> HashMap<CrateId, Rc<LinkTargetCrate<'doc>>> {
     iter::once(LOCAL_CRATE_ID)
         .chain(doc.external_crates.keys().copied())
@@ -88,7 +88,7 @@ fn create_crate_map<'doc>(
 }
 
 impl<'doc> IntraLinkResolver<'doc> {
-    fn new(doc: &'doc Crate, options: &BuildUrlOptions<'doc>) -> Self {
+    fn new(doc: &'doc Crate, options: &UrlOptions<'doc>) -> Self {
         let crate_map = create_crate_map(doc, options);
         let mut per_crate_resolved_paths = HashMap::new();
         let mut fallback_resolved_paths = HashMap::new();
@@ -368,8 +368,8 @@ fn warn_missing_container_information<T>(kind: ItemKind, path: &[String]) -> Opt
 }
 
 #[derive(Debug)]
-pub(super) struct BuildUrlOptions<'url> {
-    pub(super) local_html_root_url: &'url str,
+pub(super) struct UrlOptions<'url> {
+    pub(super) local_html_root_url: Cow<'url, str>,
     pub(super) expected_toolchain: Toolchain,
     pub(super) rustdoc_toolchain: Toolchain,
 }
@@ -446,7 +446,7 @@ impl<'resolver, 'doc> LinkTarget<'resolver, 'doc> {
 enum LinkTargetCrate<'doc> {
     Local {
         name: Option<&'doc str>,
-        html_root_url: &'doc str,
+        html_root_url: Cow<'doc, str>,
     },
     External {
         id: CrateId,
@@ -468,7 +468,7 @@ fn toolchain_url_slug(toolchain: &Toolchain) -> Option<&str> {
 
 fn build_html_root_url_for_external_crate<'doc>(
     html_root_url: &'doc str,
-    options: &BuildUrlOptions<'doc>,
+    options: &UrlOptions<'doc>,
 ) -> Cow<'doc, str> {
     if options.expected_toolchain == options.rustdoc_toolchain {
         return html_root_url.into();
@@ -491,7 +491,7 @@ fn build_html_root_url_for_external_crate<'doc>(
 }
 
 impl<'doc> LinkTargetCrate<'doc> {
-    fn new(doc: &'doc Crate, id: CrateId, options: &BuildUrlOptions<'doc>) -> Self {
+    fn new(doc: &'doc Crate, id: CrateId, options: &UrlOptions<'doc>) -> Self {
         if id == LOCAL_CRATE_ID {
             let name = doc
                 .index
@@ -499,14 +499,14 @@ impl<'doc> LinkTargetCrate<'doc> {
                 .and_then(|root| root.name.as_deref());
             return Self::Local {
                 name,
-                html_root_url: options.local_html_root_url,
+                html_root_url: options.local_html_root_url.clone(),
             };
         }
         let info = doc.external_crates.get(&id);
         let name = info.map(|info| info.name.as_ref());
         let html_root_url = match info.and_then(|info| info.html_root_url.as_deref()) {
             Some(html_root_url) => build_html_root_url_for_external_crate(html_root_url, options),
-            None => options.local_html_root_url.into(), // assume the documentation is located relative to the shared documentation root
+            None => options.local_html_root_url.clone(), // assume the documentation is located relative to the shared documentation root
         };
         Self::External {
             id,
@@ -540,8 +540,9 @@ impl<'doc> LinkTargetCrate<'doc> {
         'doc: 'a,
     {
         match self {
-            Self::Local { html_root_url, .. } => (*html_root_url).into(),
-            Self::External { html_root_url, .. } => html_root_url.clone(),
+            Self::Local { html_root_url, .. } | Self::External { html_root_url, .. } => {
+                html_root_url.clone()
+            }
         }
     }
 }
@@ -1042,8 +1043,8 @@ mod tests {
         let expected_toolchain = Toolchain::from_str(expected_toolchain).unwrap();
         let rustdoc_toolchain = Toolchain::from_str(rustdoc_toolchain).unwrap();
 
-        let options = BuildUrlOptions {
-            local_html_root_url: "https://example.com/",
+        let options = UrlOptions {
+            local_html_root_url: "https://example.com/".into(),
             expected_toolchain,
             rustdoc_toolchain,
         };

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -1,72 +1,31 @@
-use std::{
-    ffi::OsString,
-    io::{self, BufReader},
-    process::{ExitStatus, Stdio},
-};
+use std::borrow::Cow;
 
-use cargo_metadata::{Message, Package, PackageName, camino::Utf8PathBuf};
-use pulldown_cmark::Options;
-use snafu::{OptionExt as _, ResultExt as _, Snafu, ensure};
-use tracing::Level;
+use cargo_metadata::{Metadata, Package, PackageName};
+use miette::Diagnostic;
+use pulldown_cmark::{Event, Options};
+use snafu::{OptionExt as _, ResultExt as _, Snafu};
 
 use crate::{
     cargo,
     sync::{
         ManifestFile, SyncOptions,
-        contents::rustdoc::{
-            document::{BuildUrlOptions, RustdocDocument},
-            intra_link::LinkMappingConfig,
-        },
+        contents::rustdoc::{document::UrlOptions, intra_link::LinkMappingConfig},
     },
-    traits::CommandExt as _,
-    with_source::{ReadFileError, WithSource},
 };
 
+mod build;
 mod code_block;
 mod document;
 mod heading;
 mod intra_link;
 
-type CreateResult<T> = Result<T, CreateRustdocError>;
-
-#[derive(Debug, Snafu, miette::Diagnostic)]
-pub(in super::super) enum CreateRustdocError {
-    #[snafu(display("failed to start rustdoc: {}", commandline.display()))]
-    StartRustdocProcess {
-        commandline: OsString,
-        #[snafu(source)]
-        source: io::Error,
-    },
-    #[snafu(display("failed to read rustdoc output: {}", source))]
-    ReadRustdocOutput {
-        commandline: OsString,
-        #[snafu(source)]
-        source: io::Error,
-    },
-    #[snafu(display("failed to wait for rustdoc completion: {}", commandline.display()))]
-    WaitRustdocProcess {
-        commandline: OsString,
-        #[snafu(source)]
-        source: io::Error,
-    },
-    #[snafu(display("rustdoc exited with status `{status}`: {}", commandline.display()))]
-    NonZeroExitStatus {
-        commandline: OsString,
-        status: ExitStatus,
-    },
-    #[snafu(display("rustdoc did not produce any JSON output files: {}", commandline.display()))]
-    NoRustdocJsonFiles { commandline: OsString },
-    #[snafu(display("rustdoc produced multiple JSON output files: {}\nfiles: {files:?}", commandline.display()))]
-    MultipleRustdocJsonFiles {
-        commandline: OsString,
-        files: Vec<Utf8PathBuf>,
-    },
-    #[snafu(transparent)]
-    #[diagnostic(transparent)]
-    ReadFileError {
+#[derive(Debug, Snafu, Diagnostic)]
+pub(in crate::sync) enum CreateRustdocError {
+    #[snafu(display("failed to build rustdoc JSON output"))]
+    BuildRustdoc {
         #[snafu(source)]
         #[diagnostic_source]
-        source: ReadFileError,
+        source: build::BuildRustdocError,
     },
     #[snafu(display("package {package_name} does not have a root item"))]
     RootNotFound { package_name: PackageName },
@@ -78,40 +37,26 @@ pub(in super::super) enum CreateRustdocError {
         #[diagnostic_source]
         source: cargo::ToolchainError,
     },
+    #[snafu(display("failed to construct markdown from rustdoc output"))]
+    Render {
+        #[snafu(source)]
+        source: pulldown_cmark_to_cmark::Error,
+    },
 }
 
 pub(super) fn create(
     manifest: &ManifestFile,
+    workspace: &Metadata,
     package: &Package,
     options: &SyncOptions<'_>,
-) -> CreateResult<String> {
-    let config = manifest.value().config();
-    let local_html_root_url = config
-        .rustdoc
-        .html_root_url
-        .clone()
-        .unwrap_or_else(|| format!("https://docs.rs/{}/{}", package.name, package.version));
-    let expected_toolchain = cargo::toolchain(None).context(DetermineToolchainSnafu)?;
-    let rustdoc_toolchain =
-        cargo::toolchain(Some(options.toolchain)).context(DetermineToolchainSnafu)?;
-    let build_url_options = BuildUrlOptions {
-        local_html_root_url: &local_html_root_url,
-        expected_toolchain,
-        rustdoc_toolchain,
-    };
-
-    let mapping_config = LinkMappingConfig {
-        mappings: &config.rustdoc.mappings,
-    };
-
-    let output_file = run_rustdoc(package, options)?;
-
-    let doc = WithSource::from_json("rustdoc output", output_file)?.into_value();
-    let doc = RustdocDocument::new(doc);
+) -> Result<String, CreateRustdocError> {
+    let doc = build::build_rustdoc(workspace, package, options).context(BuildRustdocSnafu)?;
     let root = doc.root_item().with_context(|| RootNotFoundSnafu {
         package_name: package.name.clone(),
     })?;
 
+    let build_url_options = build_url_options(package, manifest, options)?;
+    let mapping_config = build_mapping_config(manifest);
     let resolver = doc.intra_link_resolver(&build_url_options);
     let mapper = mapping_config
         .build_mapper(&resolver, root)
@@ -123,95 +68,35 @@ pub(super) fn create(
     let events = heading::convert(events);
     let events = code_block::convert(events);
 
-    let mut buf = String::new();
-    pulldown_cmark_to_cmark::cmark(events, &mut buf).unwrap();
-    if !buf.is_empty() && !buf.ends_with('\n') {
-        buf.push('\n');
-    }
-    Ok(buf)
+    let output = render(events)?;
+    Ok(output)
 }
 
-fn run_rustdoc(package: &Package, options: &SyncOptions<'_>) -> CreateResult<Utf8PathBuf> {
-    let mut command = cargo::command_for_build_doc(options.toolchain);
-    match options.verbosity {
-        Some(Level::TRACE) => _ = command.arg("-v"),
-        Some(Level::DEBUG) => {}
-        _ => _ = command.arg("-q"),
-    }
-    command
-        .args(["rustdoc", "--package", &package.name])
-        .args(cargo::feature_args(options.feature))
-        .args([
-            "--message-format=json-render-diagnostics",
-            "-Zunstable-options",
-            // `--output-format=json` must be passed to Cargo, not forwarded to rustdoc.
-            // Put it before `--`.
-            // If passed after `--`, rustdoc still writes the JSON file, but Cargo does not
-            // treat it as the documented artifact, so `compiler-artifact.filenames` is
-            // empty and the output path cannot be discovered from the message stream.
-            "--output-format=json",
-            // Pass `-Zrustdoc-map` so Cargo provides documentation URLs for
-            // external crates that do not define `#![doc(html_root_url = ...)]`.
-            // `cargo-sync-rdme` reads those URLs from
-            // `external_crates[*].html_root_url` when generating links to
-            // external items.
-            "-Zrustdoc-map",
-            "--",
-            "--document-private-items",
-        ])
-        .stdout(Stdio::piped());
-
-    let commandline = command.commandline();
-    tracing::debug!("executing rustdoc command: {}", commandline.display());
-    let mut child = command
-        .spawn()
-        .with_context(|_source| StartRustdocProcessSnafu {
-            commandline: &commandline,
-        })?;
-
-    let stdout = BufReader::new(child.stdout.take().unwrap());
-    let mut output_files = vec![];
-    for message in Message::parse_stream(stdout) {
-        let message = message.context(ReadRustdocOutputSnafu {
-            commandline: &commandline,
-        })?;
-        if let Message::CompilerArtifact(artifact) = message
-            && artifact.package_id == package.id
-        {
-            output_files.extend(
-                artifact
-                    .filenames
-                    .into_iter()
-                    .filter(|f| f.extension().is_some_and(|e| e == "json")),
-            );
-        }
-    }
-    let status = child.wait().context(WaitRustdocProcessSnafu {
-        commandline: &commandline,
-    })?;
-    ensure!(
-        status.success(),
-        NonZeroExitStatusSnafu {
-            commandline: &commandline,
-            status,
-        }
+fn build_url_options<'a>(
+    package: &'a Package,
+    manifest: &'a ManifestFile,
+    options: &SyncOptions<'_>,
+) -> Result<UrlOptions<'a>, CreateRustdocError> {
+    let config = manifest.value().config();
+    let local_html_root_url = config.rustdoc.html_root_url.as_deref().map_or_else(
+        || format!("https://docs.rs/{}/{}", package.name, package.version).into(),
+        Cow::Borrowed,
     );
+    let expected_toolchain = cargo::toolchain(None).context(DetermineToolchainSnafu)?;
+    let rustdoc_toolchain =
+        cargo::toolchain(Some(options.toolchain)).context(DetermineToolchainSnafu)?;
+    Ok(UrlOptions {
+        local_html_root_url,
+        expected_toolchain,
+        rustdoc_toolchain,
+    })
+}
 
-    ensure!(
-        output_files.len() <= 1,
-        MultipleRustdocJsonFilesSnafu {
-            commandline: &commandline,
-            files: output_files.clone(),
-        }
-    );
-    let Some(output_file) = output_files.pop() else {
-        return Err(NoRustdocJsonFilesSnafu {
-            commandline: &commandline,
-        }
-        .build());
-    };
-
-    Ok(output_file)
+fn build_mapping_config(manifest: &ManifestFile) -> LinkMappingConfig<'_> {
+    let config = manifest.value().config();
+    LinkMappingConfig {
+        mappings: &config.rustdoc.mappings,
+    }
 }
 
 // Same options as rustdoc uses for the main body of the crate-level documentation.
@@ -227,4 +112,16 @@ fn main_body_opts() -> Options {
         // rendered output more closely, including on renderers like GitHub that
         // do not apply those substitutions themselves.
         | Options::ENABLE_SMART_PUNCTUATION
+}
+
+fn render<'a, I>(events: I) -> Result<String, CreateRustdocError>
+where
+    I: Iterator<Item = Event<'a>>,
+{
+    let mut buf = String::new();
+    pulldown_cmark_to_cmark::cmark(events, &mut buf).context(RenderSnafu)?;
+    if !buf.is_empty() && !buf.ends_with('\n') {
+        buf.push('\n');
+    }
+    Ok(buf)
 }

--- a/src/with_source.rs
+++ b/src/with_source.rs
@@ -1,7 +1,7 @@
 use std::{fs, io, rc::Rc, sync::Arc};
 
 use cargo_metadata::camino::Utf8PathBuf;
-use miette::{NamedSource, SourceOffset, SourceSpan};
+use miette::{NamedSource, SourceSpan};
 
 use serde::Deserialize;
 
@@ -26,16 +26,6 @@ pub(crate) enum ReadFileError {
         source_code: NamedSource<Arc<str>>,
         #[label]
         label: Option<SourceSpan>,
-    },
-    #[snafu(display("failed to parse {name}"))]
-    ParseJson {
-        name: String,
-        #[snafu(source(from(serde_json::Error, Box::new)))]
-        source: Box<serde_json::Error>,
-        #[source_code]
-        source_code: NamedSource<Arc<str>>,
-        #[label]
-        label: SourceSpan,
     },
 }
 
@@ -94,41 +84,12 @@ impl<T> WithSource<T> {
         Ok(Self { source_info, value })
     }
 
-    pub(crate) fn from_json(
-        name: impl Into<String>,
-        path: impl Into<Utf8PathBuf>,
-    ) -> Result<Self, ReadFileError>
-    where
-        T: for<'de> Deserialize<'de>,
-    {
-        let source_info = SourceInfo::open(name, path)?;
-
-        let value: T = serde_json::from_str(&source_info.text).with_context(|source| {
-            let offset =
-                SourceOffset::from_location(&source_info.text, source.line(), source.column());
-            let label = SourceSpan::new(offset, 1);
-            let source_code = source_info.to_named_source();
-            ParseJsonSnafu {
-                name: source_info.name.clone(),
-                source_code,
-                label,
-            }
-        })?;
-
-        let source_info = Rc::new(source_info);
-        Ok(Self { source_info, value })
-    }
-
     pub(crate) fn name(&self) -> &str {
         &self.source_info.name
     }
 
     pub(crate) fn value(&self) -> &T {
         &self.value
-    }
-
-    pub(crate) fn into_value(self) -> T {
-        self.value
     }
 
     pub(crate) fn to_named_source(&self) -> NamedSource<Arc<str>> {


### PR DESCRIPTION
## Summary
- extract rustdoc JSON generation, reading, and parsing into `src/sync/contents/rustdoc/build.rs`
- keep `src/sync/contents/rustdoc/mod.rs` focused on transforming a `RustdocDocument` into Markdown
- report rustdoc JSON file paths relative to the workspace root in diagnostics
- remove the now-unused generic JSON loading support from `src/with_source.rs`

## Validation
- `cargo check`
- `cargo test`

## Impact
This is a refactor with a small diagnostic improvement. Rustdoc JSON read/parse failures now point at workspace-relative paths, matching the existing markdown file diagnostics.