### PR TITLE
Escape rustdoc marker-like comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Pass `--features` (not the invalid `--feature`) when forwarding feature selection to Cargo for rustdoc builds.
+* Escape `<!-- cargo-sync-rdme ... -->`-like comments in rustdoc output so repeated synchronization remains idempotent.
 * Resolve intra-doc links to workspace packages even when rustdoc does not provide an `html_root_url` for that package, instead of leaving those references unresolved.
 * When using `--toolchain`, intra-doc links to Rust standard-library items now generate links to the documentation for the toolchain running Cargo instead of the version selected by `--toolchain`.
 

--- a/src/sync/contents/rustdoc/escape_markers.rs
+++ b/src/sync/contents/rustdoc/escape_markers.rs
@@ -1,0 +1,14 @@
+use pulldown_cmark::Event;
+
+use crate::sync::marker;
+
+pub(super) fn convert<'a, I>(events: I) -> impl Iterator<Item = Event<'a>>
+where
+    I: IntoIterator<Item = Event<'a>>,
+{
+    events.into_iter().map(|event| {
+        let mut event = event;
+        marker::escape_marker(&mut event);
+        event
+    })
+}

--- a/src/sync/contents/rustdoc/mod.rs
+++ b/src/sync/contents/rustdoc/mod.rs
@@ -16,6 +16,7 @@ use crate::{
 mod build;
 mod code_block;
 mod document;
+mod escape_markers;
 mod heading;
 mod intra_link;
 
@@ -61,6 +62,7 @@ pub(super) fn create(cx: &PackageSyncContext<'_>) -> Result<String, CreateRustdo
     let events = mapper.build_parser(main_body_opts());
     let events = heading::convert(events);
     let events = code_block::convert(events);
+    let events = escape_markers::convert(events);
 
     let output = render(events)?;
     Ok(output)

--- a/src/sync/marker/mod.rs
+++ b/src/sync/marker/mod.rs
@@ -2,6 +2,7 @@ use std::{fmt, sync::Arc};
 
 use cargo_metadata::PackageName;
 use miette::NamedSource;
+use pulldown_cmark::Event;
 use snafu::{Snafu, ensure};
 
 use crate::{
@@ -96,4 +97,8 @@ pub(super) fn make_marked_contents(contents: &Contents) -> String {
     } else {
         format!("<!-- {MAGIC} {specifier} [[ -->\n{text}<!-- {MAGIC} ]] -->")
     }
+}
+
+pub(super) fn escape_marker(event: &mut Event<'_>) {
+    parse::escape_marker_comment(event);
 }

--- a/src/sync/marker/parse.rs
+++ b/src/sync/marker/parse.rs
@@ -36,6 +36,24 @@ pub(crate) enum ParseMarkerError {
     },
 }
 
+pub(super) fn escape_marker_comment(event: &mut Event<'_>) {
+    let Event::Html(html) = event else {
+        return;
+    };
+    let escaped = (|| {
+        let html = Spanned::new(html.as_ref(), 0..html.len());
+        let comment_body = trim_comment(html)?;
+        // check if the comment body starts with the magic string
+        trim_magic(comment_body)?;
+        let mut escaped = html.value.to_owned();
+        escaped.insert(comment_body.span.start, '_');
+        Some(escaped)
+    })();
+    if let Some(escaped) = escaped {
+        *html = escaped.into();
+    }
+}
+
 #[derive(Debug)]
 pub(super) struct MarkerParser<'a> {
     markdown: &'a str,
@@ -634,5 +652,40 @@ mod tests {
         source.assert_source_span(span, "\0");
 
         assert!(parser.try_next().unwrap().is_none());
+    }
+
+    fn escape(html: &str) -> String {
+        let mut event = Event::Html(html.into());
+        escape_marker_comment(&mut event);
+        let Event::Html(escaped) = event else {
+            panic!("unexpected event: {event:?}");
+        };
+        escaped.into_string()
+    }
+
+    #[test]
+    fn escape_marker_comment_escapes_marker_like_comments() {
+        assert_eq!(
+            escape("<!-- cargo-sync-rdme kind:group -->"),
+            "<!-- _cargo-sync-rdme kind:group -->"
+        );
+        assert_eq!(
+            escape("<!--cargo-sync-rdme kind:group-->"),
+            "<!--_cargo-sync-rdme kind:group-->"
+        );
+        assert_eq!(
+            escape("<!--    cargo-sync-rdme kind:group-->"),
+            "<!--    _cargo-sync-rdme kind:group-->"
+        );
+        assert_eq!(
+            escape("<!-- cargo-sync-rdme-->"),
+            "<!-- _cargo-sync-rdme-->"
+        );
+        assert_eq!(
+            escape("<!-- cargo-sync-rdme invalid-->"),
+            "<!-- _cargo-sync-rdme invalid-->"
+        );
+        assert_eq!(escape("<!-- other comment -->"), "<!-- other comment -->");
+        assert_eq!(escape("normal text"), "normal text");
     }
 }

--- a/tests/fixtures/packages/empty/README.md
+++ b/tests/fixtures/packages/empty/README.md
@@ -1,3 +1,3 @@
-# link showcase
+# empty
 
 <!-- cargo-sync-rdme rustdoc -->

--- a/tests/idempotency.rs
+++ b/tests/idempotency.rs
@@ -1,0 +1,47 @@
+//! Integration test to ensure that `cargo-sync-rdme` remains idempotent when rustdoc output contains `<!-- cargo-sync-rdme ... -->`-like comments.
+
+use rstest::rstest;
+use similar_asserts::assert_eq;
+use test_helper::{self as helper, SPAN_END_MARKER, SPAN_START_MARKER, Workspace};
+
+#[rstest]
+#[case::valid_marker("title")]
+#[case::invalid_marker("invalid")]
+fn generated_markdown_is_idempotent_when_rustdoc_contains_marker_like_comment(
+    #[case] marker_body: &str,
+) {
+    let crate_name = "empty";
+    let workspace = Workspace::from_fixture(crate_name);
+    let readme_path = workspace
+        .metadata()
+        .root_package()
+        .unwrap()
+        .readme()
+        .unwrap();
+
+    let doc_comment = indoc::formatdoc! {r"
+        //! {SPAN_START_MARKER}
+        //! * FIRST ITEM
+        //! <!-- cargo-sync-rdme {marker_body} -->
+        //! * SECOND ITEM
+        //! {SPAN_END_MARKER}
+    "};
+
+    workspace.insert_crate_doc_comment("src/lib.rs", &doc_comment);
+
+    workspace.cargo_sync_rdme_default().assert().success();
+    workspace.cargo_doc_default().assert().success();
+
+    let md_items = helper::collect_list_item_from_markdown_file(&readme_path);
+    assert_eq!(md_items, ["FIRST ITEM", "SECOND ITEM"]);
+
+    let readme_content = std::fs::read_to_string(&readme_path).unwrap();
+
+    // Run sync again to ensure the README remains unchanged.
+    workspace.cargo_sync_rdme_default().assert().success();
+
+    assert_eq!(
+        std::fs::read_to_string(&readme_path).unwrap(),
+        readme_content
+    );
+}


### PR DESCRIPTION
## Summary
- escape `<!-- cargo-sync-rdme ... -->`-like comments in rustdoc-derived Markdown before rendering README output
- keep repeated synchronization idempotent even when crate docs contain marker-like comments, including comments that look like valid markers
- add unit and integration coverage for valid/invalid marker-like comments and whitespace variants
- document the fix in `CHANGELOG.md`

## Motivation
Marker-like HTML comments emitted from crate documentation could be reinterpreted as sync markers on a later `cargo sync-rdme` run. That broke idempotency and could also trigger marker parse or nesting errors.

## Validation
- `cargo test`

## Impact
Generated README content now escapes marker-like comments from rustdoc output by inserting an underscore into the marker magic so later runs do not treat those comments as sync markers.
