### PR TITLE
Fix maintenance status typo

### DIFF
--- a/src/config/manifest/badges.rs
+++ b/src/config/manifest/badges.rs
@@ -159,7 +159,7 @@ impl MaintenanceStatus {
             Self::Experimental => "experimental",
             Self::LookingForMaintainer => "looking-for-maintainer",
             Self::Deprecated => "deprecated",
-            Self::None => "done",
+            Self::None => "none",
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix the `MaintenanceStatus::None` string mapping in `src/config/manifest/badges.rs`
- return `"none"` instead of the typo `"done"`

## Validation
- `cargo test badges`