### PR TITLE
Align Spanned equality with toml::Spanned

### DIFF
--- a/src/source/spanned.rs
+++ b/src/source/spanned.rs
@@ -1,5 +1,7 @@
 use std::{
+    cmp,
     fmt::{self, Display},
+    hash::{self, Hash},
     ops::Deref,
     range::{Range, legacy},
 };
@@ -7,10 +9,51 @@ use std::{
 use miette::SourceSpan;
 use serde::{Deserialize, Deserializer};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct Spanned<T> {
     pub(crate) value: T,
     pub(crate) span: Range<usize>,
+}
+
+impl<T> PartialEq for Spanned<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl<T> Eq for Spanned<T> where T: Eq {}
+
+impl<T> PartialOrd for Spanned<T>
+where
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+}
+
+impl<T> Ord for Spanned<T>
+where
+    T: Ord,
+{
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+impl<T> Hash for Spanned<T>
+where
+    T: Hash,
+{
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: hash::Hasher,
+    {
+        self.value.hash(state);
+    }
 }
 
 impl<T> Spanned<T> {


### PR DESCRIPTION
## Summary
- make `Spanned<T>` compare and hash by `value` rather than by source `span`
- add `PartialOrd`, `Ord`, and `Hash` implementations that follow the same value-only semantics
- align this wrapper's behavior with `toml::Spanned<T>` so the local type is less misleading

## Motivation
`Spanned<T>` is used as a wrapper around a value with source-location metadata. Treating the span as part of equality made the type behave differently from `toml::Spanned<T>` and unlike smart-pointer-style wrappers, which made the API more surprising than intended.

## Validation
- `cargo test`
- user-reported: lint passed