### PR TITLE
Refactor package sync context setup

### DIFF
--- a/src/config/manifest/mod.rs
+++ b/src/config/manifest/mod.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::LazyLock};
+use std::fmt;
 
 use serde::{Deserialize, de};
 
@@ -27,12 +27,6 @@ impl Manifest {
             .as_ref()
             .ok_or_else(|| self.toml_table.missing_key_error(KEY_BADGES))?;
         Ok(badges)
-    }
-
-    pub(crate) fn config(&self) -> &package::metadata::CargoSyncRdme {
-        static DEFAULT: LazyLock<package::metadata::CargoSyncRdme> =
-            LazyLock::new(Default::default);
-        (|| Some(&self.package.as_ref()?.metadata.as_ref()?.cargo_sync_rdme))().unwrap_or(&DEFAULT)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use supports_color::Stream;
 use tracing::Level;
 use tracing_subscriber::{EnvFilter, filter::LevelFilter, fmt::writer::BoxMakeWriter};
 
-use crate::{args::Args, sync::SyncOptions};
+use crate::{args::Args, sync::PackageSyncContext};
 
 mod args;
 mod cargo;
@@ -47,24 +47,20 @@ fn main() -> miette::Result<()> {
 
     let args = args::parse();
     let output_stream = Stream::Stderr;
+    let diff_stream = output_stream;
     let use_color = should_use_color(args.color, output_stream);
     set_console_color(use_color, output_stream);
     set_miette_hook(use_color, output_stream);
     install_logger(args.verbosity, use_color, output_stream);
 
-    let sync_options = SyncOptions {
-        mode: args.mode.mode(),
-        verbosity: args.verbosity.into(),
-        diff_stream: output_stream,
-        fix: &args.fix,
-        toolchain: &args.toolchain,
-        feature: &args.feature,
-    };
-
     let workspace = cargo::metadata(&args.manifest)?;
-    for package in cargo::select_packages(&workspace, &args.package)? {
-        sync::sync_all(&workspace, package, &sync_options)
-            .map_err(|source| miette::Report::new_boxed(source))?;
+    let cxs = cargo::select_packages(&workspace, &args.package)?
+        .into_iter()
+        .map(|package| PackageSyncContext::load(diff_stream, &args, &workspace, package))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|source| miette::Report::new_boxed(source))?;
+    for cx in cxs {
+        sync::sync_all(&cx).map_err(|source| miette::Report::new_boxed(source))?;
     }
 
     Ok(())

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -1,14 +1,14 @@
 use std::{
-    borrow::Cow,
     cell::RefCell,
     fs,
     io::{self, Write as _},
     sync::Arc,
 };
 
-#[cfg(test)]
-use cargo_metadata::camino::Utf8PathBuf;
-use cargo_metadata::{Metadata, Package, camino::Utf8Path};
+use cargo_metadata::{
+    Metadata, Package,
+    camino::{Utf8Path, Utf8PathBuf},
+};
 use miette::{Diagnostic, NamedSource, SourceOffset, SourceSpan};
 use serde::de::{self, Deserialize};
 use snafu::Snafu;
@@ -21,16 +21,16 @@ pub(crate) struct SourceFilePath {
     pub(crate) path: Arc<Utf8Path>,
 }
 
-impl From<&SourceFileLoader<'_>> for SourceFilePath {
-    fn from(loader: &SourceFileLoader<'_>) -> Self {
+impl From<&SourceFileLoader> for SourceFilePath {
+    fn from(loader: &SourceFileLoader) -> Self {
         Self {
             path: Arc::clone(&loader.workspace_relative_path),
         }
     }
 }
 
-impl From<&SourceFile<'_>> for SourceFilePath {
-    fn from(file: &SourceFile<'_>) -> Self {
+impl From<&SourceFile> for SourceFilePath {
+    fn from(file: &SourceFile) -> Self {
         Self {
             path: Arc::clone(&file.workspace_relative_path),
         }
@@ -38,32 +38,29 @@ impl From<&SourceFile<'_>> for SourceFilePath {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct SourceFileLoader<'a> {
+pub(crate) struct SourceFileLoader {
     workspace_relative_path: Arc<Utf8Path>,
-    path: Cow<'a, Utf8Path>,
+    path: Utf8PathBuf,
 }
 
-impl<'a> SourceFileLoader<'a> {
+impl SourceFileLoader {
     pub(crate) fn from_package_relative_path(
-        workspace: &'a Metadata,
-        package: &'a Package,
-        package_relative_path: &'a Utf8Path,
+        workspace: &Metadata,
+        package: &Package,
+        package_relative_path: &Utf8Path,
     ) -> Self {
         let workspace_relative_path = package
             .workspace_relative_root_directory(workspace)
             .join(package_relative_path)
             .into();
-        let path = workspace
-            .workspace_root
-            .join(&workspace_relative_path)
-            .into();
+        let path = workspace.workspace_root.join(&workspace_relative_path);
         Self {
             workspace_relative_path,
             path,
         }
     }
 
-    pub(crate) fn from_path(workspace: &'a Metadata, path: &'a Utf8Path) -> Self {
+    pub(crate) fn from_path(workspace: &Metadata, path: &Utf8Path) -> Self {
         let workspace_relative_path = path
             .strip_prefix(&workspace.workspace_root)
             .unwrap_or(path)
@@ -75,8 +72,8 @@ impl<'a> SourceFileLoader<'a> {
         }
     }
 
-    pub(crate) fn load(&self) -> io::Result<SourceFile<'_>> {
-        let text = fs::read_to_string(self.path.as_ref())?.into();
+    pub(crate) fn load(&self) -> io::Result<SourceFile> {
+        let text = fs::read_to_string(&self.path)?.into();
         Ok(SourceFile {
             workspace_relative_path: Arc::clone(&self.workspace_relative_path),
             path: self.path.clone(),
@@ -107,9 +104,9 @@ impl SourceFileRef {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct SourceFile<'a> {
+pub(crate) struct SourceFile {
     workspace_relative_path: Arc<Utf8Path>,
-    path: Cow<'a, Utf8Path>,
+    path: Utf8PathBuf,
     text: Arc<str>,
 }
 
@@ -133,7 +130,7 @@ pub(crate) struct ParseTomlError {
     pub(crate) label: Option<SourceSpan>,
 }
 
-impl SourceFile<'_> {
+impl SourceFile {
     #[cfg(test)]
     pub(crate) fn new_for_test<P, T>(workspace_relative_path: P, text: T) -> Self
     where
@@ -141,7 +138,7 @@ impl SourceFile<'_> {
         T: Into<String>,
     {
         let workspace_relative_path = Arc::<Utf8Path>::from(workspace_relative_path.into());
-        let path = workspace_relative_path.as_ref().to_owned().into();
+        let path = workspace_relative_path.as_ref().to_owned();
         let text = Arc::<str>::from(text.into());
         Self {
             workspace_relative_path,
@@ -177,9 +174,7 @@ impl SourceFile<'_> {
         let mut tempfile = NamedTempFile::new_in(output_dir)?;
         tempfile.as_file_mut().write_all(new_text.as_bytes())?;
         tempfile.as_file_mut().sync_data()?;
-        let file = tempfile
-            .persist(self.path.as_ref())
-            .map_err(|err| err.error)?;
+        let file = tempfile.persist(&self.path).map_err(|err| err.error)?;
         file.sync_all()?;
         drop(file);
         self.text = new_text;

--- a/src/sync/contents/badge.rs
+++ b/src/sync/contents/badge.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, cmp::Ordering, fmt, fmt::Write as _, fs, io, sync::Arc};
 
 use cargo_metadata::{
-    Metadata, Package,
+    Metadata,
     camino::{Utf8Path, Utf8PathBuf},
     semver::{Comparator, Op, VersionReq},
 };
@@ -11,31 +11,31 @@ use snafu::{IntoError as _, OptionExt as _, ResultExt as _, Snafu, ensure};
 use url::Url;
 
 use super::Escape;
-use crate::config::{
-    GetConfigError,
-    manifest::{
-        Manifest,
-        badges::MaintenanceStatus,
-        package::metadata::badge::item::{
-            BadgeItem, Codecov, GithubActions, GithubActionsWorkflow, License,
+use crate::{
+    config::{
+        GetConfigError,
+        manifest::{
+            badges::MaintenanceStatus,
+            package::metadata::badge::item::{
+                BadgeItem, Codecov, GithubActions, GithubActionsWorkflow, License,
+            },
         },
     },
+    sync::PackageSyncContext,
 };
 
 type CreateResult<T> = Result<T, Box<CreateBadgeError>>;
 
 pub(super) fn create_all(
+    cx: &PackageSyncContext<'_>,
     badges: &[BadgeItem],
-    manifest: &Manifest,
-    workspace: &Metadata,
-    package: &Package,
 ) -> Result<String, CreateAllBadgesError> {
     let mut output = String::new();
 
     let mut errors = vec![];
 
     for badge in badges {
-        match BadgeLinkSet::from_config(badge, manifest, workspace, package) {
+        match BadgeLinkSet::from_config(cx, badge) {
             Ok(BadgeLinkSet::None) => {}
             Ok(BadgeLinkSet::One(badge)) => writeln!(&mut output, "{badge}").unwrap(),
             Ok(BadgeLinkSet::ManyResult(bs)) => {
@@ -84,22 +84,17 @@ impl From<Vec<CreateResult<BadgeLink>>> for BadgeLinkSet {
 }
 
 impl BadgeLinkSet {
-    fn from_config(
-        config: &BadgeItem,
-        manifest: &Manifest,
-        workspace: &Metadata,
-        package: &Package,
-    ) -> CreateResult<Self> {
+    fn from_config(cx: &PackageSyncContext<'_>, config: &BadgeItem) -> CreateResult<Self> {
         Ok(match config {
-            BadgeItem::Maintenance => BadgeLink::maintenance(manifest)?.into(),
-            BadgeItem::License(license) => BadgeLink::license(license, manifest, package)?.into(),
-            BadgeItem::CratesIo => BadgeLink::crates_io(manifest, package).into(),
-            BadgeItem::DocsRs => BadgeLink::docs_rs(manifest, package).into(),
-            BadgeItem::RustVersion => BadgeLink::rust_version(manifest, package)?.into(),
+            BadgeItem::Maintenance => BadgeLink::maintenance(cx)?.into(),
+            BadgeItem::License(license) => BadgeLink::license(cx, license)?.into(),
+            BadgeItem::CratesIo => BadgeLink::crates_io(cx).into(),
+            BadgeItem::DocsRs => BadgeLink::docs_rs(cx).into(),
+            BadgeItem::RustVersion => BadgeLink::rust_version(cx)?.into(),
             BadgeItem::GithubActions(github_actions) => {
-                BadgeLink::github_actions(github_actions, manifest, workspace, package)?.into()
+                BadgeLink::github_actions(cx, github_actions)?.into()
             }
-            BadgeItem::Codecov(codecov) => BadgeLink::codecov(codecov, manifest, package)?.into(),
+            BadgeItem::Codecov(codecov) => BadgeLink::codecov(cx, codecov)?.into(),
         })
     }
 }
@@ -249,7 +244,7 @@ impl<'a> ShieldsIo<'a> {
         self
     }
 
-    fn build(self, manifest: &Manifest) -> Url {
+    fn build(self, cx: &PackageSyncContext<'_>) -> Url {
         let mut url = Url::parse("https://img.shields.io/").unwrap();
         url.set_path(&self.path);
         {
@@ -260,7 +255,7 @@ impl<'a> ShieldsIo<'a> {
             if let Some(logo) = self.logo {
                 query.append_pair("logo", &logo);
             }
-            if let Some(style) = &manifest.config().badge.style {
+            if let Some(style) = &cx.config.badge.style {
                 query.append_pair("style", style.as_str());
             }
             for (key, value) in self.extra_queries {
@@ -298,11 +293,11 @@ impl fmt::Display for BadgeLink {
 }
 
 impl BadgeLink {
-    fn maintenance(manifest: &Manifest) -> CreateResult<Option<Self>> {
-        let status = (|| manifest.try_badges()?.try_maintenance()?.try_status())()?;
+    fn maintenance(cx: &PackageSyncContext<'_>) -> CreateResult<Option<Self>> {
+        let status = (|| cx.manifest.try_badges()?.try_maintenance()?.try_status())()?;
 
         let image = match ShieldsIo::new_maintenance(status) {
-            Some(shields_io) => shields_io.build(manifest).to_string(),
+            Some(shields_io) => shields_io.build(cx).to_string(),
             None => return Ok(None),
         };
 
@@ -315,14 +310,14 @@ impl BadgeLink {
         Ok(Some(badge))
     }
 
-    fn license(license: &License, manifest: &Manifest, package: &Package) -> CreateResult<Self> {
-        let (license_str, license_path) = if let Some(name) = &package.license {
-            (name.as_str(), package.license_file.as_deref())
-        } else if let Some(file) = &package.license_file {
+    fn license(cx: &PackageSyncContext<'_>, license: &License) -> CreateResult<Self> {
+        let (license_str, license_path) = if let Some(name) = &cx.package.license {
+            (name.as_str(), cx.package.license_file.as_deref())
+        } else if let Some(file) = &cx.package.license_file {
             ("non-standard", Some(file.as_ref()))
         } else {
             return Err(MissingLicenseMetadataSnafu {
-                path: &package.manifest_path,
+                path: &cx.package.manifest_path,
             }
             .build()
             .into());
@@ -333,39 +328,39 @@ impl BadgeLink {
             .link
             .clone()
             .or_else(|| license_path.map(ToString::to_string));
-        let image = ShieldsIo::new_license(&package.name)
-            .build(manifest)
+        let image = ShieldsIo::new_license(&cx.package.name)
+            .build(cx)
             .to_string();
         Ok(Self { alt, link, image })
     }
 
-    fn crates_io(manifest: &Manifest, package: &Package) -> Self {
+    fn crates_io(cx: &PackageSyncContext<'_>) -> Self {
         let alt = "crates.io".to_owned();
-        let link = Some(format!("https://crates.io/crates/{}", package.name));
-        let image = ShieldsIo::new_version(&package.name)
+        let link = Some(format!("https://crates.io/crates/{}", cx.package.name));
+        let image = ShieldsIo::new_version(&cx.package.name)
             .logo("rust")
-            .build(manifest)
+            .build(cx)
             .to_string();
         Self { alt, link, image }
     }
 
-    fn docs_rs(manifest: &Manifest, package: &Package) -> Self {
+    fn docs_rs(cx: &PackageSyncContext<'_>) -> Self {
         let alt = "docs.rs".to_owned();
-        let link = Some(format!("https://docs.rs/{}", package.name));
-        let image = ShieldsIo::new_docs_rs(&package.name)
+        let link = Some(format!("https://docs.rs/{}", cx.package.name));
+        let image = ShieldsIo::new_docs_rs(&cx.package.name)
             .logo("docs.rs")
-            .build(manifest)
+            .build(cx)
             .to_string();
         Self { alt, link, image }
     }
 
-    fn rust_version(manifest: &Manifest, package: &Package) -> CreateResult<Self> {
+    fn rust_version(cx: &PackageSyncContext<'_>) -> CreateResult<Self> {
         let rust_version =
-            package
+            cx.package
                 .rust_version
                 .as_ref()
                 .context(MissingRustVersionMetadataSnafu {
-                    path: &package.manifest_path,
+                    path: &cx.package.manifest_path,
                 })?;
 
         let rust_version = VersionReq {
@@ -385,31 +380,30 @@ impl BadgeLink {
         );
         let image = ShieldsIo::new_rust_version(&rust_version)
             .logo("rust")
-            .build(manifest)
+            .build(cx)
             .to_string();
         Ok(Self { alt, link, image })
     }
 
     fn github_actions(
+        cx: &PackageSyncContext<'_>,
         github_actions: &GithubActions,
-        manifest: &Manifest,
-        workspace: &Metadata,
-        package: &Package,
     ) -> CreateResult<Vec<CreateResult<Self>>> {
-        let repository = package
-            .repository
-            .as_ref()
-            .context(MissingRepositoryMetadataSnafu {
-                path: &package.manifest_path,
-            })?;
+        let repository =
+            cx.package
+                .repository
+                .as_ref()
+                .context(MissingRepositoryMetadataSnafu {
+                    path: &cx.package.manifest_path,
+                })?;
         let repo_path = repository
             .strip_prefix("https://github.com/")
             .context(InvalidGithubRepositorySnafu)?;
 
         let results = if github_actions.workflows.is_empty() {
-            Self::github_actions_from_directory(workspace)?
+            Self::github_actions_from_directory(cx)?
         } else {
-            Self::github_actions_from_config(&github_actions.workflows, workspace)
+            Self::github_actions_from_config(cx, &github_actions.workflows)
         };
 
         let results = results
@@ -425,7 +419,7 @@ impl BadgeLink {
                     let image = ShieldsIo::new_github_actions(repo_path, &file)
                         .label(&name)
                         .logo("github")
-                        .build(manifest)
+                        .build(cx)
                         .to_string();
                     Self {
                         alt,
@@ -439,13 +433,14 @@ impl BadgeLink {
         Ok(results)
     }
 
-    fn codecov(codecov: &Codecov, manifest: &Manifest, package: &Package) -> CreateResult<Self> {
-        let repository = package
-            .repository
-            .as_ref()
-            .context(MissingRepositoryMetadataSnafu {
-                path: &package.manifest_path,
-            })?;
+    fn codecov(cx: &PackageSyncContext<'_>, codecov: &Codecov) -> CreateResult<Self> {
+        let repository =
+            cx.package
+                .repository
+                .as_ref()
+                .context(MissingRepositoryMetadataSnafu {
+                    path: &cx.package.manifest_path,
+                })?;
         let repo_path = repository
             .strip_prefix("https://github.com/")
             .context(InvalidGithubRepositorySnafu)?;
@@ -459,7 +454,7 @@ impl BadgeLink {
         )
         .label("codecov")
         .logo("codecov")
-        .build(manifest)
+        .build(cx)
         .to_string();
         Ok(Self {
             alt,
@@ -469,11 +464,11 @@ impl BadgeLink {
     }
 
     fn github_actions_from_directory(
-        workspace: &Metadata,
+        cx: &PackageSyncContext<'_>,
     ) -> CreateResult<Vec<CreateResult<(String, String)>>> {
         let mut badges = vec![];
 
-        let workflows_dir_path = workspace.workspace_root.join(".github/workflows");
+        let workflows_dir_path = cx.workspace.workspace_root.join(".github/workflows");
         let dirs = match workflows_dir_path.read_dir_utf8() {
             Ok(dirs) => dirs,
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
@@ -511,7 +506,7 @@ impl BadgeLink {
                 continue;
             }
 
-            let name = match read_workflow_name(workspace, path) {
+            let name = match read_workflow_name(cx.workspace, path) {
                 Ok(name) => name,
                 Err(err) => {
                     badges.push(Err(err));
@@ -536,17 +531,17 @@ impl BadgeLink {
     }
 
     fn github_actions_from_config(
+        cx: &PackageSyncContext<'_>,
         workflows: &[GithubActionsWorkflow],
-        workspace: &Metadata,
     ) -> Vec<CreateResult<(String, String)>> {
-        let workflows_dir_path = workspace.workspace_root.join(".github/workflows");
+        let workflows_dir_path = cx.workspace.workspace_root.join(".github/workflows");
 
         let mut badges = vec![];
         for workflow in workflows {
             let full_path = workflows_dir_path.join(&workflow.file);
             let name = match &workflow.name {
                 Some(name) => name.to_owned(),
-                None => match read_workflow_name(workspace, &full_path) {
+                None => match read_workflow_name(cx.workspace, &full_path) {
                     Ok(name) => name,
                     Err(err) => {
                         badges.push(Err(err));

--- a/src/sync/contents/mod.rs
+++ b/src/sync/contents/mod.rs
@@ -1,9 +1,8 @@
 use std::fmt;
 
-use cargo_metadata::{Metadata, Package};
 use snafu::{Snafu, ensure};
 
-use crate::{config::manifest::Manifest, source::Spanned, sync::SyncOptions};
+use crate::{source::Spanned, sync::PackageSyncContext};
 
 use super::marker::ResolvedReplaceSpecifier;
 
@@ -12,16 +11,13 @@ mod rustdoc;
 mod title;
 
 pub(super) fn create_all(
+    cx: &PackageSyncContext<'_>,
     specifiers: Vec<Spanned<ResolvedReplaceSpecifier>>,
-    manifest: &Manifest,
-    workspace: &Metadata,
-    package: &Package,
-    options: &SyncOptions<'_>,
 ) -> Result<Vec<Contents>, CreateAllContentsError> {
     let mut contents = vec![];
     let mut errors = vec![];
     for specifier in specifiers {
-        let res = create_content(specifier, manifest, workspace, package, options);
+        let res = create_content(cx, specifier);
         match res {
             Ok(c) => contents.push(c),
             Err(err) => errors.push(err),
@@ -65,20 +61,13 @@ pub(super) struct Contents {
 }
 
 fn create_content(
+    cx: &PackageSyncContext<'_>,
     specifier: Spanned<ResolvedReplaceSpecifier>,
-    manifest: &Manifest,
-    workspace: &Metadata,
-    package: &Package,
-    options: &SyncOptions<'_>,
 ) -> Result<Contents, CreateContentsError> {
     let text = match &specifier.value {
-        ResolvedReplaceSpecifier::Title => title::create(package),
-        ResolvedReplaceSpecifier::Badge { group: _, badges } => {
-            badge::create_all(badges, manifest, workspace, package)?
-        }
-        ResolvedReplaceSpecifier::Rustdoc => {
-            rustdoc::create(manifest, workspace, package, options)?
-        }
+        ResolvedReplaceSpecifier::Title => title::create(cx),
+        ResolvedReplaceSpecifier::Badge { group: _, badges } => badge::create_all(cx, badges)?,
+        ResolvedReplaceSpecifier::Rustdoc => rustdoc::create(cx)?,
     };
 
     assert!(text.is_empty() || text.ends_with('\n'));

--- a/src/sync/contents/rustdoc/build.rs
+++ b/src/sync/contents/rustdoc/build.rs
@@ -5,7 +5,7 @@ use std::{
     process::{ExitStatus, Stdio},
 };
 
-use cargo_metadata::{Message, Metadata, Package, PackageName, camino::Utf8PathBuf};
+use cargo_metadata::{Message, PackageName, camino::Utf8PathBuf};
 use miette::Diagnostic;
 use snafu::{ResultExt as _, Snafu, ensure};
 use tracing::Level;
@@ -13,7 +13,7 @@ use tracing::Level;
 use crate::{
     cargo,
     source::{ParseJsonError, SourceFileLoader, SourceFilePath},
-    sync::{SyncOptions, contents::rustdoc::document::RustdocDocument},
+    sync::{PackageSyncContext, contents::rustdoc::document::RustdocDocument},
     traits::CommandExt as _,
 };
 
@@ -80,42 +80,37 @@ impl Borrow<dyn Diagnostic> for Box<BuildRustdocError> {
 }
 
 pub(super) fn build_rustdoc(
-    workspace: &Metadata,
-    package: &Package,
-    options: &SyncOptions<'_>,
+    cx: &PackageSyncContext<'_>,
 ) -> Result<RustdocDocument, Box<BuildRustdocError>> {
-    let json_path = run_rustdoc(package, options)?;
-    let json_file_loader = SourceFileLoader::from_path(workspace, &json_path);
+    let json_path = run_rustdoc(cx)?;
+    let json_file_loader = SourceFileLoader::from_path(cx.workspace, &json_path);
     let json_file = json_file_loader
         .load()
         .with_context(|_source| ReadRustdocJsonSnafu {
-            package: package.name.clone(),
+            package: cx,
             json: &json_file_loader,
         })?;
     let doc = json_file
         .parse_as_json()
         .with_context(|_source| ParseRustdocJsonSnafu {
-            package: package.name.clone(),
+            package: cx,
             json: &json_file_loader,
         })?;
     let doc = RustdocDocument::new(doc);
     Ok(doc)
 }
 
-fn run_rustdoc(
-    package: &Package,
-    options: &SyncOptions<'_>,
-) -> Result<Utf8PathBuf, Box<BuildRustdocError>> {
-    let mut command = cargo::command_for_build_doc(options.toolchain);
-    match options.verbosity {
+fn run_rustdoc(cx: &PackageSyncContext<'_>) -> Result<Utf8PathBuf, Box<BuildRustdocError>> {
+    let mut command = cargo::command_for_build_doc(cx.toolchain);
+    match cx.verbosity {
         Some(Level::TRACE) => _ = command.arg("-vv"),
         Some(Level::DEBUG) => _ = command.arg("-v"),
         Some(Level::INFO) => {}
         _ => _ = command.arg("-q"),
     }
     command
-        .args(["rustdoc", "--package", &package.name])
-        .args(cargo::feature_args(options.feature))
+        .args(["rustdoc", "--package", &cx.package.name])
+        .args(cargo::feature_args(cx.feature))
         .args([
             "--message-format=json-render-diagnostics",
             "-Zunstable-options",
@@ -141,7 +136,7 @@ fn run_rustdoc(
     let mut child = command
         .spawn()
         .with_context(|_source| StartRustdocProcessSnafu {
-            package: package.name.clone(),
+            package: cx,
             commandline: &commandline,
         })?;
 
@@ -149,11 +144,11 @@ fn run_rustdoc(
     let mut json_filenames = vec![];
     for message in Message::parse_stream(stdout) {
         let message = message.with_context(|_source| ReadRustdocOutputSnafu {
-            package: package.name.clone(),
+            package: cx,
             commandline: &commandline,
         })?;
         if let Message::CompilerArtifact(artifact) = message
-            && artifact.package_id == package.id
+            && artifact.package_id == cx.package.id
         {
             json_filenames.extend(
                 artifact
@@ -166,13 +161,13 @@ fn run_rustdoc(
     let status = child
         .wait()
         .with_context(|_source| WaitRustdocProcessSnafu {
-            package: package.name.clone(),
+            package: cx,
             commandline: &commandline,
         })?;
     ensure!(
         status.success(),
         NonZeroExitStatusSnafu {
-            package: package.name.clone(),
+            package: cx,
             commandline: &commandline,
             status,
         }
@@ -181,14 +176,14 @@ fn run_rustdoc(
     ensure!(
         json_filenames.len() <= 1,
         MultipleRustdocJsonFilesSnafu {
-            package: package.name.clone(),
+            package: cx,
             commandline: &commandline,
             files: json_filenames.clone(),
         }
     );
     let Some(output_file) = json_filenames.pop() else {
         return Err(NoRustdocJsonFilesSnafu {
-            package: package.name.clone(),
+            package: cx,
             commandline: &commandline,
         }
         .build()

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -1,15 +1,14 @@
 use std::borrow::Cow;
 
-use cargo_metadata::{Metadata, Package, PackageName};
+use cargo_metadata::PackageName;
 use miette::Diagnostic;
 use pulldown_cmark::{Event, Options};
 use snafu::{OptionExt as _, ResultExt as _, Snafu};
 
 use crate::{
     cargo,
-    config::manifest::Manifest,
     sync::{
-        SyncOptions,
+        PackageSyncContext,
         contents::rustdoc::{document::UrlOptions, intra_link::LinkMappingConfig},
     },
 };
@@ -46,29 +45,18 @@ pub(in crate::sync) enum CreateRustdocError {
     },
 }
 
-pub(super) fn create(
-    manifest: &Manifest,
-    workspace: &Metadata,
-    package: &Package,
-    options: &SyncOptions<'_>,
-) -> Result<String, CreateRustdocError> {
-    let doc = build::build_rustdoc(workspace, package, options).with_context(|_source| {
-        BuildRustdocSnafu {
-            package: package.name.clone(),
-        }
-    })?;
-    let root = doc.root_item().with_context(|| RootNotFoundSnafu {
-        package: package.name.clone(),
-    })?;
+pub(super) fn create(cx: &PackageSyncContext<'_>) -> Result<String, CreateRustdocError> {
+    let doc = build::build_rustdoc(cx).with_context(|_source| BuildRustdocSnafu { package: cx })?;
+    let root = doc
+        .root_item()
+        .with_context(|| RootNotFoundSnafu { package: cx })?;
 
-    let build_url_options = build_url_options(package, manifest, options)?;
-    let mapping_config = build_mapping_config(manifest);
+    let build_url_options = build_url_options(cx)?;
+    let mapping_config = build_mapping_config(cx);
     let resolver = doc.intra_link_resolver(&build_url_options);
     let mapper = mapping_config
         .build_mapper(&resolver, root)
-        .with_context(|| RootDocNotFoundSnafu {
-            package: package.name.clone(),
-        })?;
+        .with_context(|| RootDocNotFoundSnafu { package: cx })?;
 
     let events = mapper.build_parser(main_body_opts());
     let events = heading::convert(events);
@@ -79,18 +67,16 @@ pub(super) fn create(
 }
 
 fn build_url_options<'a>(
-    package: &'a Package,
-    manifest: &'a Manifest,
-    options: &SyncOptions<'_>,
+    cx: &'a PackageSyncContext<'_>,
 ) -> Result<UrlOptions<'a>, CreateRustdocError> {
-    let config = manifest.config();
+    let config = &cx.config;
     let local_html_root_url = config.rustdoc.html_root_url.as_deref().map_or_else(
-        || format!("https://docs.rs/{}/{}", package.name, package.version).into(),
+        || format!("https://docs.rs/{}/{}", cx.package.name, cx.package.version).into(),
         Cow::Borrowed,
     );
     let expected_toolchain = cargo::toolchain(None).context(DetermineToolchainSnafu)?;
     let rustdoc_toolchain =
-        cargo::toolchain(Some(options.toolchain)).context(DetermineToolchainSnafu)?;
+        cargo::toolchain(Some(cx.toolchain)).context(DetermineToolchainSnafu)?;
     Ok(UrlOptions {
         local_html_root_url,
         expected_toolchain,
@@ -98,10 +84,9 @@ fn build_url_options<'a>(
     })
 }
 
-fn build_mapping_config(manifest: &Manifest) -> LinkMappingConfig<'_> {
-    let config = manifest.config();
+fn build_mapping_config<'a>(cx: &'a PackageSyncContext<'_>) -> LinkMappingConfig<'a> {
     LinkMappingConfig {
-        mappings: &config.rustdoc.mappings,
+        mappings: &cx.config.rustdoc.mappings,
     }
 }
 

--- a/src/sync/contents/title.rs
+++ b/src/sync/contents/title.rs
@@ -1,5 +1,5 @@
-use cargo_metadata::Package;
+use crate::sync::PackageSyncContext;
 
-pub(super) fn create(package: &Package) -> String {
-    format!("# {}\n", package.name)
+pub(super) fn create(cx: &PackageSyncContext<'_>) -> String {
+    format!("# {}\n", cx.package.name)
 }

--- a/src/sync/marker/mod.rs
+++ b/src/sync/marker/mod.rs
@@ -1,6 +1,6 @@
 use std::{fmt, sync::Arc};
 
-use cargo_metadata::{Package, PackageName};
+use cargo_metadata::PackageName;
 use miette::NamedSource;
 use snafu::{Snafu, ensure};
 
@@ -8,7 +8,7 @@ use crate::{
     config::manifest::package::metadata::badge::item::BadgeItem,
     source::{SourceFile, SourceFilePath, Spanned},
     sync::{
-        ManifestFile,
+        PackageSyncContext,
         contents::Contents,
         marker::resolve::{ResolveMarkerError, Resolver},
     },
@@ -61,11 +61,10 @@ impl fmt::Display for ResolvedReplaceSpecifier {
 }
 
 pub(super) fn parse_markers(
-    markdown: &SourceFile<'_>,
-    manifest: &ManifestFile,
-    package: &Package,
+    cx: &PackageSyncContext<'_>,
+    markdown: &SourceFile,
 ) -> Result<Vec<Spanned<ResolvedReplaceSpecifier>>, Box<ParseMarkersError>> {
-    let mut resolver = Resolver::new(markdown.text(), manifest);
+    let mut resolver = Resolver::new(cx, markdown.text());
     let mut specifiers = vec![];
     let mut errors = vec![];
 
@@ -79,7 +78,7 @@ pub(super) fn parse_markers(
     ensure!(
         errors.is_empty(),
         ParseMarkersSnafu {
-            package: package.name.clone(),
+            package: cx,
             markdown,
             source_code: markdown.to_named_source(),
             errors

--- a/src/sync/marker/resolve.rs
+++ b/src/sync/marker/resolve.rs
@@ -4,10 +4,10 @@ use miette::{Diagnostic, SourceSpan};
 use snafu::Snafu;
 
 use crate::{
-    config::manifest::Manifest,
+    config::manifest::package::metadata::CargoSyncRdme,
     source::Spanned,
     sync::{
-        ManifestFile,
+        PackageSyncContext,
         marker::{
             ResolvedReplaceSpecifier,
             parse::ReplaceSpecifier,
@@ -56,15 +56,15 @@ pub(super) enum ResolveMarkerError {
 }
 
 #[derive(Debug)]
-pub(super) struct Resolver<'markdown, 'manifest> {
-    manifest: &'manifest ManifestFile,
+pub(super) struct Resolver<'cx, 'markdown> {
+    cx: &'cx PackageSyncContext<'cx>,
     scanner: Scanner<'markdown>,
 }
 
-impl<'markdown, 'manifest> Resolver<'markdown, 'manifest> {
-    pub(super) fn new(markdown: &'markdown str, manifest: &'manifest ManifestFile) -> Self {
+impl<'cx, 'markdown> Resolver<'cx, 'markdown> {
+    pub(super) fn new(cx: &'cx PackageSyncContext<'cx>, markdown: &'markdown str) -> Self {
         Self {
-            manifest,
+            cx,
             scanner: Scanner::new(markdown),
         }
     }
@@ -75,14 +75,14 @@ impl<'markdown, 'manifest> Resolver<'markdown, 'manifest> {
         let Some(chunk) = self.scanner.try_next()? else {
             return Ok(None);
         };
-        let resolved = resolve_specifier(chunk.value.specifier, self.manifest)?;
+        let resolved = resolve_specifier(chunk.value.specifier, &self.cx.config)?;
         Ok(Some(Spanned::new(resolved, chunk.span)))
     }
 }
 
 pub(super) fn resolve_specifier(
     specifier: Spanned<ReplaceSpecifier<'_>>,
-    manifest: &Manifest,
+    config: &CargoSyncRdme,
 ) -> Result<ResolvedReplaceSpecifier, ResolveMarkerError> {
     let kind = specifier.value.kind;
     let group = specifier.value.group;
@@ -105,7 +105,7 @@ pub(super) fn resolve_specifier(
         }
     }
 
-    let badge = &manifest.config().badge;
+    let badge = &config.badge;
     if let Some(group) = group {
         let (group, badges) = badge.groups.get_key_value(group.value).ok_or_else(|| {
             NoSuchBadgeGroupSnafu {
@@ -144,8 +144,8 @@ mod tests {
     use super::*;
 
     static CONFIG: &str = indoc::indoc! {"
-        [package.metadata.cargo-sync-rdme.badge.badges]
-        [package.metadata.cargo-sync-rdme.badge.badges-foo]
+        [badge.badges]
+        [badge.badges-foo]
     "};
 
     impl ResolvedReplaceSpecifier {
@@ -210,9 +210,9 @@ mod tests {
         config: &str,
     ) -> Result<ResolvedReplaceSpecifier, ResolveMarkerError> {
         let source_file = SourceFile::new_for_test("Cargo.toml", config);
-        let manifest = source_file.parse_as_toml::<Manifest>().unwrap();
+        let config = source_file.parse_as_toml::<CargoSyncRdme>().unwrap();
         let (specifier, _rest) = parse::parse_specifier(source).unwrap().unwrap();
-        resolve_specifier(specifier, &manifest)
+        resolve_specifier(specifier, &config)
     }
 
     #[test]

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -7,8 +7,8 @@ use tracing::Level;
 use vcs_modify_guard::{AllowOptions, ModificationSafety, UnsafeModificationReason};
 
 use crate::{
-    args::{FeatureSelection, FixArgs, Mode, RustdocToolchainArgs},
-    config::manifest::Manifest,
+    args::{Args, FeatureSelection, FixArgs, Mode, RustdocToolchainArgs},
+    config::manifest::{Manifest, package::metadata::CargoSyncRdme},
     diff,
     source::{ParseTomlError, SourceFile, SourceFileLoader, SourceFilePath},
 };
@@ -129,63 +129,92 @@ impl From<contents::CreateAllContentsError> for Box<SyncError> {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct SyncOptions<'a> {
-    pub(crate) mode: Mode,
-    pub(crate) verbosity: Option<Level>,
-    pub(crate) diff_stream: Stream,
-    pub(crate) fix: &'a FixArgs,
-    pub(crate) toolchain: &'a RustdocToolchainArgs,
-    pub(crate) feature: &'a FeatureSelection,
+pub(crate) struct PackageSyncContext<'a> {
+    mode: Mode,
+    verbosity: Option<Level>,
+    diff_stream: Stream,
+    fix: &'a FixArgs,
+    toolchain: &'a RustdocToolchainArgs,
+    feature: &'a FeatureSelection,
+    workspace: &'a Metadata,
+    package: &'a Package,
+    manifest: Manifest,
+    config: CargoSyncRdme,
 }
 
-pub(crate) fn sync_all(
-    workspace: &Metadata,
-    package: &Package,
-    options: &SyncOptions<'_>,
-) -> Result<(), Box<SyncError>> {
-    let manifest_loader = SourceFileLoader::from_path(workspace, &package.manifest_path);
-    let manifest_file =
-        manifest_loader
-            .load()
-            .with_context(|_source| ReadPackageManifestSnafu {
+impl<'a> PackageSyncContext<'a> {
+    pub(crate) fn load(
+        diff_stream: Stream,
+        args: &'a Args,
+        workspace: &'a Metadata,
+        package: &'a Package,
+    ) -> Result<Self, Box<SyncError>> {
+        let manifest_loader = SourceFileLoader::from_path(workspace, &package.manifest_path);
+        let manifest_file =
+            manifest_loader
+                .load()
+                .with_context(|_source| ReadPackageManifestSnafu {
+                    package: package.name.clone(),
+                    manifest: &manifest_loader,
+                })?;
+        let manifest = manifest_file
+            .parse_as_toml::<Manifest>()
+            .with_context(|_source| ParsePackageManifestSnafu {
                 package: package.name.clone(),
                 manifest: &manifest_loader,
             })?;
-    let manifest = manifest_file
-        .parse_as_toml::<Manifest>()
-        .with_context(|_source| ParsePackageManifestSnafu {
-            package: package.name.clone(),
-            manifest: &manifest_loader,
-        })?;
-    let _span = tracing::info_span!("sync", "{}", package.name).entered();
+        let config = manifest
+            .package
+            .as_ref()
+            .and_then(|p| p.metadata.as_ref())
+            .map(|m| &m.cargo_sync_rdme)
+            .cloned()
+            .unwrap_or_default();
+        Ok(Self {
+            diff_stream,
+            mode: args.mode.mode(),
+            verbosity: args.verbosity.into(),
+            fix: &args.fix,
+            toolchain: &args.toolchain,
+            feature: &args.feature,
+            workspace,
+            package,
+            manifest,
+            config,
+        })
+    }
+}
 
-    let paths = package_target_files(package, &manifest.config().extra_targets);
+impl From<&PackageSyncContext<'_>> for PackageName {
+    fn from(cx: &PackageSyncContext<'_>) -> Self {
+        cx.package.name.clone()
+    }
+}
 
-    ensure!(
-        !paths.is_empty(),
-        NoTargetFilesFoundSnafu {
-            package: package.name.clone(),
-        }
-    );
+pub(crate) fn sync_all(cx: &PackageSyncContext<'_>) -> Result<(), Box<SyncError>> {
+    let _span = tracing::info_span!("sync", "{}", cx.package.name).entered();
+
+    let paths = package_target_files(cx);
+
+    ensure!(!paths.is_empty(), NoTargetFilesFoundSnafu { package: cx });
 
     for path in paths {
         tracing::info!("syncing markdown file: {path}");
 
         let markdown_loader =
-            SourceFileLoader::from_package_relative_path(workspace, package, path);
+            SourceFileLoader::from_package_relative_path(cx.workspace, cx.package, path);
         let mut markdown =
             markdown_loader
                 .load()
                 .with_context(|_source| ReadMarkdownFileSnafu {
-                    package: package.name.clone(),
+                    package: cx,
                     markdown: &markdown_loader,
                 })?;
 
-        let all_markers = marker::parse_markers(&markdown, &manifest, package)?;
+        let all_markers = marker::parse_markers(cx, &markdown)?;
 
         tracing::info!("creating replacement contents for markdown file: {path}");
-        let all_contents =
-            contents::create_all(all_markers, &manifest, workspace, package, options)?;
+        let all_contents = contents::create_all(cx, all_markers)?;
 
         let new_text = replace::replace_all(markdown.text(), &all_contents);
 
@@ -195,13 +224,13 @@ pub(crate) fn sync_all(
             continue;
         }
 
-        match options.mode {
+        match cx.mode {
             Mode::Check => {
                 tracing::warn!("markdown file is not up to date: {path}");
-                diff::write_pretty_diff(options.diff_stream, markdown.text(), &new_text)
+                diff::write_pretty_diff(cx.diff_stream, markdown.text(), &new_text)
                     .context(WriteDiffSnafu)?;
                 return Err(CheckFailedSnafu {
-                    package: package.name.clone(),
+                    package: cx.package.name.clone(),
                     markdown: &markdown,
                 }
                 .build()
@@ -211,11 +240,11 @@ pub(crate) fn sync_all(
         }
 
         // Update README if allowed
-        check_update_allowed(&markdown, package, options.fix)?;
+        check_update_allowed(&markdown, cx.package, cx.fix)?;
         markdown
             .replace_file_content(new_text.into())
             .with_context(|_source_| WriteMarkdownFileSnafu {
-                package: package.name.clone(),
+                package: cx.package.name.clone(),
                 markdown: &markdown,
             })?;
 
@@ -225,20 +254,15 @@ pub(crate) fn sync_all(
     Ok(())
 }
 
-type ManifestFile = Manifest;
-
-fn package_target_files<'a, P>(package: &'a Package, extra_targets: &'a [P]) -> Vec<&'a Utf8Path>
-where
-    P: AsRef<Utf8Path>,
-{
+fn package_target_files<'a>(cx: &'a PackageSyncContext<'_>) -> Vec<&'a Utf8Path> {
     let mut paths = vec![];
-    paths.extend(package.readme.as_deref());
-    paths.extend(extra_targets.iter().map(AsRef::as_ref));
+    paths.extend(cx.package.readme.as_deref());
+    paths.extend(cx.config.extra_targets.iter().map(Utf8Path::new));
     paths
 }
 
 fn check_update_allowed(
-    markdown: &SourceFile<'_>,
+    markdown: &SourceFile,
     package: &Package,
     options: &FixArgs,
 ) -> Result<(), Box<SyncError>> {

--- a/tests/fixtures/snapshots/basic_config_error/root.invalid-value.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/root.invalid-value.stderr.term.svg
@@ -1,9 +1,8 @@
-<svg width="740px" height="326px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .fg-magenta { fill: #AA00AA }
     .fg-red { fill: #AA0000 }
     .container {
@@ -23,39 +22,27 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
+    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse package `root` manifest: Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> TOML parse error: invalid type: boolean `false`, expected a</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> string or a seq</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:11:17</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ extra-targets = false</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse package `root` manifest: Cargo.toml</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>    · </tspan><tspan class="fg-magenta bold">                ─────</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> TOML parse error: invalid type: boolean `false`, expected a</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-red">      </tspan><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> string or a seq</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-red">      </tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:11:17</tspan><tspan>]</tspan>
+    <tspan x="10px" y="190px">
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
-</tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ extra-targets = false</tspan>
-</tspan>
-    <tspan x="10px" y="244px"><tspan class="fg-red">      </tspan><tspan>    · </tspan><tspan class="fg-magenta bold">                ─────</tspan>
-</tspan>
-    <tspan x="10px" y="262px"><tspan class="fg-red">      </tspan><tspan>    ╰────</tspan>
-</tspan>
-    <tspan x="10px" y="280px"><tspan class="fg-red">      </tspan>
-</tspan>
-    <tspan x="10px" y="298px">
-</tspan>
-    <tspan x="10px" y="316px">
+    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/basic_config_error/root.unknown-field.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/root.unknown-field.stderr.term.svg
@@ -1,9 +1,8 @@
-<svg width="740px" height="326px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .fg-magenta { fill: #AA00AA }
     .fg-red { fill: #AA0000 }
     .container {
@@ -23,39 +22,27 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
+    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse package `root` manifest: Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> TOML parse error: unknown field `unknown`, expected one of</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `extra-targets`, `badge`, `rustdoc`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:11:1</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ unknown = true</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse package `root` manifest: Cargo.toml</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>    · </tspan><tspan class="fg-magenta bold">───────</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> TOML parse error: unknown field `unknown`, expected one of</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-red">      </tspan><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `extra-targets`, `badge`, `rustdoc`</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-red">      </tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:11:1</tspan><tspan>]</tspan>
+    <tspan x="10px" y="190px">
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
-</tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ unknown = true</tspan>
-</tspan>
-    <tspan x="10px" y="244px"><tspan class="fg-red">      </tspan><tspan>    · </tspan><tspan class="fg-magenta bold">───────</tspan>
-</tspan>
-    <tspan x="10px" y="262px"><tspan class="fg-red">      </tspan><tspan>    ╰────</tspan>
-</tspan>
-    <tspan x="10px" y="280px"><tspan class="fg-red">      </tspan>
-</tspan>
-    <tspan x="10px" y="298px">
-</tspan>
-    <tspan x="10px" y="316px">
+    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/basic_config_error/root.unknown-table.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/root.unknown-table.stderr.term.svg
@@ -1,9 +1,8 @@
-<svg width="740px" height="344px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="236px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .fg-magenta { fill: #AA00AA }
     .fg-red { fill: #AA0000 }
     .container {
@@ -23,41 +22,29 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
+    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse package `root` manifest: Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> TOML parse error: unknown field `unknown`, expected one of</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `extra-targets`, `badge`, `rustdoc`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:10:35</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ members = ["pkg-a", "pkg-b"]</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-b</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ [package.metadata.cargo-sync-rdme.unknown]</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse package `root` manifest: Cargo.toml</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>    · </tspan><tspan class="fg-magenta bold">                                  ───────</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> TOML parse error: unknown field `unknown`, expected one of</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ foo = true</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `extra-targets`, `badge`, `rustdoc`</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-red">      </tspan><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:10:35</tspan><tspan>]</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-red">      </tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ members = ["pkg-a", "pkg-b"]</tspan>
+    <tspan x="10px" y="208px">
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ [package.metadata.cargo-sync-rdme.unknown]</tspan>
-</tspan>
-    <tspan x="10px" y="244px"><tspan class="fg-red">      </tspan><tspan>    · </tspan><tspan class="fg-magenta bold">                                  ───────</tspan>
-</tspan>
-    <tspan x="10px" y="262px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ foo = true</tspan>
-</tspan>
-    <tspan x="10px" y="280px"><tspan class="fg-red">      </tspan><tspan>    ╰────</tspan>
-</tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-red">      </tspan>
-</tspan>
-    <tspan x="10px" y="316px">
-</tspan>
-    <tspan x="10px" y="334px">
+    <tspan x="10px" y="226px">
 </tspan>
   </text>
 


### PR DESCRIPTION
## Summary
- refactor sync processing around a new per-package `PackageSyncContext`
- load each selected package's manifest and `cargo-sync-rdme` config up front
- simplify content and marker generation code to read package, workspace, manifest, and config state from one context object
- update UI snapshots for the changed root config error timing/output

## Motivation
This is a first step toward upcoming changes such as:
- supporting workspace metadata in `Cargo.toml`
- adding command-line arguments to override config values
- making default behavior configurable when command-line arguments are omitted

Centralizing per-package state makes those follow-up changes easier to implement without threading more parameters through the sync pipeline.

## Behavior notes
As part of this refactor, the command now constructs each selected package's sync context before starting sync work.

This means manifest/config loading and parse failures are reported before any markdown files are updated. Failures can still occur later during sync itself, for example while reading markdown, building rustdoc, or writing files.

This behavior change is incidental to the refactor and is not intended to define a new stable user-facing guarantee.

## Validation
- `cargo test`
- `diagnostics` in Zed: no errors or warnings