### PR TITLE
Extract package text file handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod config;
 mod diff;
 mod parse;
 mod sync;
+mod text_file;
 mod traits;
 mod with_source;
 

--- a/src/sync/contents/rustdoc/build.rs
+++ b/src/sync/contents/rustdoc/build.rs
@@ -1,67 +1,72 @@
 use std::{
+    borrow::Borrow,
     ffi::OsString,
-    fs,
     io::{self, BufReader},
     process::{ExitStatus, Stdio},
     sync::Arc,
 };
 
-use cargo_metadata::{
-    Message, Metadata, Package,
-    camino::{Utf8Path, Utf8PathBuf},
-};
+use cargo_metadata::{Message, Metadata, Package, PackageName, camino::Utf8PathBuf};
 use miette::{Diagnostic, NamedSource, SourceOffset, SourceSpan};
-use rustdoc_types::Crate;
 use snafu::{ResultExt as _, Snafu, ensure};
 use tracing::Level;
 
 use crate::{
     cargo,
     sync::{SyncOptions, contents::rustdoc::document::RustdocDocument},
+    text_file::{PackageTextFileDisplayPath, PackageTextFileLoader},
     traits::CommandExt as _,
 };
 
 #[derive(Debug, Snafu, Diagnostic)]
 pub(in crate::sync) enum BuildRustdocError {
-    #[snafu(display("failed to start rustdoc: {}", commandline.display()))]
+    #[snafu(display("failed to start rustdoc for package `{package}`: {}", commandline.display()))]
     StartRustdocProcess {
+        package: PackageName,
         commandline: OsString,
         #[snafu(source)]
         source: io::Error,
     },
-    #[snafu(display("failed to read rustdoc output: {}", source))]
+    #[snafu(display("failed to read rustdoc output for package `{package}`: {}", source))]
     ReadRustdocOutput {
+        package: PackageName,
         commandline: OsString,
         #[snafu(source)]
         source: io::Error,
     },
-    #[snafu(display("failed to wait for rustdoc completion: {}", commandline.display()))]
+    #[snafu(display("failed to wait for rustdoc completion for package `{package}`: {}", commandline.display()))]
     WaitRustdocProcess {
+        package: PackageName,
         commandline: OsString,
         #[snafu(source)]
         source: io::Error,
     },
-    #[snafu(display("rustdoc exited with status `{status}`: {}", commandline.display()))]
+    #[snafu(display("rustdoc exited with status `{status}` for package `{package}`: {}", commandline.display()))]
     NonZeroExitStatus {
+        package: PackageName,
         commandline: OsString,
         status: ExitStatus,
     },
-    #[snafu(display("rustdoc did not produce any JSON output files: {}", commandline.display()))]
-    NoRustdocJsonFiles { commandline: OsString },
-    #[snafu(display("rustdoc produced multiple JSON output files: {}\nfiles: {files:?}", commandline.display()))]
+    #[snafu(display("rustdoc did not produce any JSON output files for package `{package}`: {}", commandline.display()))]
+    NoRustdocJsonFiles {
+        package: PackageName,
+        commandline: OsString,
+    },
+    #[snafu(display("rustdoc produced multiple JSON output files for package `{package}`: {}\nfiles: {files:?}", commandline.display()))]
     MultipleRustdocJsonFiles {
+        package: PackageName,
         commandline: OsString,
         files: Vec<Utf8PathBuf>,
     },
-    #[snafu(display("failed to read rustdoc JSON output file: {path}"))]
+    #[snafu(display("failed to read rustdoc JSON output file for package `{package}`: {path}", package = json.package, path = json.path))]
     ReadRustdocJson {
-        path: Utf8PathBuf,
+        json: PackageTextFileDisplayPath,
         #[snafu(source)]
         source: io::Error,
     },
-    #[snafu(display("failed to parse rustdoc JSON output file: {path}"))]
+    #[snafu(display("failed to parse rustdoc JSON output file for package `{package}`: {path}", package = json.package, path = json.path))]
     ParseRustdocJson {
-        path: Utf8PathBuf,
+        json: PackageTextFileDisplayPath,
         #[snafu(source)]
         source: serde_json::Error,
         #[source_code]
@@ -71,14 +76,32 @@ pub(in crate::sync) enum BuildRustdocError {
     },
 }
 
+impl Borrow<dyn Diagnostic> for Box<BuildRustdocError> {
+    fn borrow(&self) -> &(dyn Diagnostic + 'static) {
+        self.as_ref()
+    }
+}
+
 pub(super) fn build_rustdoc(
     workspace: &Metadata,
     package: &Package,
     options: &SyncOptions<'_>,
-) -> Result<RustdocDocument, BuildRustdocError> {
+) -> Result<RustdocDocument, Box<BuildRustdocError>> {
     let json_path = run_rustdoc(package, options)?;
-    let json_file = JsonFile::new(workspace, &json_path)?;
-    let doc = json_file.parse()?;
+    let json_file_loader = PackageTextFileLoader::from_path(workspace, package, &json_path);
+    let json_file = json_file_loader.load().context(ReadRustdocJsonSnafu {
+        json: &json_file_loader,
+    })?;
+    let doc = json_file.parse_as_json().with_context(|source| {
+        let source_code = json_file.to_named_source();
+        let offset = SourceOffset::from_location(json_file.text(), source.line(), source.column());
+        let label = SourceSpan::new(offset, 1);
+        ParseRustdocJsonSnafu {
+            json: &json_file_loader,
+            source_code,
+            label,
+        }
+    })?;
     let doc = RustdocDocument::new(doc);
     Ok(doc)
 }
@@ -86,7 +109,7 @@ pub(super) fn build_rustdoc(
 fn run_rustdoc(
     package: &Package,
     options: &SyncOptions<'_>,
-) -> Result<Utf8PathBuf, BuildRustdocError> {
+) -> Result<Utf8PathBuf, Box<BuildRustdocError>> {
     let mut command = cargo::command_for_build_doc(options.toolchain);
     match options.verbosity {
         Some(Level::TRACE) => _ = command.arg("-v"),
@@ -121,13 +144,15 @@ fn run_rustdoc(
     let mut child = command
         .spawn()
         .with_context(|_source| StartRustdocProcessSnafu {
+            package: package.name.clone(),
             commandline: &commandline,
         })?;
 
     let stdout = BufReader::new(child.stdout.take().unwrap());
     let mut json_filenames = vec![];
     for message in Message::parse_stream(stdout) {
-        let message = message.context(ReadRustdocOutputSnafu {
+        let message = message.with_context(|_source| ReadRustdocOutputSnafu {
+            package: package.name.clone(),
             commandline: &commandline,
         })?;
         if let Message::CompilerArtifact(artifact) = message
@@ -141,12 +166,16 @@ fn run_rustdoc(
             );
         }
     }
-    let status = child.wait().context(WaitRustdocProcessSnafu {
-        commandline: &commandline,
-    })?;
+    let status = child
+        .wait()
+        .with_context(|_source| WaitRustdocProcessSnafu {
+            package: package.name.clone(),
+            commandline: &commandline,
+        })?;
     ensure!(
         status.success(),
         NonZeroExitStatusSnafu {
+            package: package.name.clone(),
             commandline: &commandline,
             status,
         }
@@ -155,59 +184,19 @@ fn run_rustdoc(
     ensure!(
         json_filenames.len() <= 1,
         MultipleRustdocJsonFilesSnafu {
+            package: package.name.clone(),
             commandline: &commandline,
             files: json_filenames.clone(),
         }
     );
     let Some(output_file) = json_filenames.pop() else {
         return Err(NoRustdocJsonFilesSnafu {
+            package: package.name.clone(),
             commandline: &commandline,
         }
-        .build());
+        .build()
+        .into());
     };
 
     Ok(output_file)
-}
-
-#[derive(Debug)]
-struct JsonFile {
-    relative_path: Utf8PathBuf,
-    text: Arc<str>,
-}
-
-impl JsonFile {
-    fn new(workspace: &Metadata, path: &Utf8Path) -> Result<Self, BuildRustdocError> {
-        let relative_path = path
-            .strip_prefix(&workspace.workspace_root)
-            .unwrap_or(path)
-            .to_owned();
-        let text = fs::read_to_string(path)
-            .with_context(|_source| ReadRustdocJsonSnafu {
-                path: &relative_path,
-            })?
-            .into();
-        Ok(Self {
-            relative_path,
-            text,
-        })
-    }
-
-    fn parse(&self) -> Result<Crate, BuildRustdocError> {
-        let doc = serde_json::from_str(&self.text).with_context(|source| {
-            let path = &self.relative_path;
-            let source_code = self.to_named_source();
-            let offset = SourceOffset::from_location(&self.text, source.line(), source.column());
-            let label = SourceSpan::new(offset, 1);
-            ParseRustdocJsonSnafu {
-                path,
-                source_code,
-                label,
-            }
-        })?;
-        Ok(doc)
-    }
-
-    fn to_named_source(&self) -> NamedSource<Arc<str>> {
-        NamedSource::new(&self.relative_path, Arc::clone(&self.text))
-    }
 }

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -25,7 +25,7 @@ pub(in crate::sync) enum CreateRustdocError {
     BuildRustdoc {
         #[snafu(source)]
         #[diagnostic_source]
-        source: build::BuildRustdocError,
+        source: Box<build::BuildRustdocError>,
     },
     #[snafu(display("package {package_name} does not have a root item"))]
     RootNotFound { package_name: PackageName },

--- a/src/sync/marker/mod.rs
+++ b/src/sync/marker/mod.rs
@@ -7,10 +7,11 @@ use crate::{
     config::metadata::BadgeItem,
     parse::Spanned,
     sync::{
-        ManifestFile, MarkdownFile, MarkdownPath,
+        ManifestFile,
         contents::Contents,
         marker::resolve::{ResolveMarkerError, Resolver},
     },
+    text_file::{PackageTextFile, PackageTextFileDisplayPath},
 };
 
 mod parse;
@@ -25,7 +26,7 @@ const MAGIC: &str = "cargo-sync-rdme";
     package = markdown.package, markdown = markdown.path,
 ))]
 pub(crate) struct ParseMarkersError {
-    markdown: MarkdownPath,
+    markdown: PackageTextFileDisplayPath,
     #[source_code]
     source_code: NamedSource<Arc<str>>,
     #[related]
@@ -59,10 +60,10 @@ impl fmt::Display for ResolvedReplaceSpecifier {
 }
 
 pub(super) fn parse_markers(
-    markdown: &MarkdownFile<'_>,
+    markdown: &PackageTextFile<'_>,
     manifest: &ManifestFile,
 ) -> Result<Vec<Spanned<ResolvedReplaceSpecifier>>, Box<ParseMarkersError>> {
-    let mut resolver = Resolver::new(&markdown.text, manifest);
+    let mut resolver = Resolver::new(markdown.text(), manifest);
     let mut specifiers = vec![];
     let mut errors = vec![];
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,18 +1,9 @@
-use std::{
-    fs,
-    io::{self, Write as _},
-    sync::Arc,
-};
+use std::io;
 
-use cargo_metadata::{
-    Metadata, Package, PackageName,
-    camino::{Utf8Path, Utf8PathBuf},
-};
+use cargo_metadata::{Metadata, Package, PackageName, camino::Utf8Path};
 
-use miette::NamedSource;
 use snafu::{ResultExt as _, Snafu, ensure};
 use supports_color::Stream;
-use tempfile::NamedTempFile;
 use tracing::Level;
 use vcs_modify_guard::{AllowOptions, ModificationSafety, UnsafeModificationReason};
 
@@ -20,7 +11,7 @@ use crate::{
     args::{FeatureSelection, FixArgs, Mode, RustdocToolchainArgs},
     config::Manifest,
     diff,
-    traits::PackageExt as _,
+    text_file::{PackageTextFile, PackageTextFileDisplayPath, PackageTextFileLoader},
     with_source::{self, WithSource},
 };
 
@@ -39,13 +30,13 @@ pub(crate) enum SyncError {
     },
     #[snafu(display("failed to read markdown file for package `{package}`: {markdown}", package = markdown.package, markdown = markdown.path))]
     ReadMarkdownFile {
-        markdown: MarkdownPath,
+        markdown: PackageTextFileDisplayPath,
         #[snafu(source)]
         source: io::Error,
     },
     #[snafu(display("failed to write markdown file for package `{package}`: {markdown}", package = markdown.package, markdown = markdown.path))]
     WriteMarkdownFile {
-        markdown: MarkdownPath,
+        markdown: PackageTextFileDisplayPath,
         #[snafu(source)]
         source: io::Error,
     },
@@ -73,32 +64,40 @@ pub(crate) enum SyncError {
         source: io::Error,
     },
     #[snafu(display("markdown file for package `{package}` is not up to date: {markdown}", package = markdown.package, markdown = markdown.path))]
-    CheckFailed { markdown: MarkdownPath },
+    CheckFailed {
+        markdown: PackageTextFileDisplayPath,
+    },
     #[snafu(display(
         "failed to check whether the markdown file can be modified for package `{package}`: {markdown}", package = markdown.package, markdown = markdown.path
     ))]
     CheckFileModificationSafety {
-        markdown: MarkdownPath,
+        markdown: PackageTextFileDisplayPath,
         #[snafu(source)]
         source: vcs_modify_guard::ModifyGuardError,
     },
     #[snafu(display(
         "markdown file for package `{package}` is not under version control: {markdown}\nUse --allow-no-vcs to override this check.", package = markdown.package, markdown = markdown.path
     ))]
-    NoVcs { markdown: MarkdownPath },
+    NoVcs {
+        markdown: PackageTextFileDisplayPath,
+    },
     #[snafu(display(
         "markdown file for package `{package}` has uncommitted changes: {markdown}\nUse --allow-dirty to override this check.", package = markdown.package, markdown = markdown.path
     ))]
-    DirtyFile { markdown: MarkdownPath },
+    DirtyFile {
+        markdown: PackageTextFileDisplayPath,
+    },
     #[snafu(display(
         "markdown file for package `{package}` has staged changes: {markdown}\nUse --allow-staged to override this check.", package = markdown.package, markdown = markdown.path
     ))]
-    StagedFile { markdown: MarkdownPath },
+    StagedFile {
+        markdown: PackageTextFileDisplayPath,
+    },
     #[snafu(display(
         "markdown file for package `{package}` is not safe to modify for some reason: {markdown}\nreason: {reason:?}", package = markdown.package, markdown = markdown.path
     ))]
     UnsafeToModifyForSomeReason {
-        markdown: MarkdownPath,
+        markdown: PackageTextFileDisplayPath,
         reason: UnsafeModificationReason,
     },
 }
@@ -151,7 +150,11 @@ pub(crate) fn sync_all(
     for path in paths {
         tracing::info!("syncing markdown file: {path}");
 
-        let mut markdown = MarkdownFile::new(workspace, package, path)?;
+        let markdown_loader =
+            PackageTextFileLoader::from_package_relative_path(workspace, package, path);
+        let mut markdown = markdown_loader.load().context(ReadMarkdownFileSnafu {
+            markdown: &markdown_loader,
+        })?;
 
         let all_markers = marker::parse_markers(&markdown, &manifest)?;
 
@@ -159,9 +162,9 @@ pub(crate) fn sync_all(
         let all_contents =
             contents::create_all(all_markers, &manifest, workspace, package, options)?;
 
-        let new_text = replace::replace_all(&markdown.text, &all_contents);
+        let new_text = replace::replace_all(markdown.text(), &all_contents);
 
-        let changed = new_text.as_str() != &*markdown.text;
+        let changed = new_text.as_str() != markdown.text();
         if !changed {
             tracing::info!("markdown file is already up to date: {path}");
             continue;
@@ -170,7 +173,7 @@ pub(crate) fn sync_all(
         match options.mode {
             Mode::Check => {
                 tracing::warn!("markdown file is not up to date: {path}");
-                diff::write_pretty_diff(options.diff_stream, &markdown.text, &new_text)
+                diff::write_pretty_diff(options.diff_stream, markdown.text(), &new_text)
                     .context(WriteDiffSnafu)?;
                 return Err(CheckFailedSnafu {
                     markdown: &markdown,
@@ -183,88 +186,16 @@ pub(crate) fn sync_all(
 
         // Update README if allowed
         check_update_allowed(&markdown, options.fix)?;
-        markdown.replace(new_text.into())?;
+        markdown
+            .replace_file_content(new_text.into())
+            .context(WriteMarkdownFileSnafu {
+                markdown: &markdown,
+            })?;
 
         tracing::info!("updated markdown file: {path}");
     }
 
     Ok(())
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct MarkdownPath {
-    package: PackageName,
-    path: Utf8PathBuf,
-}
-
-impl MarkdownPath {
-    fn new(package: &Package, path: Utf8PathBuf) -> Self {
-        Self {
-            package: package.name.clone(),
-            path,
-        }
-    }
-}
-
-impl From<&MarkdownFile<'_>> for MarkdownPath {
-    fn from(markdown: &MarkdownFile<'_>) -> Self {
-        Self {
-            package: markdown.package.name.clone(),
-            path: markdown.relative_path.clone(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct MarkdownFile<'a> {
-    package: &'a Package,
-    relative_path: Utf8PathBuf,
-    path: Utf8PathBuf,
-    text: Arc<str>,
-}
-
-impl<'a> MarkdownFile<'a> {
-    fn new(
-        workspace: &'a Metadata,
-        package: &'a Package,
-        package_relative_path: &'a Utf8Path,
-    ) -> Result<Self, Box<SyncError>> {
-        let relative_path = package
-            .workspace_relative_root_directory(workspace)
-            .join(package_relative_path);
-        let path = workspace.workspace_root.join(&relative_path);
-        let text = fs::read_to_string(&path)
-            .with_context(|_source| ReadMarkdownFileSnafu {
-                markdown: MarkdownPath::new(package, relative_path.clone()),
-            })?
-            .into();
-        Ok(Self {
-            package,
-            relative_path,
-            path,
-            text,
-        })
-    }
-
-    fn to_named_source(&self) -> NamedSource<Arc<str>> {
-        NamedSource::new(&self.relative_path, Arc::clone(&self.text))
-    }
-
-    fn replace(&mut self, new_text: Arc<str>) -> Result<(), Box<SyncError>> {
-        (|| {
-            let output_dir = self.path.parent().unwrap();
-            let mut tempfile = NamedTempFile::new_in(output_dir)?;
-            tempfile.as_file_mut().write_all(new_text.as_bytes())?;
-            tempfile.as_file_mut().sync_data()?;
-            let file = tempfile.persist(&self.path).map_err(|err| err.error)?;
-            file.sync_all()?;
-            drop(file);
-            Ok(())
-        })()
-        .context(WriteMarkdownFileSnafu { markdown: &*self })?;
-        self.text = new_text;
-        Ok(())
-    }
 }
 
 type ManifestFile = WithSource<Manifest>;
@@ -280,7 +211,7 @@ where
 }
 
 fn check_update_allowed(
-    markdown: &MarkdownFile<'_>,
+    markdown: &PackageTextFile<'_>,
     options: &FixArgs,
 ) -> Result<(), Box<SyncError>> {
     let FixArgs {
@@ -293,7 +224,7 @@ fn check_update_allowed(
         .allow_no_vcs(*allow_no_vcs)
         .allow_dirty(*allow_dirty)
         .allow_staged(*allow_staged)
-        .check_safe_to_modify(&markdown.path)
+        .check_safe_to_modify(markdown.path())
         .context(CheckFileModificationSafetySnafu { markdown })?;
 
     match safety {

--- a/src/text_file.rs
+++ b/src/text_file.rs
@@ -1,0 +1,132 @@
+use std::{
+    borrow::Cow,
+    fs,
+    io::{self, Write as _},
+    sync::Arc,
+};
+
+use cargo_metadata::{
+    Metadata, Package, PackageName,
+    camino::{Utf8Path, Utf8PathBuf},
+};
+use miette::NamedSource;
+use serde::de::Deserialize;
+use tempfile::NamedTempFile;
+
+use crate::traits::PackageExt as _;
+
+#[derive(Debug, Clone)]
+pub(crate) struct PackageTextFileDisplayPath {
+    pub(crate) package: PackageName,
+    pub(crate) path: Utf8PathBuf,
+}
+
+impl From<&PackageTextFileLoader<'_>> for PackageTextFileDisplayPath {
+    fn from(loader: &PackageTextFileLoader<'_>) -> Self {
+        Self {
+            package: loader.package.name.clone(),
+            path: loader.workspace_relative_path.clone().into_owned(),
+        }
+    }
+}
+
+impl From<&PackageTextFile<'_>> for PackageTextFileDisplayPath {
+    fn from(file: &PackageTextFile<'_>) -> Self {
+        file.loader.into()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PackageTextFileLoader<'a> {
+    package: &'a Package,
+    workspace_relative_path: Cow<'a, Utf8Path>,
+    path: Cow<'a, Utf8Path>,
+}
+
+impl<'a> PackageTextFileLoader<'a> {
+    pub(crate) fn from_package_relative_path(
+        workspace: &'a Metadata,
+        package: &'a Package,
+        package_relative_path: &'a Utf8Path,
+    ) -> Self {
+        let workspace_relative_path = package
+            .workspace_relative_root_directory(workspace)
+            .join(package_relative_path)
+            .into();
+        let path = workspace
+            .workspace_root
+            .join(&workspace_relative_path)
+            .into();
+        Self {
+            package,
+            workspace_relative_path,
+            path,
+        }
+    }
+
+    pub(crate) fn from_path(
+        workspace: &'a Metadata,
+        package: &'a Package,
+        path: &'a Utf8Path,
+    ) -> Self {
+        let workspace_relative_path = path
+            .strip_prefix(&workspace.workspace_root)
+            .unwrap_or(path)
+            .into();
+        let path = path.into();
+        Self {
+            package,
+            workspace_relative_path,
+            path,
+        }
+    }
+
+    pub(crate) fn load(&self) -> io::Result<PackageTextFile<'_>> {
+        let text = fs::read_to_string(self.path.as_ref())?.into();
+        Ok(PackageTextFile { loader: self, text })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PackageTextFile<'a> {
+    loader: &'a PackageTextFileLoader<'a>,
+    text: Arc<str>,
+}
+
+impl PackageTextFile<'_> {
+    pub(crate) fn path(&self) -> &Utf8Path {
+        self.loader.path.as_ref()
+    }
+
+    pub(crate) fn text(&self) -> &str {
+        self.text.as_ref()
+    }
+
+    pub(crate) fn to_named_source(&self) -> NamedSource<Arc<str>> {
+        NamedSource::new(
+            self.loader.workspace_relative_path.as_ref(),
+            Arc::clone(&self.text),
+        )
+    }
+
+    pub(crate) fn replace_file_content(&mut self, new_text: Arc<str>) -> io::Result<()> {
+        let output_dir = self.loader.path.parent().unwrap();
+        let mut tempfile = NamedTempFile::new_in(output_dir)?;
+        tempfile.as_file_mut().write_all(new_text.as_bytes())?;
+        tempfile.as_file_mut().sync_data()?;
+        let file = tempfile
+            .persist(self.loader.path.as_ref())
+            .map_err(|err| err.error)?;
+        file.sync_all()?;
+        drop(file);
+        self.text = new_text;
+        Ok(())
+    }
+
+    pub(crate) fn parse_as_json<'a, T>(&'a self) -> Result<T, serde_json::Error>
+    where
+        T: Deserialize<'a>,
+    {
+        serde_json::from_str(self.text())
+    }
+}


### PR DESCRIPTION
## Summary
- extract shared package text file loading and writing logic into `src/text_file.rs`
- reuse the new abstraction for markdown syncing and rustdoc JSON loading
- unify display paths and package-aware diagnostics for markdown and rustdoc JSON files

## Validation
- `cargo check`
- `cargo test`

## Impact
This is a refactor of internal file handling. It keeps the existing behavior while making the shared path/text handling reusable for additional package-related text files.