### PR TITLE
Store config key spans in manifest structs

### DIFF
--- a/src/config/manifest/badges.rs
+++ b/src/config/manifest/badges.rs
@@ -1,43 +1,139 @@
-use serde::Deserialize;
+use std::fmt;
 
-use super::{GetConfigError, KeyNotSet};
-use crate::source::SourceFileSpanned;
+use serde::{
+    Deserialize,
+    de::{self, DeserializeSeed},
+};
 
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+use super::GetConfigError;
+use crate::{config::TomlTable, source::Spanned};
+
+#[derive(Debug, Clone, Default)]
 pub(crate) struct Badges {
-    #[serde(default)]
-    pub(crate) maintenance: Option<SourceFileSpanned<Maintenance>>,
+    pub(crate) toml_table: TomlTable,
+    pub(crate) maintenance: Option<Maintenance>,
 }
 
-impl SourceFileSpanned<&Badges> {
-    pub(crate) fn try_maintenance(
-        &self,
-    ) -> Result<SourceFileSpanned<&Maintenance>, GetConfigError> {
-        let maintenance = self.value.maintenance.as_ref().ok_or_else(|| KeyNotSet {
-            key: "badges.maintenance".to_owned(),
-            span: self.source_span(),
-            source_code: self.source.to_named_source(),
-        })?;
-        Ok(maintenance.as_ref())
+const KEY_MAINTENANCE: &str = "maintenance";
+
+impl Badges {
+    pub(crate) fn try_maintenance(&self) -> Result<&Maintenance, Box<GetConfigError>> {
+        let maintenance = self
+            .maintenance
+            .as_ref()
+            .ok_or_else(|| self.toml_table.missing_key_error(KEY_MAINTENANCE))?;
+        Ok(maintenance)
     }
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Debug, Clone)]
+pub(super) struct BadgesSeed(pub(super) TomlTable);
+
+impl<'de> DeserializeSeed<'de> for BadgesSeed {
+    type Value = Badges;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct BadgesVisitor(TomlTable);
+
+        impl<'de> de::Visitor<'de> for BadgesVisitor {
+            type Value = Badges;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("table")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let toml_table = self.0;
+                let mut maintenance = None;
+
+                while let Some(key) = map.next_key::<Spanned<String>>()? {
+                    match key.value.as_str() {
+                        KEY_MAINTENANCE => {
+                            maintenance = Some(map.next_value_seed(MaintenanceSeed(
+                                toml_table.child(key.as_deref()),
+                            ))?);
+                        }
+                        _ => {
+                            let _ = map.next_value::<de::IgnoredAny>()?;
+                        }
+                    }
+                }
+
+                Ok(Badges {
+                    toml_table,
+                    maintenance,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(BadgesVisitor(self.0))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
 pub(crate) struct Maintenance {
-    #[serde(default)]
+    pub(crate) toml_table: TomlTable,
     pub(crate) status: Option<MaintenanceStatus>,
 }
 
-impl SourceFileSpanned<&Maintenance> {
-    pub(crate) fn try_status(&self) -> Result<MaintenanceStatus, GetConfigError> {
-        let status = self.value.status.as_ref().ok_or_else(|| KeyNotSet {
-            key: "badges.maintenance.status".to_owned(),
-            span: self.source_span(),
-            source_code: self.source.to_named_source(),
-        })?;
+const KEY_STATUS: &str = "status";
+
+impl Maintenance {
+    pub(crate) fn try_status(&self) -> Result<MaintenanceStatus, Box<GetConfigError>> {
+        let status = self
+            .status
+            .as_ref()
+            .ok_or_else(|| self.toml_table.missing_key_error(KEY_STATUS))?;
         Ok(*status)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct MaintenanceSeed(pub(super) TomlTable);
+
+impl<'de> DeserializeSeed<'de> for MaintenanceSeed {
+    type Value = Maintenance;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct MaintenanceVisitor(TomlTable);
+
+        impl<'de> de::Visitor<'de> for MaintenanceVisitor {
+            type Value = Maintenance;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("table")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let toml_table = self.0;
+                let mut status = None;
+
+                while let Some(key) = map.next_key::<Spanned<String>>()? {
+                    match key.value.as_str() {
+                        KEY_STATUS => status = Some(map.next_value()?),
+                        _ => {
+                            map.next_value::<de::IgnoredAny>()?;
+                        }
+                    }
+                }
+
+                Ok(Maintenance { toml_table, status })
+            }
+        }
+
+        deserializer.deserialize_map(MaintenanceVisitor(self.0))
     }
 }
 
@@ -72,8 +168,6 @@ impl MaintenanceStatus {
 mod tests {
     use crate::config::testing;
 
-    use super::*;
-
     #[test]
     fn try_maintenance_returns_error_when_not_set() {
         let source = indoc::indoc! {r#"
@@ -84,14 +178,16 @@ mod tests {
             [badges]
         "#};
         let manifest = testing::parse_manifest(source);
-        let GetConfigError::KeyNotSet { source: err } = manifest
+        let (key, table, span, source_code) = manifest
             .try_badges()
             .unwrap()
             .try_maintenance()
-            .unwrap_err();
-        assert_eq!(err.key, "badges.maintenance");
-        assert_eq!(&source[err.span.offset()..][..err.span.len()], "[badges]");
-        assert_eq!(err.source_code.name(), "Cargo.toml");
+            .unwrap_err()
+            .into_missing_key_in_table();
+        assert_eq!(key, "maintenance");
+        assert_eq!(table, "badges");
+        assert_eq!(&source[span.offset()..][..span.len()], "badges");
+        assert_eq!(source_code.name(), "Cargo.toml");
     }
 
     #[test]
@@ -105,15 +201,17 @@ mod tests {
             maintenance = {}
         "#};
         let manifest = testing::parse_manifest(source);
-        let GetConfigError::KeyNotSet { source: err } = manifest
+        let (key, table, span, source_code) = manifest
             .try_badges()
             .unwrap()
             .try_maintenance()
             .unwrap()
             .try_status()
-            .unwrap_err();
-        assert_eq!(err.key, "badges.maintenance.status");
-        assert_eq!(&source[err.span.offset()..][..err.span.len()], "{}");
-        assert_eq!(err.source_code.name(), "Cargo.toml");
+            .unwrap_err()
+            .into_missing_key_in_table();
+        assert_eq!(key, "status");
+        assert_eq!(table, "badges.maintenance");
+        assert_eq!(&source[span.offset()..][..span.len()], "maintenance");
+        assert_eq!(source_code.name(), "Cargo.toml");
     }
 }

--- a/src/config/manifest/mod.rs
+++ b/src/config/manifest/mod.rs
@@ -1,40 +1,88 @@
-use std::sync::LazyLock;
+use std::{fmt, sync::LazyLock};
 
-use serde::Deserialize;
+use serde::{Deserialize, de};
 
 use crate::{
-    config::{GetConfigError, KeyNotSet},
-    source::SourceFileSpanned,
+    config::{GetConfigError, TomlTable, manifest::badges::BadgesSeed},
+    source::{self, Spanned},
 };
 
 pub(crate) mod badges;
 pub(crate) mod package;
 
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct Manifest {
-    #[serde(default)]
+    pub(crate) toml_table: TomlTable,
     pub(crate) package: Option<package::Package>,
-    #[serde(default)]
-    pub(crate) badges: Option<SourceFileSpanned<badges::Badges>>,
+    pub(crate) badges: Option<badges::Badges>,
 }
 
-impl SourceFileSpanned<Manifest> {
-    pub(crate) fn try_badges(&self) -> Result<SourceFileSpanned<&badges::Badges>, GetConfigError> {
-        let badges = self.value.badges.as_ref().ok_or_else(|| KeyNotSet {
-            key: "badges".to_owned(),
-            span: self.source_span(),
-            source_code: self.source.to_named_source(),
-        })?;
-        Ok(badges.as_ref())
-    }
-}
+const KEY_PACKAGE: &str = "package";
+const KEY_BADGES: &str = "badges";
 
 impl Manifest {
+    pub(crate) fn try_badges(&self) -> Result<&badges::Badges, Box<GetConfigError>> {
+        let badges = self
+            .badges
+            .as_ref()
+            .ok_or_else(|| self.toml_table.missing_key_error(KEY_BADGES))?;
+        Ok(badges)
+    }
+
     pub(crate) fn config(&self) -> &package::metadata::CargoSyncRdme {
         static DEFAULT: LazyLock<package::metadata::CargoSyncRdme> =
             LazyLock::new(Default::default);
         (|| Some(&self.package.as_ref()?.metadata.as_ref()?.cargo_sync_rdme))().unwrap_or(&DEFAULT)
+    }
+}
+
+impl<'de> Deserialize<'de> for Manifest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ManifestVisitor;
+
+        impl<'de> de::Visitor<'de> for ManifestVisitor {
+            type Value = Manifest;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("table")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let toml_table = TomlTable::root(source::current_source_file()?);
+
+                let mut package = None;
+                let mut badges = None;
+                while let Some(key) = map.next_key::<Spanned<String>>()? {
+                    match key.value.as_str() {
+                        KEY_PACKAGE => {
+                            package = Some(map.next_value()?);
+                        }
+                        KEY_BADGES => {
+                            badges = Some(
+                                map.next_value_seed(BadgesSeed(toml_table.child(key.as_deref())))?,
+                            );
+                        }
+                        _ => {
+                            let _ = map.next_value::<de::IgnoredAny>()?;
+                        }
+                    }
+                }
+
+                Ok(Manifest {
+                    toml_table,
+                    package,
+                    badges,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(ManifestVisitor)
     }
 }
 
@@ -52,12 +100,13 @@ mod tests {
             version = "0.1.0"
         "#};
         let source_file = SourceFile::new_for_test("Cargo.toml", source);
-        let manifest = source_file
-            .parse_as_toml::<SourceFileSpanned<Manifest>>()
-            .unwrap();
-        let GetConfigError::KeyNotSet { source: err } = manifest.try_badges().unwrap_err();
-        assert_eq!(err.key, "badges");
-        assert_eq!(err.span, (0..0).into());
-        assert_eq!(err.source_code.name(), "Cargo.toml");
+        let manifest = source_file.parse_as_toml::<Manifest>().unwrap();
+        let (key, span, source_code) = manifest
+            .try_badges()
+            .unwrap_err()
+            .into_missing_top_level_key();
+        assert_eq!(key, "badges");
+        assert_eq!(span, (0..0).into());
+        assert_eq!(source_code.name(), "Cargo.toml");
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,7 +1,12 @@
-use std::sync::Arc;
+use std::{range::Range, sync::Arc};
 
 use miette::{NamedSource, SourceSpan};
 use snafu::Snafu;
+
+use crate::{
+    source::{SourceFileRef, Spanned},
+    traits::RangeExt as _,
+};
 
 // To detect items that do not have explicit values, wrap cargo's standard
 // configuration items in Options.
@@ -13,31 +18,103 @@ mod testing;
 
 #[derive(Debug, Snafu, miette::Diagnostic)]
 pub(crate) enum GetConfigError {
-    #[snafu(transparent)]
-    #[diagnostic(transparent)]
-    KeyNotSet {
-        #[snafu(source(from(KeyNotSet, Box::new)))]
-        #[diagnostic_source]
-        source: Box<KeyNotSet>,
+    #[snafu(display("missing top-level key `{key}`"))]
+    MissingTopLevelKey {
+        key: String,
+        #[label]
+        span: SourceSpan,
+        #[source_code]
+        source_code: NamedSource<Arc<str>>,
+    },
+    #[snafu(display("missing key `{key}` in table `{table}`"))]
+    MissingKeyInTable {
+        key: String,
+        table: String,
+        #[label]
+        span: SourceSpan,
+        #[source_code]
+        source_code: NamedSource<Arc<str>>,
     },
 }
 
-#[derive(Debug, Snafu, miette::Diagnostic)]
-#[snafu(display("key `{key}` is not set in `{path}`", path = source_code.name()))]
-pub(crate) struct KeyNotSet {
-    key: String,
-    #[label]
-    span: SourceSpan,
-    #[source_code]
-    source_code: NamedSource<Arc<str>>,
+impl GetConfigError {
+    #[cfg(test)]
+    pub(crate) fn into_missing_top_level_key(self) -> (String, SourceSpan, NamedSource<Arc<str>>) {
+        let Self::MissingTopLevelKey {
+            key,
+            span,
+            source_code,
+        } = self
+        else {
+            panic!("unexpected error: {self:?}");
+        };
+        (key, span, source_code)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_missing_key_in_table(
+        self,
+    ) -> (String, String, SourceSpan, NamedSource<Arc<str>>) {
+        let Self::MissingKeyInTable {
+            key,
+            table,
+            span,
+            source_code,
+        } = self
+        else {
+            panic!("unexpected error: {self:?}");
+        };
+        (key, table, span, source_code)
+    }
 }
 
-impl GetConfigError {
-    pub(crate) fn with_key(mut self, key: impl Into<String>) -> Self {
-        let key = key.into();
-        match &mut self {
-            Self::KeyNotSet { source } => source.key = key,
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TomlTable {
+    pub(crate) source: SourceFileRef,
+    pub(crate) path: Option<String>,
+    pub(crate) key_span: Range<usize>,
+}
+
+impl TomlTable {
+    pub(crate) fn root(source: SourceFileRef) -> Self {
+        Self {
+            source,
+            path: None,
+            key_span: (0..0).into(),
         }
-        self
+    }
+
+    pub(crate) fn child(&self, key: Spanned<&str>) -> Self {
+        let path = if let Some(parent) = &self.path {
+            format!("{parent}.{key}")
+        } else {
+            key.value.to_owned()
+        };
+        Self {
+            source: self.source.clone(),
+            path: Some(path),
+            key_span: key.span,
+        }
+    }
+
+    pub(crate) fn missing_key_error(&self, key: &str) -> GetConfigError {
+        let span = self.key_span.to_span();
+        let source_code = self.source.to_named_source();
+        if let Some(table) = &self.path {
+            MissingKeyInTableSnafu {
+                key,
+                table,
+                span,
+                source_code,
+            }
+            .build()
+        } else {
+            MissingTopLevelKeySnafu {
+                key,
+                span,
+                source_code,
+            }
+            .build()
+        }
     }
 }

--- a/src/config/testing.rs
+++ b/src/config/testing.rs
@@ -5,7 +5,7 @@ use crate::{
         Manifest,
         package::metadata::{badge::Badge, rustdoc::Rustdoc},
     },
-    source::{SourceFile, SourceFileSpanned},
+    source::SourceFile,
 };
 
 pub(crate) fn badge_manifest(badge: &str) -> String {
@@ -30,7 +30,7 @@ pub(crate) fn rustdoc_manifest(rustdoc: &str) -> String {
     "#}
 }
 
-pub(crate) fn parse_manifest(source: &str) -> SourceFileSpanned<Manifest> {
+pub(crate) fn parse_manifest(source: &str) -> Manifest {
     let source_file = SourceFile::new_for_test("Cargo.toml", source);
     source_file.parse_as_toml().unwrap()
 }
@@ -38,9 +38,7 @@ pub(crate) fn parse_manifest(source: &str) -> SourceFileSpanned<Manifest> {
 #[track_caller]
 pub(crate) fn parse_manifest_err(source: &str, prefix: &str, spanned: &str) {
     let source_file = SourceFile::new_for_test("Cargo.toml", source);
-    let err = source_file
-        .parse_as_toml::<SourceFileSpanned<Manifest>>()
-        .unwrap_err();
+    let err = source_file.parse_as_toml::<Manifest>().unwrap_err();
     assert!(
         err.message.starts_with(prefix),
         "message: {:?}",
@@ -54,7 +52,6 @@ pub(crate) fn parse_manifest_err(source: &str, prefix: &str, spanned: &str) {
 #[track_caller]
 pub(crate) fn parse_badge(source: &str) -> Badge {
     parse_manifest(source)
-        .value
         .package
         .unwrap()
         .metadata
@@ -66,7 +63,6 @@ pub(crate) fn parse_badge(source: &str) -> Badge {
 #[track_caller]
 pub(crate) fn parse_rustdoc(source: &str) -> Rustdoc {
     parse_manifest(source)
-        .value
         .package
         .unwrap()
         .metadata

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -10,7 +10,7 @@ use std::{
 use cargo_metadata::camino::Utf8PathBuf;
 use cargo_metadata::{Metadata, Package, camino::Utf8Path};
 use miette::{Diagnostic, NamedSource, SourceOffset, SourceSpan};
-use serde::de::Deserialize;
+use serde::de::{self, Deserialize};
 use snafu::Snafu;
 use tempfile::NamedTempFile;
 
@@ -89,6 +89,15 @@ impl<'a> SourceFileLoader<'a> {
 pub(crate) struct SourceFileRef {
     pub(crate) path: Arc<Utf8Path>,
     pub(crate) text: Arc<str>,
+}
+
+impl Default for SourceFileRef {
+    fn default() -> Self {
+        Self {
+            path: Utf8Path::new("").into(),
+            text: Arc::default(),
+        }
+    }
 }
 
 impl SourceFileRef {
@@ -218,8 +227,17 @@ thread_local! {
     static CURRENT_SOURCE_FILE: RefCell<Option<SourceFileRef>> = const { RefCell::new(None) };
 }
 
-pub(super) fn current_source_file() -> Option<SourceFileRef> {
-    CURRENT_SOURCE_FILE.with(|cell| cell.borrow().clone())
+pub(crate) fn current_source_file<E>() -> Result<SourceFileRef, E>
+where
+    E: de::Error,
+{
+    CURRENT_SOURCE_FILE
+        .with(|cell| cell.borrow().clone())
+        .ok_or_else(|| {
+            E::custom(
+                "no active TOML deserialization context found. source file information is not available.",
+            )
+        })
 }
 
 fn set_current_source_file(file: SourceFileRef) -> Reset {

--- a/src/source/spanned.rs
+++ b/src/source/spanned.rs
@@ -1,12 +1,11 @@
 use std::{
     fmt::{self, Display},
+    ops::Deref,
     range::{Range, legacy},
 };
 
 use miette::SourceSpan;
-use serde::{Deserialize, Deserializer, de};
-
-use crate::source::{SourceFileRef, file};
+use serde::{Deserialize, Deserializer};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Spanned<T> {
@@ -25,6 +24,16 @@ impl<T> Spanned<T> {
 
     pub(crate) fn source_span(&self) -> SourceSpan {
         SourceSpan::from(legacy::Range::from(self.span))
+    }
+
+    pub(crate) fn as_deref(&self) -> Spanned<&T::Target>
+    where
+        T: Deref,
+    {
+        Spanned {
+            value: &self.value,
+            span: self.span,
+        }
     }
 }
 
@@ -162,49 +171,6 @@ where
         Ok(Self {
             span: spanned.span().into(),
             value: spanned.into_inner(),
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct SourceFileSpanned<T> {
-    pub(crate) source: SourceFileRef,
-    pub(crate) value: T,
-    pub(crate) span: Range<usize>,
-}
-
-impl<T> SourceFileSpanned<T> {
-    pub(crate) fn source_span(&self) -> SourceSpan {
-        SourceSpan::from(legacy::Range::from(self.span))
-    }
-
-    pub(crate) fn as_ref(&self) -> SourceFileSpanned<&T> {
-        SourceFileSpanned {
-            source: self.source.clone(),
-            value: &self.value,
-            span: self.span,
-        }
-    }
-}
-
-impl<'de, T> Deserialize<'de> for SourceFileSpanned<T>
-where
-    T: Deserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let Some(source) = file::current_source_file() else {
-            return Err(de::Error::custom(
-                "SourceFileSpanned can only be deserialized in the context of a source file",
-            ));
-        };
-        let spanned = <Spanned<T>>::deserialize(deserializer)?;
-        Ok(Self {
-            source,
-            span: spanned.span,
-            value: spanned.value,
         })
     }
 }

--- a/src/sync/contents/badge.rs
+++ b/src/sync/contents/badge.rs
@@ -11,24 +11,22 @@ use snafu::{IntoError as _, OptionExt as _, ResultExt as _, Snafu, ensure};
 use url::Url;
 
 use super::Escape;
-use crate::{
-    config::{
-        GetConfigError,
-        manifest::{
-            badges::MaintenanceStatus,
-            package::metadata::badge::item::{
-                BadgeItem, Codecov, GithubActions, GithubActionsWorkflow, License,
-            },
+use crate::config::{
+    GetConfigError,
+    manifest::{
+        Manifest,
+        badges::MaintenanceStatus,
+        package::metadata::badge::item::{
+            BadgeItem, Codecov, GithubActions, GithubActionsWorkflow, License,
         },
     },
-    sync::ManifestFile,
 };
 
 type CreateResult<T> = Result<T, Box<CreateBadgeError>>;
 
 pub(super) fn create_all(
     badges: &[BadgeItem],
-    manifest: &ManifestFile,
+    manifest: &Manifest,
     workspace: &Metadata,
     package: &Package,
 ) -> Result<String, CreateAllBadgesError> {
@@ -88,7 +86,7 @@ impl From<Vec<CreateResult<BadgeLink>>> for BadgeLinkSet {
 impl BadgeLinkSet {
     fn from_config(
         config: &BadgeItem,
-        manifest: &ManifestFile,
+        manifest: &Manifest,
         workspace: &Metadata,
         package: &Package,
     ) -> CreateResult<Self> {
@@ -120,7 +118,7 @@ enum CreateBadgeError {
     GetConfig {
         #[snafu(source)]
         #[diagnostic_source]
-        source: GetConfigError,
+        source: Box<GetConfigError>,
     },
     #[snafu(display("neither `package.license` nor `package.license-file` is set: {path}"))]
     MissingLicenseMetadata { path: Utf8PathBuf },
@@ -158,6 +156,12 @@ enum CreateBadgeError {
     },
     #[snafu(display("`package.repository` must start with `https://github.com/`"))]
     InvalidGithubRepository,
+}
+
+impl From<Box<GetConfigError>> for Box<CreateBadgeError> {
+    fn from(source: Box<GetConfigError>) -> Self {
+        Box::new(source.into())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -245,7 +249,7 @@ impl<'a> ShieldsIo<'a> {
         self
     }
 
-    fn build(self, manifest: &ManifestFile) -> Url {
+    fn build(self, manifest: &Manifest) -> Url {
         let mut url = Url::parse("https://img.shields.io/").unwrap();
         url.set_path(&self.path);
         {
@@ -256,7 +260,7 @@ impl<'a> ShieldsIo<'a> {
             if let Some(logo) = self.logo {
                 query.append_pair("logo", &logo);
             }
-            if let Some(style) = &manifest.value.config().badge.style {
+            if let Some(style) = &manifest.config().badge.style {
                 query.append_pair("style", style.as_str());
             }
             for (key, value) in self.extra_queries {
@@ -294,9 +298,8 @@ impl fmt::Display for BadgeLink {
 }
 
 impl BadgeLink {
-    fn maintenance(manifest: &ManifestFile) -> CreateResult<Option<Self>> {
-        let status = (|| manifest.try_badges()?.try_maintenance()?.try_status())()
-            .map_err(|err| CreateBadgeError::from(err.with_key("badges.maintenance.status")))?;
+    fn maintenance(manifest: &Manifest) -> CreateResult<Option<Self>> {
+        let status = (|| manifest.try_badges()?.try_maintenance()?.try_status())()?;
 
         let image = match ShieldsIo::new_maintenance(status) {
             Some(shields_io) => shields_io.build(manifest).to_string(),
@@ -312,11 +315,7 @@ impl BadgeLink {
         Ok(Some(badge))
     }
 
-    fn license(
-        license: &License,
-        manifest: &ManifestFile,
-        package: &Package,
-    ) -> CreateResult<Self> {
+    fn license(license: &License, manifest: &Manifest, package: &Package) -> CreateResult<Self> {
         let (license_str, license_path) = if let Some(name) = &package.license {
             (name.as_str(), package.license_file.as_deref())
         } else if let Some(file) = &package.license_file {
@@ -340,7 +339,7 @@ impl BadgeLink {
         Ok(Self { alt, link, image })
     }
 
-    fn crates_io(manifest: &ManifestFile, package: &Package) -> Self {
+    fn crates_io(manifest: &Manifest, package: &Package) -> Self {
         let alt = "crates.io".to_owned();
         let link = Some(format!("https://crates.io/crates/{}", package.name));
         let image = ShieldsIo::new_version(&package.name)
@@ -350,7 +349,7 @@ impl BadgeLink {
         Self { alt, link, image }
     }
 
-    fn docs_rs(manifest: &ManifestFile, package: &Package) -> Self {
+    fn docs_rs(manifest: &Manifest, package: &Package) -> Self {
         let alt = "docs.rs".to_owned();
         let link = Some(format!("https://docs.rs/{}", package.name));
         let image = ShieldsIo::new_docs_rs(&package.name)
@@ -360,7 +359,7 @@ impl BadgeLink {
         Self { alt, link, image }
     }
 
-    fn rust_version(manifest: &ManifestFile, package: &Package) -> CreateResult<Self> {
+    fn rust_version(manifest: &Manifest, package: &Package) -> CreateResult<Self> {
         let rust_version =
             package
                 .rust_version
@@ -393,7 +392,7 @@ impl BadgeLink {
 
     fn github_actions(
         github_actions: &GithubActions,
-        manifest: &ManifestFile,
+        manifest: &Manifest,
         workspace: &Metadata,
         package: &Package,
     ) -> CreateResult<Vec<CreateResult<Self>>> {
@@ -440,11 +439,7 @@ impl BadgeLink {
         Ok(results)
     }
 
-    fn codecov(
-        codecov: &Codecov,
-        manifest: &ManifestFile,
-        package: &Package,
-    ) -> CreateResult<Self> {
+    fn codecov(codecov: &Codecov, manifest: &Manifest, package: &Package) -> CreateResult<Self> {
         let repository = package
             .repository
             .as_ref()

--- a/src/sync/contents/mod.rs
+++ b/src/sync/contents/mod.rs
@@ -3,9 +3,9 @@ use std::fmt;
 use cargo_metadata::{Metadata, Package};
 use snafu::{Snafu, ensure};
 
-use crate::{source::Spanned, sync::SyncOptions};
+use crate::{config::manifest::Manifest, source::Spanned, sync::SyncOptions};
 
-use super::{ManifestFile, marker::ResolvedReplaceSpecifier};
+use super::marker::ResolvedReplaceSpecifier;
 
 mod badge;
 mod rustdoc;
@@ -13,7 +13,7 @@ mod title;
 
 pub(super) fn create_all(
     specifiers: Vec<Spanned<ResolvedReplaceSpecifier>>,
-    manifest: &ManifestFile,
+    manifest: &Manifest,
     workspace: &Metadata,
     package: &Package,
     options: &SyncOptions<'_>,
@@ -66,7 +66,7 @@ pub(super) struct Contents {
 
 fn create_content(
     specifier: Spanned<ResolvedReplaceSpecifier>,
-    manifest: &ManifestFile,
+    manifest: &Manifest,
     workspace: &Metadata,
     package: &Package,
     options: &SyncOptions<'_>,

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -7,8 +7,9 @@ use snafu::{OptionExt as _, ResultExt as _, Snafu};
 
 use crate::{
     cargo,
+    config::manifest::Manifest,
     sync::{
-        ManifestFile, SyncOptions,
+        SyncOptions,
         contents::rustdoc::{document::UrlOptions, intra_link::LinkMappingConfig},
     },
 };
@@ -46,7 +47,7 @@ pub(in crate::sync) enum CreateRustdocError {
 }
 
 pub(super) fn create(
-    manifest: &ManifestFile,
+    manifest: &Manifest,
     workspace: &Metadata,
     package: &Package,
     options: &SyncOptions<'_>,
@@ -79,10 +80,10 @@ pub(super) fn create(
 
 fn build_url_options<'a>(
     package: &'a Package,
-    manifest: &'a ManifestFile,
+    manifest: &'a Manifest,
     options: &SyncOptions<'_>,
 ) -> Result<UrlOptions<'a>, CreateRustdocError> {
-    let config = manifest.value.config();
+    let config = manifest.config();
     let local_html_root_url = config.rustdoc.html_root_url.as_deref().map_or_else(
         || format!("https://docs.rs/{}/{}", package.name, package.version).into(),
         Cow::Borrowed,
@@ -97,8 +98,8 @@ fn build_url_options<'a>(
     })
 }
 
-fn build_mapping_config(manifest: &ManifestFile) -> LinkMappingConfig<'_> {
-    let config = manifest.value.config();
+fn build_mapping_config(manifest: &Manifest) -> LinkMappingConfig<'_> {
+    let config = manifest.config();
     LinkMappingConfig {
         mappings: &config.rustdoc.mappings,
     }

--- a/src/sync/marker/resolve.rs
+++ b/src/sync/marker/resolve.rs
@@ -4,6 +4,7 @@ use miette::{Diagnostic, SourceSpan};
 use snafu::Snafu;
 
 use crate::{
+    config::manifest::Manifest,
     source::Spanned,
     sync::{
         ManifestFile,
@@ -81,7 +82,7 @@ impl<'markdown, 'manifest> Resolver<'markdown, 'manifest> {
 
 pub(super) fn resolve_specifier(
     specifier: Spanned<ReplaceSpecifier<'_>>,
-    manifest: &ManifestFile,
+    manifest: &Manifest,
 ) -> Result<ResolvedReplaceSpecifier, ResolveMarkerError> {
     let kind = specifier.value.kind;
     let group = specifier.value.group;
@@ -104,7 +105,7 @@ pub(super) fn resolve_specifier(
         }
     }
 
-    let badge = &manifest.value.config().badge;
+    let badge = &manifest.config().badge;
     if let Some(group) = group {
         let (group, badges) = badge.groups.get_key_value(group.value).ok_or_else(|| {
             NoSuchBadgeGroupSnafu {
@@ -136,8 +137,7 @@ mod tests {
     use similar_asserts::assert_eq;
 
     use crate::{
-        config::manifest::{Manifest, package::metadata::badge::item::BadgeItem},
-        source::{SourceFile, SourceFileSpanned},
+        config::manifest::package::metadata::badge::item::BadgeItem, source::SourceFile,
         sync::marker::parse,
     };
 
@@ -210,9 +210,7 @@ mod tests {
         config: &str,
     ) -> Result<ResolvedReplaceSpecifier, ResolveMarkerError> {
         let source_file = SourceFile::new_for_test("Cargo.toml", config);
-        let manifest = source_file
-            .parse_as_toml::<SourceFileSpanned<Manifest>>()
-            .unwrap();
+        let manifest = source_file.parse_as_toml::<Manifest>().unwrap();
         let (specifier, _rest) = parse::parse_specifier(source).unwrap().unwrap();
         resolve_specifier(specifier, &manifest)
     }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     args::{FeatureSelection, FixArgs, Mode, RustdocToolchainArgs},
     config::manifest::Manifest,
     diff,
-    source::{ParseTomlError, SourceFile, SourceFileLoader, SourceFilePath, SourceFileSpanned},
+    source::{ParseTomlError, SourceFile, SourceFileLoader, SourceFilePath},
 };
 
 mod contents;
@@ -152,14 +152,14 @@ pub(crate) fn sync_all(
                 manifest: &manifest_loader,
             })?;
     let manifest = manifest_file
-        .parse_as_toml::<ManifestFile>()
+        .parse_as_toml::<Manifest>()
         .with_context(|_source| ParsePackageManifestSnafu {
             package: package.name.clone(),
             manifest: &manifest_loader,
         })?;
     let _span = tracing::info_span!("sync", "{}", package.name).entered();
 
-    let paths = package_target_files(package, &manifest.value.config().extra_targets);
+    let paths = package_target_files(package, &manifest.config().extra_targets);
 
     ensure!(
         !paths.is_empty(),
@@ -225,7 +225,7 @@ pub(crate) fn sync_all(
     Ok(())
 }
 
-type ManifestFile = SourceFileSpanned<Manifest>;
+type ManifestFile = Manifest;
 
 fn package_target_files<'a, P>(package: &'a Package, extra_targets: &'a [P]) -> Vec<&'a Utf8Path>
 where


### PR DESCRIPTION
## Summary
- collect TOML table/key source information during manifest deserialization and store it on config structs
- remove config accessor dependence on `SourceFileSpanned` wrappers and access config data directly from `Manifest`
- make missing-config diagnostics distinguish top-level missing keys from keys missing within a specific table
- update config parsing helpers and call sites to use the new table-backed span tracking

## Motivation
This moves config diagnostics closer to the manifest data model itself.

Instead of propagating source-aware wrapper types through config access,
`Manifest`, `Badges`, and `Maintenance` now carry the table metadata
needed to report missing keys precisely. That simplifies field access,
reduces wrapper-driven plumbing, and lets callers pass `Manifest`
around directly.

## Validation
- `cargo test`
- project diagnostics

## Impact
No intended behavior change for successful parsing. Missing-key
configuration errors now report more explicit context about where the
key was expected.