### PR TITLE
Increase rustdoc command verbosity

### DIFF
--- a/src/sync/contents/rustdoc/build.rs
+++ b/src/sync/contents/rustdoc/build.rs
@@ -112,8 +112,9 @@ fn run_rustdoc(
 ) -> Result<Utf8PathBuf, Box<BuildRustdocError>> {
     let mut command = cargo::command_for_build_doc(options.toolchain);
     match options.verbosity {
-        Some(Level::TRACE) => _ = command.arg("-v"),
-        Some(Level::DEBUG) => {}
+        Some(Level::TRACE) => _ = command.arg("-vv"),
+        Some(Level::DEBUG) => _ = command.arg("-v"),
+        Some(Level::INFO) => {}
         _ => _ = command.arg("-q"),
     }
     command


### PR DESCRIPTION
## Summary
- make `TRACE` pass `-vv` to `cargo rustdoc`
- make `DEBUG` pass `-v` to `cargo rustdoc`
- leave `INFO` at Cargo's default verbosity, while lower levels still use `-q`

## Motivation
The rustdoc invocation was one step quieter than the application's own tracing level. This aligns rustdoc's verbosity with the requested CLI verbosity while still keeping lower-verbosity runs quiet.

## Validation
- `cargo test --test crate_type`
- manually ran `cargo-sync-rdme` against temporary fixture copies with `-v` and `-vv` to confirm the spawned rustdoc command used `cargo rustdoc -v` and `cargo rustdoc -vv`
