### PR TITLE
Test config accessor error spans

### DIFF
--- a/src/config/manifest/badges.rs
+++ b/src/config/manifest/badges.rs
@@ -34,13 +34,11 @@ impl<'a> WithSource<&'a Spanned<Badges>> {
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct Maintenance {
     #[serde(default)]
-    pub(crate) status: Option<Spanned<MaintenanceStatus>>,
+    pub(crate) status: Option<MaintenanceStatus>,
 }
 
-impl<'a> WithSource<&'a Spanned<Maintenance>> {
-    pub(crate) fn try_status(
-        &self,
-    ) -> Result<WithSource<&'a Spanned<MaintenanceStatus>>, GetConfigError> {
+impl WithSource<&Spanned<Maintenance>> {
+    pub(crate) fn try_status(&self) -> Result<MaintenanceStatus, GetConfigError> {
         let status = self
             .value()
             .get_ref()
@@ -52,7 +50,7 @@ impl<'a> WithSource<&'a Spanned<Maintenance>> {
                 span: self.span(),
                 source_code: self.to_named_source(),
             })?;
-        Ok(self.map(|_| status))
+        Ok(*status)
     }
 }
 
@@ -80,5 +78,59 @@ impl MaintenanceStatus {
             Self::Deprecated => "deprecated",
             Self::None => "done",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::manifest::Manifest;
+
+    use super::*;
+
+    #[test]
+    fn try_maintenance_returns_error_when_not_set() {
+        let source = indoc::indoc! {r#"
+            [package]
+            name = "test"
+            version = "0.1.0"
+
+            [badges]
+        "#};
+        let manifest =
+            WithSource::<Manifest>::dummy_with_source(source, toml::from_str(source).unwrap());
+        let GetConfigError::KeyNotSet { source: err } = manifest
+            .try_badges()
+            .unwrap()
+            .try_maintenance()
+            .unwrap_err();
+        assert_eq!(err.name, "dummy-name");
+        assert_eq!(err.key, "badges.maintenance");
+        assert_eq!(&source[err.span.offset()..][..err.span.len()], "[badges]");
+        assert_eq!(err.source_code.name(), "dummy-path");
+    }
+
+    #[test]
+    fn try_status_returns_error_when_not_set() {
+        let source = indoc::indoc! {r#"
+            [package]
+            name = "test"
+            version = "0.1.0"
+
+            [badges]
+            maintenance = {}
+        "#};
+        let manifest =
+            WithSource::<Manifest>::dummy_with_source(source, toml::from_str(source).unwrap());
+        let GetConfigError::KeyNotSet { source: err } = manifest
+            .try_badges()
+            .unwrap()
+            .try_maintenance()
+            .unwrap()
+            .try_status()
+            .unwrap_err();
+        assert_eq!(err.name, "dummy-name");
+        assert_eq!(err.key, "badges.maintenance.status");
+        assert_eq!(&source[err.span.offset()..][..err.span.len()], "{}");
+        assert_eq!(err.source_code.name(), "dummy-path");
     }
 }

--- a/src/config/manifest/mod.rs
+++ b/src/config/manifest/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod package;
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct Manifest {
     #[serde(default)]
-    pub(crate) package: Option<Spanned<package::Package>>,
+    pub(crate) package: Option<package::Package>,
     #[serde(default)]
     pub(crate) badges: Option<Spanned<badges::Badges>>,
 }
@@ -38,18 +38,27 @@ impl Manifest {
     pub(crate) fn config(&self) -> &package::metadata::CargoSyncRdme {
         static DEFAULT: LazyLock<package::metadata::CargoSyncRdme> =
             LazyLock::new(Default::default);
-        (|| {
-            Some(
-                &self
-                    .package
-                    .as_ref()?
-                    .get_ref()
-                    .metadata
-                    .as_ref()?
-                    .get_ref()
-                    .cargo_sync_rdme,
-            )
-        })()
-        .unwrap_or(&DEFAULT)
+        (|| Some(&self.package.as_ref()?.metadata.as_ref()?.cargo_sync_rdme))().unwrap_or(&DEFAULT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_badges_returns_error_when_not_set() {
+        let source = indoc::indoc! {r#"
+            [package]
+            name = "test"
+            version = "0.1.0"
+        "#};
+        let manifest =
+            WithSource::<Manifest>::dummy_with_source(source, toml::from_str(source).unwrap());
+        let GetConfigError::KeyNotSet { source: err } = manifest.try_badges().unwrap_err();
+        assert_eq!(err.name, "dummy-name");
+        assert_eq!(err.key, "badges");
+        assert_eq!(err.span, (0..0).into());
+        assert_eq!(err.source_code.name(), "dummy-path");
     }
 }

--- a/src/config/manifest/package/mod.rs
+++ b/src/config/manifest/package/mod.rs
@@ -1,5 +1,4 @@
 use serde::Deserialize;
-use toml::Spanned;
 
 pub(crate) mod metadata;
 
@@ -7,5 +6,5 @@ pub(crate) mod metadata;
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct Package {
     #[serde(default)]
-    pub(crate) metadata: Option<Spanned<metadata::Metadata>>,
+    pub(crate) metadata: Option<metadata::Metadata>,
 }

--- a/src/config/testing.rs
+++ b/src/config/testing.rs
@@ -33,10 +33,8 @@ pub(crate) fn parse_badge(source: &str) -> Badge {
     manifest
         .package
         .unwrap()
-        .into_inner()
         .metadata
         .unwrap()
-        .into_inner()
         .cargo_sync_rdme
         .badge
 }
@@ -47,10 +45,8 @@ pub(crate) fn parse_rustdoc(source: &str) -> Rustdoc {
     manifest
         .package
         .unwrap()
-        .into_inner()
         .metadata
         .unwrap()
-        .into_inner()
         .cargo_sync_rdme
         .rustdoc
 }

--- a/src/sync/contents/badge.rs
+++ b/src/sync/contents/badge.rs
@@ -295,9 +295,8 @@ impl fmt::Display for BadgeLink {
 
 impl BadgeLink {
     fn maintenance(manifest: &ManifestFile) -> CreateResult<Option<Self>> {
-        let status_with_source = (|| manifest.try_badges()?.try_maintenance()?.try_status())()
+        let status = (|| manifest.try_badges()?.try_maintenance()?.try_status())()
             .map_err(|err| CreateBadgeError::from(err.with_key("badges.maintenance.status")))?;
-        let status = *status_with_source.value().get_ref();
 
         let image = match ShieldsIo::new_maintenance(status) {
             Some(shields_io) => shields_io.build(manifest).to_string(),

--- a/src/with_source.rs
+++ b/src/with_source.rs
@@ -107,9 +107,24 @@ impl<T> WithSource<T> {
     pub(crate) fn dummy(value: T) -> Self {
         Self {
             source_info: Rc::new(SourceInfo {
-                name: "dummy".to_string(),
-                path: Utf8PathBuf::from("dummy"),
-                text: "dummy".into(),
+                name: "dummy-name".to_string(),
+                path: Utf8PathBuf::from("dummy-path"),
+                text: "dummy-text".into(),
+            }),
+            value,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn dummy_with_source<S>(text: S, value: T) -> Self
+    where
+        S: Into<Arc<str>>,
+    {
+        Self {
+            source_info: Rc::new(SourceInfo {
+                name: "dummy-name".to_string(),
+                path: Utf8PathBuf::from("dummy-path"),
+                text: text.into(),
             }),
             value,
         }


### PR DESCRIPTION
## Summary
- add tests that lock in the current `KeyNotSet` span and source behavior for config accessors
- remove unused `WithSource` / `toml::Spanned` wrapping from package metadata and maintenance status values
- simplify the badge maintenance accessor to return the final status value directly

## Motivation
This preserves the current config-accessor diagnostics before replacing `WithSource`, while trimming wrapping that is not currently used by callers.

## Validation
- `cargo test`
- project diagnostics

## Impact
No intended behavior change. The new tests document the current error spans, and the config accessors keep source information only where it is currently needed.

## Follow-up
If value-level span information becomes necessary later, it can be added back on top of this narrower API surface.