### PR TITLE
Reuse parsed TOML for config loading

### DIFF
--- a/src/config/badge/item.rs
+++ b/src/config/badge/item.rs
@@ -261,7 +261,7 @@ mod tests {
               unknown = true,
             }
         "});
-        testing::parse_manifest_err(&source, "unknown field `unknown`", "unknown");
+        testing::deserialize_config_err(&source, "unknown field `unknown`", "unknown");
     }
 
     #[test]
@@ -319,7 +319,7 @@ mod tests {
                   {field} = 34,
                 }}
             "});
-            testing::parse_manifest_err(&source, "invalid type: integer `34`", "34");
+            testing::deserialize_config_err(&source, "invalid type: integer `34`", "34");
         }
     }
 
@@ -354,14 +354,14 @@ mod tests {
               license = { link = 34 },
             }
         "});
-        testing::parse_manifest_err(&source, "invalid type: integer `34`", "34");
+        testing::deserialize_config_err(&source, "invalid type: integer `34`", "34");
 
         let source = testing::badge_manifest(indoc! {r"
             badges = {
               license = { unknown = true },
             }
         "});
-        testing::parse_manifest_err(&source, "unknown field `unknown`", "unknown");
+        testing::deserialize_config_err(&source, "unknown field `unknown`", "unknown");
     }
 
     #[test]
@@ -414,14 +414,14 @@ mod tests {
               github-actions = { workflows = 34 },
             }
         "});
-        testing::parse_manifest_err(&source, "invalid type: integer `34`", "34");
+        testing::deserialize_config_err(&source, "invalid type: integer `34`", "34");
 
         let source = testing::badge_manifest(indoc! {r"
             badges = {
               github-actions = { workflows = { unknown = true } },
             }
         "});
-        testing::parse_manifest_err(&source, "unknown field `unknown`", "unknown");
+        testing::deserialize_config_err(&source, "unknown field `unknown`", "unknown");
     }
 
     #[test]
@@ -452,13 +452,13 @@ mod tests {
               codecov = { component = 34 },
             }
         "});
-        testing::parse_manifest_err(&source, "invalid type: integer `34`", "34");
+        testing::deserialize_config_err(&source, "invalid type: integer `34`", "34");
 
         let source = testing::badge_manifest(indoc! {r"
             badges = {
               codecov = { unknown = true },
             }
         "});
-        testing::parse_manifest_err(&source, "unknown field `unknown`", "unknown");
+        testing::deserialize_config_err(&source, "unknown field `unknown`", "unknown");
     }
 }

--- a/src/config/badge/mod.rs
+++ b/src/config/badge/mod.rs
@@ -211,12 +211,12 @@ mod tests {
         let source = testing::badge_manifest(indoc! {r#"
             style = "invalid"
         "#});
-        testing::parse_manifest_err(&source, "unknown variant `invalid`", r#""invalid""#);
+        testing::deserialize_config_err(&source, "unknown variant `invalid`", r#""invalid""#);
 
         let source = testing::badge_manifest(indoc! {r"
             style = false
         "});
-        testing::parse_manifest_err(&source, "wanted string or table", "false");
+        testing::deserialize_config_err(&source, "wanted string or table", "false");
     }
 
     #[test]
@@ -224,28 +224,28 @@ mod tests {
         let source = testing::badge_manifest(indoc! {"
             unknown = true
         "});
-        testing::parse_manifest_err(&source, "unknown field `unknown`", "unknown");
+        testing::deserialize_config_err(&source, "unknown field `unknown`", "unknown");
     }
 
     #[test]
     fn deserialize_badge_rejects_invalid_group_names() {
         let source = testing::badge_manifest("badges- = {}");
-        testing::parse_manifest_err(&source, "invalid field name `badges-`", "badges-");
+        testing::deserialize_config_err(&source, "invalid field name `badges-`", "badges-");
 
         let source = testing::badge_manifest("badges-123 = {}");
-        testing::parse_manifest_err(&source, "invalid field name `badges-123`", "badges-123");
+        testing::deserialize_config_err(&source, "invalid field name `badges-123`", "badges-123");
 
         let source = testing::badge_manifest(r#""badges-!" = {}"#);
-        testing::parse_manifest_err(&source, "invalid field name `badges-!`", r#""badges-!""#);
+        testing::deserialize_config_err(&source, "invalid field name `badges-!`", r#""badges-!""#);
 
         let source = testing::badge_manifest(r#""badges- " = {}"#);
-        testing::parse_manifest_err(&source, "invalid field name `badges- `", r#""badges- ""#);
+        testing::deserialize_config_err(&source, "invalid field name `badges- `", r#""badges- ""#);
 
         let source = testing::badge_manifest(indoc! {"
             badges = {}
             badges-123 = {}
         "});
-        testing::parse_manifest_err(&source, "invalid field name `badges-123`", "badges-123");
+        testing::deserialize_config_err(&source, "invalid field name `badges-123`", "badges-123");
     }
 
     #[test]
@@ -255,14 +255,14 @@ mod tests {
             badges = {}
             badges = {}
         "});
-        testing::parse_manifest_err(&source, "duplicate key", "badges");
+        testing::parse_config_err(&source, "duplicate key", "badges");
 
         let source = testing::badge_manifest(indoc! {"
             badges-group1 = {}
             badges-group2 = {}
             badges-group2 = {}
         "});
-        testing::parse_manifest_err(&source, "duplicate key", "badges-group2");
+        testing::parse_config_err(&source, "duplicate key", "badges-group2");
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,34 +1,10 @@
 use serde::Deserialize;
 
-use crate::source::{DeserializeAsTomlError, SourceFile};
-
 pub(crate) mod badge;
 mod de;
 pub(crate) mod rustdoc;
 #[cfg(test)]
 mod testing;
-
-// To detect items that do not have explicit values, wrap cargo's standard
-// configuration items in Options.
-#[derive(Debug, Clone, Default, Deserialize)]
-struct Manifest {
-    #[serde(default)]
-    package: Option<Package>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct Package {
-    #[serde(default)]
-    metadata: Option<Metadata>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct Metadata {
-    #[serde(default)]
-    cargo_sync_rdme: Option<Config>,
-}
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
@@ -39,16 +15,4 @@ pub(crate) struct Config {
     pub(crate) badge: badge::Badge,
     #[serde(default)]
     pub(crate) rustdoc: rustdoc::Rustdoc,
-}
-
-impl Config {
-    pub(crate) fn parse(manifest_file: &SourceFile) -> Result<Self, DeserializeAsTomlError> {
-        let manifest = manifest_file.deserialize_as_toml::<Manifest>()?;
-        let config = manifest
-            .package
-            .and_then(|package| package.metadata)
-            .and_then(|metadata| metadata.cargo_sync_rdme)
-            .unwrap_or_default();
-        Ok(config)
-    }
 }

--- a/src/config/testing.rs
+++ b/src/config/testing.rs
@@ -1,7 +1,8 @@
 use indoc::formatdoc;
 
 use crate::{
-    config::{Manifest, badge::Badge, rustdoc::Rustdoc},
+    config::{badge::Badge, rustdoc::Rustdoc},
+    manifest::Manifest,
     source::SourceFile,
 };
 
@@ -27,45 +28,46 @@ pub(crate) fn rustdoc_manifest(rustdoc: &str) -> String {
     "#}
 }
 
-pub(crate) fn parse_manifest(source: &str) -> Manifest {
-    let source_file = SourceFile::new_for_test("Cargo.toml", source);
-    source_file.deserialize_as_toml().unwrap()
+#[track_caller]
+fn manifest(source: &str) -> Manifest {
+    let source = SourceFile::new_for_test("Cargo.toml", source);
+    Manifest::new_for_test(&source).unwrap()
 }
 
 #[track_caller]
-pub(crate) fn parse_manifest_err(source: &str, prefix: &str, spanned: &str) {
-    let source_file = SourceFile::new_for_test("Cargo.toml", source);
-    let err = source_file.deserialize_as_toml::<Manifest>().unwrap_err();
-    assert!(
-        err.message.starts_with(prefix),
-        "message: {:?}",
-        err.message
-    );
-    let label = err.label.unwrap();
+pub(crate) fn parse_config_err(source: &str, prefix: &str, spanned: &str) {
+    let source = SourceFile::new_for_test("Cargo.toml", source);
+    let (message, label, source_code) = Manifest::new_for_test(&source)
+        .unwrap_err()
+        .into_toml()
+        .into_parse_toml();
+    assert!(message.starts_with(prefix), "message: {message:?}");
+    let label = label.unwrap();
+    let span = label.offset()..label.offset() + label.len();
+    assert_eq!(source.text().get(span).unwrap(), spanned);
+    assert_eq!(source_code.name(), "Cargo.toml");
+}
+
+#[track_caller]
+pub(crate) fn deserialize_config_err(source: &str, prefix: &str, spanned: &str) {
+    let (message, label, source_code) = manifest(source)
+        .package_config()
+        .unwrap_err()
+        .into_toml()
+        .into_deserialize_toml();
+    assert!(message.starts_with(prefix), "message: {message:?}");
+    let label = label.unwrap();
     let span = label.offset()..label.offset() + label.len();
     assert_eq!(source.get(span).unwrap(), spanned);
+    assert_eq!(source_code.name(), "Cargo.toml");
 }
 
 #[track_caller]
 pub(crate) fn parse_badge(source: &str) -> Badge {
-    parse_manifest(source)
-        .package
-        .unwrap()
-        .metadata
-        .unwrap()
-        .cargo_sync_rdme
-        .unwrap()
-        .badge
+    manifest(source).package_config().unwrap().unwrap().badge
 }
 
 #[track_caller]
 pub(crate) fn parse_rustdoc(source: &str) -> Rustdoc {
-    parse_manifest(source)
-        .package
-        .unwrap()
-        .metadata
-        .unwrap()
-        .cargo_sync_rdme
-        .unwrap()
-        .rustdoc
+    manifest(source).package_config().unwrap().unwrap().rustdoc
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,10 +1,13 @@
-use std::{str::FromStr as _, sync::Arc};
+use std::{borrow::Borrow, io, str::FromStr as _, sync::Arc};
 
 use miette::{Diagnostic, NamedSource, SourceSpan};
 use snafu::Snafu;
 use strum::{EnumString, IntoStaticStr};
 
-use crate::source::{FindEntryError, TomlDocument};
+use crate::{
+    config::Config,
+    source::{ParseTomlResultExt as _, SourceFileLoader, TomlDocument, TomlError},
+};
 
 #[derive(Debug)]
 pub(crate) struct Manifest {
@@ -12,8 +15,26 @@ pub(crate) struct Manifest {
 }
 
 impl Manifest {
-    pub(crate) fn new(document: TomlDocument) -> Self {
-        Self { document }
+    pub(crate) fn load(loader: &SourceFileLoader) -> Result<Self, Box<ManifestError>> {
+        let file = loader.load()?;
+        let document = file.parse_as_toml()?;
+        Ok(Self { document })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(
+        source: &crate::source::SourceFile,
+    ) -> Result<Self, Box<ManifestError>> {
+        let document = source.parse_as_toml()?;
+        Ok(Self { document })
+    }
+
+    pub(crate) fn package_config(&self) -> Result<Option<Config>, Box<ManifestError>> {
+        let config = self
+            .document
+            .deserialize_entry(&["package", "metadata", "cargo-sync-rdme"])
+            .ignore_missing_key_error()?;
+        Ok(config)
     }
 
     pub(crate) fn maintenance_status(&self) -> Result<MaintenanceStatus, Box<ManifestError>> {
@@ -36,11 +57,16 @@ impl Manifest {
 #[derive(Debug, Snafu, Diagnostic)]
 pub(crate) enum ManifestError {
     #[snafu(transparent)]
+    ReadManifest {
+        #[snafu(source)]
+        source: io::Error,
+    },
+    #[snafu(transparent)]
     #[diagnostic(transparent)]
-    FindEntry {
+    Toml {
         #[snafu(source)]
         #[diagnostic_source]
-        source: Box<FindEntryError>,
+        source: Box<TomlError>,
     },
     #[snafu(display("invalid value for {kind}: {value}"))]
     InvalidValue {
@@ -53,8 +79,20 @@ pub(crate) enum ManifestError {
     },
 }
 
-impl From<Box<FindEntryError>> for Box<ManifestError> {
-    fn from(source: Box<FindEntryError>) -> Self {
+impl Borrow<dyn Diagnostic> for Box<ManifestError> {
+    fn borrow(&self) -> &(dyn Diagnostic + 'static) {
+        &**self
+    }
+}
+
+impl From<io::Error> for Box<ManifestError> {
+    fn from(source: io::Error) -> Self {
+        Box::new(source.into())
+    }
+}
+
+impl From<Box<TomlError>> for Box<ManifestError> {
+    fn from(source: Box<TomlError>) -> Self {
         Box::new(source.into())
     }
 }
@@ -62,8 +100,8 @@ impl From<Box<FindEntryError>> for Box<ManifestError> {
 impl ManifestError {
     #[cfg(test)]
     #[track_caller]
-    pub(crate) fn into_find_entry(self) -> FindEntryError {
-        let ManifestError::FindEntry { source } = self else {
+    pub(crate) fn into_toml(self) -> TomlError {
+        let ManifestError::Toml { source } = self else {
             panic!("unexpected error: {self:?}");
         };
         *source
@@ -123,8 +161,7 @@ mod tests {
             maintenance = { status = "actively-developed" }
         "#};
         let source = SourceFile::new_for_test("Cargo.toml", source);
-        let document = source.parse_as_toml().unwrap();
-        let manifest = Manifest::new(document);
+        let manifest = Manifest::new_for_test(&source).unwrap();
         let status = manifest.maintenance_status().unwrap();
         assert_eq!(status, MaintenanceStatus::ActivelyDeveloped);
     }
@@ -137,12 +174,11 @@ mod tests {
             version = "0.1.0"
         "#};
         let source = SourceFile::new_for_test("Cargo.toml", source);
-        let document = source.parse_as_toml().unwrap();
-        let manifest = Manifest::new(document);
+        let manifest = Manifest::new_for_test(&source).unwrap();
         let (key, span, source_code) = manifest
             .maintenance_status()
             .unwrap_err()
-            .into_find_entry()
+            .into_toml()
             .into_missing_top_level_key();
         assert_eq!(key, "badges");
         source.assert_source_span(span, "");
@@ -156,12 +192,11 @@ mod tests {
             [badges]
         "#};
         let source = SourceFile::new_for_test("Cargo.toml", source);
-        let document = source.parse_as_toml().unwrap();
-        let manifest = Manifest::new(document);
+        let manifest = Manifest::new_for_test(&source).unwrap();
         let (key, table, span, source_code) = manifest
             .maintenance_status()
             .unwrap_err()
-            .into_find_entry()
+            .into_toml()
             .into_missing_key_in_table();
         assert_eq!(key, "maintenance");
         assert_eq!(source::render_toml_path(&table), "badges");
@@ -177,12 +212,11 @@ mod tests {
             maintenance = {}
         "#};
         let source = SourceFile::new_for_test("Cargo.toml", source);
-        let document = source.parse_as_toml().unwrap();
-        let manifest = Manifest::new(document);
+        let manifest = Manifest::new_for_test(&source).unwrap();
         let (key, table, span, source_code) = manifest
             .maintenance_status()
             .unwrap_err()
-            .into_find_entry()
+            .into_toml()
             .into_missing_key_in_table();
         assert_eq!(key, "status");
         assert_eq!(source::render_toml_path(&table), "badges.maintenance");
@@ -201,8 +235,7 @@ mod tests {
             maintenance = { status = "invalid" }
         "#};
         let source = SourceFile::new_for_test("Cargo.toml", source);
-        let document = source.parse_as_toml().unwrap();
-        let manifest = Manifest::new(document);
+        let manifest = Manifest::new_for_test(&source).unwrap();
         let (kind, value, span, source_code) = manifest
             .maintenance_status()
             .unwrap_err()

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -19,7 +19,7 @@ use tempfile::NamedTempFile;
 #[cfg(test)]
 use crate::source::Spanned;
 use crate::{
-    source::toml::{ParseTomlError, TomlDocument},
+    source::toml::{TomlDocument, TomlError},
     traits::PackageExt as _,
 };
 
@@ -127,16 +127,6 @@ pub(crate) struct DeserializeAsJsonError {
     label: SourceSpan,
 }
 
-#[derive(Debug, Snafu, Diagnostic)]
-#[snafu(display("TOML parse error: {message}"))]
-pub(crate) struct DeserializeAsTomlError {
-    pub(crate) message: String,
-    #[source_code]
-    pub(crate) source_code: NamedSource<Arc<str>>,
-    #[label]
-    pub(crate) label: Option<SourceSpan>,
-}
-
 impl SourceFile {
     #[cfg(test)]
     pub(crate) fn new_for_test<P, T>(workspace_relative_path: P, text: T) -> Self
@@ -206,25 +196,7 @@ impl SourceFile {
         })
     }
 
-    pub(crate) fn deserialize_as_toml<'a, T>(&'a self) -> Result<T, DeserializeAsTomlError>
-    where
-        T: Deserialize<'a>,
-    {
-        let _reset = set_current_source_file(self.to_source_file_ref());
-        toml::from_str(self.text()).map_err(|err| {
-            let message = err.message();
-            let source_code = self.to_named_source().with_language("toml");
-            let label = err.span().map(SourceSpan::from);
-            DeserializeAsTomlSnafu {
-                message,
-                source_code,
-                label,
-            }
-            .build()
-        })
-    }
-
-    pub(crate) fn parse_as_toml(&self) -> Result<TomlDocument, Box<ParseTomlError>> {
+    pub(crate) fn parse_as_toml(&self) -> Result<TomlDocument, Box<TomlError>> {
         let _reset = set_current_source_file(self.to_source_file_ref());
         TomlDocument::parse(self.to_source_file_ref())
     }

--- a/src/source/toml.rs
+++ b/src/source/toml.rs
@@ -2,7 +2,9 @@ use std::{borrow::Borrow, fmt, sync::Arc};
 
 use miette::{Diagnostic, NamedSource, SourceSpan};
 use self_cell::self_cell;
-use snafu::{OptionExt as _, Snafu};
+use serde::Deserialize;
+use snafu::Snafu;
+use strum::IntoStaticStr;
 use toml::de;
 
 use crate::source::{SourceFileRef, Spanned};
@@ -25,71 +27,24 @@ self_cell! {
     impl { Debug }
 }
 
-#[derive(Debug, Snafu, Diagnostic)]
-#[snafu(display("TOML parse error: {message}"))]
-pub(crate) struct ParseTomlError {
-    pub(crate) message: String,
-    #[source_code]
-    pub(crate) source_code: NamedSource<Arc<str>>,
-    #[label]
-    pub(crate) label: Option<SourceSpan>,
-}
-
-impl Borrow<dyn Diagnostic> for Box<ParseTomlError> {
-    fn borrow(&self) -> &(dyn Diagnostic + 'static) {
-        &**self
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ValueType {
-    String,
-    Integer,
-    Float,
-    Boolean,
-    Datetime,
-    Array,
-    Table,
-}
-
-impl ValueType {
-    pub(crate) fn of(value: &de::DeValue<'_>) -> Self {
-        match value {
-            de::DeValue::String(_) => Self::String,
-            de::DeValue::Integer(_) => Self::Integer,
-            de::DeValue::Float(_) => Self::Float,
-            de::DeValue::Boolean(_) => Self::Boolean,
-            de::DeValue::Datetime(_) => Self::Datetime,
-            de::DeValue::Array(_) => Self::Array,
-            de::DeValue::Table(_) => Self::Table,
-        }
-    }
-
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::String => "string",
-            Self::Integer => "integer",
-            Self::Float => "float",
-            Self::Boolean => "boolean",
-            Self::Datetime => "datetime",
-            Self::Array => "array",
-            Self::Table => "table",
-        }
-    }
-}
-
-impl fmt::Display for ValueType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.as_str().fmt(f)
-    }
-}
-
-pub(crate) fn render_toml_path(path: &[String]) -> String {
-    path.join(".")
-}
-
 #[derive(Debug, Snafu, miette::Diagnostic)]
-pub(crate) enum FindEntryError {
+pub(crate) enum TomlError {
+    #[snafu(display("{message}"))]
+    ParseToml {
+        message: String,
+        #[source_code]
+        source_code: NamedSource<Arc<str>>,
+        #[label]
+        label: Option<SourceSpan>,
+    },
+    #[snafu(display("{message}"))]
+    DeserializeToml {
+        message: String,
+        #[source_code]
+        source_code: NamedSource<Arc<str>>,
+        #[label]
+        label: Option<SourceSpan>,
+    },
     #[snafu(display("missing top-level key `{key}`"))]
     MissingTopLevelKey {
         key: String,
@@ -119,7 +74,83 @@ pub(crate) enum FindEntryError {
     },
 }
 
-impl FindEntryError {
+impl Borrow<dyn Diagnostic> for Box<TomlError> {
+    fn borrow(&self) -> &(dyn Diagnostic + 'static) {
+        &**self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
+pub(crate) enum ValueType {
+    String,
+    Integer,
+    Float,
+    Boolean,
+    Datetime,
+    Array,
+    Table,
+}
+
+impl ValueType {
+    pub(crate) fn of(value: &de::DeValue<'_>) -> Self {
+        match value {
+            de::DeValue::String(_) => Self::String,
+            de::DeValue::Integer(_) => Self::Integer,
+            de::DeValue::Float(_) => Self::Float,
+            de::DeValue::Boolean(_) => Self::Boolean,
+            de::DeValue::Datetime(_) => Self::Datetime,
+            de::DeValue::Array(_) => Self::Array,
+            de::DeValue::Table(_) => Self::Table,
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        self.into()
+    }
+}
+
+impl fmt::Display for ValueType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+pub(crate) fn render_toml_path(path: &[String]) -> String {
+    path.join(".")
+}
+
+impl TomlError {
+    #[cfg(test)]
+    #[track_caller]
+    pub(crate) fn into_parse_toml(self) -> (String, Option<SourceSpan>, NamedSource<Arc<str>>) {
+        let Self::ParseToml {
+            message,
+            label,
+            source_code,
+        } = self
+        else {
+            panic!("unexpected error: {self:?}");
+        };
+        (message, label, source_code)
+    }
+
+    #[cfg(test)]
+    #[track_caller]
+    pub(crate) fn into_deserialize_toml(
+        self,
+    ) -> (String, Option<SourceSpan>, NamedSource<Arc<str>>) {
+        let Self::DeserializeToml {
+            message,
+            label,
+            source_code,
+        } = self
+        else {
+            panic!("unexpected error: {self:?}");
+        };
+        (message, label, source_code)
+    }
+
     #[cfg(test)]
     #[track_caller]
     pub(crate) fn into_missing_top_level_key(self) -> (String, SourceSpan, NamedSource<Arc<str>>) {
@@ -176,73 +207,165 @@ impl FindEntryError {
     }
 }
 
+pub(crate) trait ParseTomlResultExt {
+    type Item;
+    fn ignore_missing_key_error(self) -> Result<Option<Self::Item>, Box<TomlError>>;
+}
+
+impl<T> ParseTomlResultExt for Result<T, Box<TomlError>> {
+    type Item = T;
+
+    fn ignore_missing_key_error(self) -> Result<Option<Self::Item>, Box<TomlError>> {
+        match self {
+            Ok(value) => Ok(Some(value)),
+            Err(err) => match &*err {
+                TomlError::MissingTopLevelKey { .. } | TomlError::MissingKeyInTable { .. } => {
+                    Ok(None)
+                }
+                _ => Err(err),
+            },
+        }
+    }
+}
+
 fn build_toml_path(path: &[&str]) -> Vec<String> {
     path.iter().copied().map(ToOwned::to_owned).collect()
 }
 
 impl TomlDocument {
-    pub(crate) fn parse(source: SourceFileRef) -> Result<Self, Box<ParseTomlError>> {
+    pub(crate) fn parse(source: SourceFileRef) -> Result<Self, Box<TomlError>> {
         Ok(Self {
             inner: Inner::try_new(source, |source| {
                 de::DeTable::parse(&source.text).map_err(|err| {
                     let message = err.message();
                     let source_code = source.to_named_source().with_language("toml");
                     let label = err.span().map(SourceSpan::from);
-                    ParseTomlSnafu {
-                        message,
-                        source_code,
-                        label,
-                    }
-                    .build()
+                    Box::new(
+                        ParseTomlSnafu {
+                            message,
+                            source_code,
+                            label,
+                        }
+                        .build(),
+                    )
                 })
             })?,
         })
     }
 
     pub(crate) fn named_source(&self) -> NamedSource<Arc<str>> {
-        self.inner.borrow_owner().to_named_source()
+        self.inner
+            .borrow_owner()
+            .to_named_source()
+            .with_language("toml")
     }
 
     fn document(&self) -> Spanned<&de::DeTable<'_>> {
         self.inner.borrow_dependent().into()
     }
 
+    fn deserialize_toml_error(&self, err: &de::Error) -> TomlError {
+        let message = err.message();
+        let source_code = self.named_source();
+        let label = err.span().map(SourceSpan::from);
+        DeserializeTomlSnafu {
+            message,
+            source_code,
+            label,
+        }
+        .build()
+    }
+
+    fn missing_top_level_key_error(&self, key: &str) -> TomlError {
+        MissingTopLevelKeySnafu {
+            key,
+            span: self.document().source_span(),
+            source_code: self.named_source(),
+        }
+        .build()
+    }
+
+    fn missing_key_in_table_error(
+        &self,
+        key: &str,
+        table_path: &[&str],
+        value_key: Spanned<&de::DeString<'_>>,
+    ) -> TomlError {
+        MissingKeyInTableSnafu {
+            key,
+            table: build_toml_path(table_path),
+            span: value_key.source_span(),
+            source_code: self.named_source(),
+        }
+        .build()
+    }
+
+    fn unexpected_value_type_error(
+        &self,
+        path: &[&str],
+        expected: ValueType,
+        actual: Spanned<&de::DeValue<'_>>,
+    ) -> TomlError {
+        UnexpectedValueTypeSnafu {
+            path: build_toml_path(path),
+            expected,
+            actual: ValueType::of(actual.value),
+            span: actual.source_span(),
+            source_code: self.named_source(),
+        }
+        .build()
+    }
+
+    fn value_as_table<'a>(
+        &self,
+        value: Spanned<&'a de::DeValue<'a>>,
+        path: &[&str],
+    ) -> Result<Spanned<&'a de::DeTable<'a>>, Box<TomlError>> {
+        let table = value
+            .value
+            .as_table()
+            .ok_or_else(|| self.unexpected_value_type_error(path, ValueType::Table, value))?;
+        Ok(Spanned {
+            span: value.span,
+            value: table,
+        })
+    }
+
+    fn value_as_str<'a>(
+        &self,
+        value: Spanned<&'a de::DeValue<'a>>,
+        path: &[&str],
+    ) -> Result<Spanned<&'a str>, Box<TomlError>> {
+        let s = value
+            .value
+            .as_str()
+            .ok_or_else(|| self.unexpected_value_type_error(path, ValueType::String, value))?;
+        Ok(Spanned {
+            span: value.span,
+            value: s,
+        })
+    }
+
     pub(crate) fn find_entry<'a>(
         &'a self,
         path: &[&str],
-    ) -> Result<Spanned<&'a de::DeValue<'a>>, Box<FindEntryError>> {
+    ) -> Result<Spanned<&'a de::DeValue<'a>>, Box<TomlError>> {
         assert!(!path.is_empty());
         let (&head, tail) = path.split_first().unwrap();
         let document = self.document();
         let kv = document
             .value
             .get_key_value(head)
-            .with_context(|| MissingTopLevelKeySnafu {
-                key: head,
-                span: document.source_span(),
-                source_code: self.named_source(),
-            })?;
+            .ok_or_else(|| self.missing_top_level_key_error(head))?;
         let mut value_key: Spanned<&de::DeString<'_>> = kv.0.into();
         let mut value: Spanned<&de::DeValue<'_>> = kv.1.into();
         for (i, key) in tail.iter().copied().enumerate() {
             let table_path = &path[..=i];
-            let kv = value
+            let kv = self
+                .value_as_table(value, table_path)?
                 .value
-                .as_table()
-                .with_context(|| UnexpectedValueTypeSnafu {
-                    path: build_toml_path(table_path),
-                    expected: ValueType::Table,
-                    actual: ValueType::of(value.value),
-                    span: value.source_span(),
-                    source_code: self.named_source(),
-                })?
                 .get_key_value(key)
-                .with_context(|| MissingKeyInTableSnafu {
-                    key,
-                    table: build_toml_path(table_path),
-                    span: value_key.source_span(),
-                    source_code: self.named_source(),
-                })?;
+                .ok_or_else(|| self.missing_key_in_table_error(key, table_path, value_key))?;
             value_key = kv.0.into();
             value = kv.1.into();
         }
@@ -252,22 +375,29 @@ impl TomlDocument {
     pub(crate) fn find_entry_as_str<'a>(
         &'a self,
         path: &[&str],
-    ) -> Result<Spanned<&'a str>, Box<FindEntryError>> {
+    ) -> Result<Spanned<&'a str>, Box<TomlError>> {
         let value = self.find_entry(path)?;
-        let s = value
-            .value
-            .as_str()
-            .with_context(|| UnexpectedValueTypeSnafu {
-                path: build_toml_path(path),
-                expected: ValueType::String,
-                actual: ValueType::of(value.value),
-                span: value.source_span(),
-                source_code: self.named_source(),
-            })?;
-        Ok(Spanned {
-            span: value.span,
-            value: s,
-        })
+        self.value_as_str(value, path)
+    }
+
+    pub(crate) fn find_entry_as_table<'a>(
+        &'a self,
+        path: &[&str],
+    ) -> Result<Spanned<&'a de::DeTable<'a>>, Box<TomlError>> {
+        let value = self.find_entry(path)?;
+        self.value_as_table(value, path)
+    }
+
+    pub(crate) fn deserialize_entry<'a, T>(&'a self, path: &[&str]) -> Result<T, Box<TomlError>>
+    where
+        T: Deserialize<'a>,
+    {
+        let value = self.find_entry_as_table(path)?;
+        let deserializer =
+            de::Deserializer::from(toml::Spanned::new(value.span.into(), value.value.clone()));
+        let value =
+            T::deserialize(deserializer).map_err(|err| self.deserialize_toml_error(&err))?;
+        Ok(value)
     }
 }
 

--- a/src/sync/marker/resolve.rs
+++ b/src/sync/marker/resolve.rs
@@ -136,14 +136,20 @@ pub(super) fn resolve_specifier(
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::{config::badge::item::BadgeItem, source::SourceFile, sync::marker::parse};
+    use crate::{
+        config::badge::item::BadgeItem, manifest::Manifest, source::SourceFile, sync::marker::parse,
+    };
 
     use super::*;
 
-    static CONFIG: &str = indoc::indoc! {"
-        [badge.badges]
-        [badge.badges-foo]
-    "};
+    static CONFIG: &str = indoc::indoc! {r#"
+        [package]
+        name = "foo"
+        version = "0.1.0"
+
+        [package.metadata.cargo-sync-rdme.badge.badges]
+        [package.metadata.cargo-sync-rdme.badge.badges-foo]
+    "#};
 
     impl ResolvedReplaceSpecifier {
         #[track_caller]
@@ -207,7 +213,8 @@ mod tests {
         config: &str,
     ) -> Result<ResolvedReplaceSpecifier, ResolveMarkerError> {
         let source_file = SourceFile::new_for_test("Cargo.toml", config);
-        let config = source_file.deserialize_as_toml::<Config>().unwrap();
+        let manifest = Manifest::new_for_test(&source_file).unwrap();
+        let config = manifest.package_config().unwrap().unwrap_or_default();
         let (specifier, _rest) = parse::parse_specifier(source).unwrap().unwrap();
         resolve_specifier(specifier, &config)
     }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -10,10 +10,8 @@ use crate::{
     args::{Args, FeatureSelection, FixArgs, Mode, RustdocToolchainArgs},
     config::Config,
     diff,
-    manifest::Manifest,
-    source::{
-        DeserializeAsTomlError, ParseTomlError, SourceFile, SourceFileLoader, SourceFilePath,
-    },
+    manifest::{Manifest, ManifestError},
+    source::{SourceFile, SourceFileLoader, SourceFilePath},
 };
 
 mod contents;
@@ -22,28 +20,13 @@ mod replace;
 
 #[derive(Debug, Snafu, miette::Diagnostic)]
 pub(crate) enum SyncError {
-    #[snafu(display("failed to read package `{package}` manifest: {path}", path = manifest.path))]
-    ReadPackageManifest {
-        package: PackageName,
-        manifest: SourceFilePath,
-        #[snafu(source)]
-        source: io::Error,
-    },
-    #[snafu(display("failed to parse package `{package}` manifest: {path}", path = manifest.path))]
-    ParsePackageManifest {
+    #[snafu(display("failed to load package manifest file for package `{package}`: {path}", path = manifest.path))]
+    LoadPackageManifestFile {
         package: PackageName,
         manifest: SourceFilePath,
         #[snafu(source)]
         #[diagnostic_source]
-        source: Box<ParseTomlError>,
-    },
-    #[snafu(display("failed to deserialize package `{package}` manifest: {path}", path = manifest.path))]
-    DeserializePackageManifest {
-        package: PackageName,
-        manifest: SourceFilePath,
-        #[snafu(source)]
-        #[diagnostic_source]
-        source: DeserializeAsTomlError,
+        source: Box<ManifestError>,
     },
     #[snafu(display("failed to read markdown file for package `{package}`: {markdown}", markdown = markdown.path))]
     ReadMarkdownFile {
@@ -161,27 +144,19 @@ impl<'a> PackageSyncContext<'a> {
         package: &'a Package,
     ) -> Result<Self, Box<SyncError>> {
         let manifest_loader = SourceFileLoader::from_path(workspace, &package.manifest_path);
-        let manifest_file =
-            manifest_loader
-                .load()
-                .with_context(|_source| ReadPackageManifestSnafu {
-                    package: package.name.clone(),
-                    manifest: &manifest_loader,
-                })?;
-        let manifest_toml =
-            manifest_file
-                .parse_as_toml()
-                .with_context(|_source| ParsePackageManifestSnafu {
-                    package: package.name.clone(),
-                    manifest: &manifest_loader,
-                })?;
-        let manifest = Manifest::new(manifest_toml);
-        let config = Config::parse(&manifest_file).with_context(|_source| {
-            DeserializePackageManifestSnafu {
+        let manifest = Manifest::load(&manifest_loader).with_context(|_source| {
+            LoadPackageManifestFileSnafu {
                 package: package.name.clone(),
                 manifest: &manifest_loader,
             }
         })?;
+        let config = manifest
+            .package_config()
+            .with_context(|_source| LoadPackageManifestFileSnafu {
+                package: package.name.clone(),
+                manifest: &manifest_loader,
+            })?
+            .unwrap_or_default();
         Ok(Self {
             diff_stream,
             mode: args.mode.mode(),

--- a/tests/fixtures/snapshots/basic_config_error/pkg-a.invalid-value.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/pkg-a.invalid-value.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -22,27 +22,25 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to deserialize package `pkg-a` manifest: pkg-a/Cargo.toml</tspan>
+    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to load package manifest file for package `pkg-a`: pkg-a/Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> TOML parse error: invalid type: boolean `false`, expected a</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> invalid type: boolean `false`, expected a string or a seq</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> string or a seq</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/Cargo.toml:7:17</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/Cargo.toml:7:17</tspan><tspan>]</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">6</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">6</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ extra-targets = false</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ extra-targets = false</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan>   · </tspan><tspan class="fg-magenta bold">                ─────</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>   · </tspan><tspan class="fg-magenta bold">                ─────</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>   ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-red">      </tspan><tspan>   ╰────</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-red">      </tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-red">      </tspan>
+    <tspan x="10px" y="172px">
 </tspan>
     <tspan x="10px" y="190px">
-</tspan>
-    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/basic_config_error/pkg-a.unknown-field.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/pkg-a.unknown-field.stderr.term.svg
@@ -22,11 +22,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to deserialize package `pkg-a` manifest: pkg-a/Cargo.toml</tspan>
+    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to load package manifest file for package `pkg-a`: pkg-a/Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> TOML parse error: unknown field `unknown`, expected one of</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown field `unknown`, expected one of `extra-targets`,</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `extra-targets`, `badge`, `rustdoc`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `badge`, `rustdoc`</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/Cargo.toml:7:1</tspan><tspan>]</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/basic_config_error/pkg-a.unknown-table.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/pkg-a.unknown-table.stderr.term.svg
@@ -22,11 +22,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to deserialize package `pkg-a` manifest: pkg-a/Cargo.toml</tspan>
+    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to load package manifest file for package `pkg-a`: pkg-a/Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> TOML parse error: unknown field `unknown`, expected one of</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown field `unknown`, expected one of `extra-targets`,</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `extra-targets`, `badge`, `rustdoc`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `badge`, `rustdoc`</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/Cargo.toml:6:35</tspan><tspan>]</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/basic_config_error/root.invalid-value.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/root.invalid-value.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -22,27 +22,25 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to deserialize package `root` manifest: Cargo.toml</tspan>
+    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to load package manifest file for package `root`: Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> TOML parse error: invalid type: boolean `false`, expected a</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> invalid type: boolean `false`, expected a string or a seq</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> string or a seq</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:10:17</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:10:17</tspan><tspan>]</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ extra-targets = false</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ extra-targets = false</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan>    · </tspan><tspan class="fg-magenta bold">                ─────</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>    · </tspan><tspan class="fg-magenta bold">                ─────</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-red">      </tspan><tspan>    ╰────</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-red">      </tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-red">      </tspan>
+    <tspan x="10px" y="172px">
 </tspan>
     <tspan x="10px" y="190px">
-</tspan>
-    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/basic_config_error/root.unknown-field.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/root.unknown-field.stderr.term.svg
@@ -22,11 +22,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to deserialize package `root` manifest: Cargo.toml</tspan>
+    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to load package manifest file for package `root`: Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> TOML parse error: unknown field `unknown`, expected one of</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown field `unknown`, expected one of `extra-targets`,</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `extra-targets`, `badge`, `rustdoc`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `badge`, `rustdoc`</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:10:1</tspan><tspan>]</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/basic_config_error/root.unknown-table.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/root.unknown-table.stderr.term.svg
@@ -22,11 +22,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to deserialize package `root` manifest: Cargo.toml</tspan>
+    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to load package manifest file for package `root`: Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> TOML parse error: unknown field `unknown`, expected one of</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-red">  ╰─▶ </tspan><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown field `unknown`, expected one of `extra-targets`,</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `extra-targets`, `badge`, `rustdoc`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `badge`, `rustdoc`</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:9:35</tspan><tspan>]</tspan>
 </tspan>


### PR DESCRIPTION
## Summary

- reuse the parsed `TomlDocument` to deserialize `package.metadata.cargo-sync-rdme` instead of parsing the manifest TOML twice
- add `TomlDocument::deserialize_entry()` and refactor manifest loading around `Manifest::load()` / `Manifest::package_config()`
- clean up related control flow and simplify some manifest/config error messages and snapshots

## Motivation

The previous refactor separated typed config parsing from manifest lookups, but still ended up parsing the same `Cargo.toml` twice: once into a retained TOML document and once again through serde just to recover `package.metadata.cargo-sync-rdme`.

This change keeps the same overall structure while removing the duplicate parse by deserializing the config directly from the already-parsed TOML subtree. That keeps manifest lookups extensible without paying the extra parse cost.

## Validation

- `cargo test`

## Notes

- manifest/config loading is now funneled through `Manifest::load()` and `Manifest::package_config()`
- the top-level sync error wording for package manifest failures was adjusted to match the broader loading path rather than only TOML parsing