### PR TITLE
Disable mise lock file maintenance

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -32,12 +32,10 @@
       "commitMessageTopic": "for Cargo.lock"
     },
     {
-      "description": "Keep mise lock file maintenance in a dedicated PR",
+      "description": "Disable mise lock file maintenance",
       "matchManagers": ["mise"],
       "matchUpdateTypes": ["lockFileMaintenance"],
-      "branchTopic": "mise-lock-file-maintenance",
-      "groupName": "Mise lock file maintenance",
-      "commitMessageTopic": "for mise.lock"
+      "enabled": false
     },
     {
       "description": "Group compatible Cargo updates",


### PR DESCRIPTION
## Summary
- disable Renovate `lockFileMaintenance` for the `mise` manager
- keep Cargo lock file maintenance enabled

## Motivation
- avoid `mise.lock` maintenance PRs that only refresh platform-specific URLs and checksums
- pinned `mise` tool versions still receive normal dependency update PRs

## Validation
- `mise run lint:renovate`