### PR TITLE
Remove explicit readme manifest entries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Cargo subcommand to synchronize README with crate documentation"
-readme = "README.md"
 repository.workspace = true
 license.workspace = true
 keywords = ["cargo", "documentation", "readme", "rustdoc", "subcommand"]

--- a/examples/lib/Cargo.toml
+++ b/examples/lib/Cargo.toml
@@ -3,7 +3,6 @@ name = "cargo-sync-rdme-example-lib"
 version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
-readme = "README.md"
 repository.workspace = true
 license.workspace = true
 publish = false

--- a/tests/fixtures/packages/empty/Cargo.toml
+++ b/tests/fixtures/packages/empty/Cargo.toml
@@ -2,7 +2,6 @@
 name = "empty"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [package.metadata.cargo-sync-rdme.rustdoc]

--- a/tests/fixtures/packages/features/Cargo.toml
+++ b/tests/fixtures/packages/features/Cargo.toml
@@ -2,7 +2,6 @@
 name = "features"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [package.metadata.cargo-sync-rdme.rustdoc]

--- a/tests/fixtures/packages/link_showcase/Cargo.toml
+++ b/tests/fixtures/packages/link_showcase/Cargo.toml
@@ -2,7 +2,6 @@
 name = "link-showcase"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [package.metadata.cargo-sync-rdme.rustdoc]

--- a/tests/fixtures/packages/link_showcase/pkg-a/Cargo.toml
+++ b/tests/fixtures/packages/link_showcase/pkg-a/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pkg-a"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [package.metadata.cargo-sync-rdme.rustdoc]

--- a/tests/fixtures/packages/no_config/Cargo.toml
+++ b/tests/fixtures/packages/no_config/Cargo.toml
@@ -2,7 +2,6 @@
 name = "root"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [workspace]

--- a/tests/fixtures/packages/no_config/pkg-a/Cargo.toml
+++ b/tests/fixtures/packages/no_config/pkg-a/Cargo.toml
@@ -2,5 +2,4 @@
 name = "pkg-a"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false

--- a/tests/fixtures/packages/no_config/pkg-b/Cargo.toml
+++ b/tests/fixtures/packages/no_config/pkg-b/Cargo.toml
@@ -2,5 +2,4 @@
 name = "pkg-b"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false

--- a/tests/fixtures/packages/workspace/Cargo.toml
+++ b/tests/fixtures/packages/workspace/Cargo.toml
@@ -2,7 +2,6 @@
 name = "root"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [package.metadata.cargo-sync-rdme]

--- a/tests/fixtures/packages/workspace/pkg-a/Cargo.toml
+++ b/tests/fixtures/packages/workspace/pkg-a/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pkg-a"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [package.metadata.cargo-sync-rdme]

--- a/tests/fixtures/packages/workspace/pkg-b/Cargo.toml
+++ b/tests/fixtures/packages/workspace/pkg-b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pkg-b"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [package.metadata.cargo-sync-rdme]

--- a/tests/fixtures/packages/workspace_default/Cargo.toml
+++ b/tests/fixtures/packages/workspace_default/Cargo.toml
@@ -2,7 +2,6 @@
 name = "root"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [package.metadata.cargo-sync-rdme.rustdoc]

--- a/tests/fixtures/packages/workspace_default/pkg-a/Cargo.toml
+++ b/tests/fixtures/packages/workspace_default/pkg-a/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pkg-a"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [package.metadata.cargo-sync-rdme.rustdoc]

--- a/tests/fixtures/packages/workspace_default/pkg-b/Cargo.toml
+++ b/tests/fixtures/packages/workspace_default/pkg-b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pkg-b"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [package.metadata.cargo-sync-rdme.rustdoc]

--- a/tests/fixtures/packages/workspace_virtual/pkg-a/Cargo.toml
+++ b/tests/fixtures/packages/workspace_virtual/pkg-a/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pkg-a"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [package.metadata.cargo-sync-rdme.rustdoc]

--- a/tests/fixtures/packages/workspace_virtual/pkg-b/Cargo.toml
+++ b/tests/fixtures/packages/workspace_virtual/pkg-b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pkg-b"
 version = "0.1.0"
 edition = "2024"
-readme = "README.md"
 publish = false
 
 [package.metadata.cargo-sync-rdme.rustdoc]

--- a/tests/fixtures/snapshots/basic_config_error/pkg-a.invalid-value.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/pkg-a.invalid-value.stderr.term.svg
@@ -28,11 +28,11 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> string or a seq</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/Cargo.toml:8:17</tspan><tspan>]</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/Cargo.toml:7:17</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">6</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ extra-targets = false</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ extra-targets = false</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>   · </tspan><tspan class="fg-magenta bold">                ─────</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/basic_config_error/pkg-a.unknown-field.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/pkg-a.unknown-field.stderr.term.svg
@@ -28,11 +28,11 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `extra-targets`, `badge`, `rustdoc`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/Cargo.toml:8:1</tspan><tspan>]</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/Cargo.toml:7:1</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">6</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ unknown = true</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ unknown = true</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>   · </tspan><tspan class="fg-magenta bold">───────</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/basic_config_error/pkg-a.unknown-table.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/pkg-a.unknown-table.stderr.term.svg
@@ -28,15 +28,15 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `extra-targets`, `badge`, `rustdoc`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/Cargo.toml:7:35</tspan><tspan>]</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/Cargo.toml:6:35</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">6</tspan><tspan> │ publish = false</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">5</tspan><tspan> │ publish = false</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ [package.metadata.cargo-sync-rdme.unknown]</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">6</tspan><tspan> │ [package.metadata.cargo-sync-rdme.unknown]</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>   · </tspan><tspan class="fg-magenta bold">                                  ───────</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ foo = true</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ foo = true</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-red">      </tspan><tspan>   ╰────</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/basic_config_error/root.invalid-value.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/root.invalid-value.stderr.term.svg
@@ -28,11 +28,11 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> string or a seq</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:11:17</tspan><tspan>]</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:10:17</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ extra-targets = false</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ extra-targets = false</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>    · </tspan><tspan class="fg-magenta bold">                ─────</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/basic_config_error/root.unknown-field.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/root.unknown-field.stderr.term.svg
@@ -28,11 +28,11 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `extra-targets`, `badge`, `rustdoc`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:11:1</tspan><tspan>]</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:10:1</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ [package.metadata.cargo-sync-rdme]</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ unknown = true</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ unknown = true</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>    · </tspan><tspan class="fg-magenta bold">───────</tspan>
 </tspan>

--- a/tests/fixtures/snapshots/basic_config_error/root.unknown-table.stderr.term.svg
+++ b/tests/fixtures/snapshots/basic_config_error/root.unknown-table.stderr.term.svg
@@ -28,15 +28,15 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-red">      </tspan><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `extra-targets`, `badge`, `rustdoc`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:10:35</tspan><tspan>]</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-red">      </tspan><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">Cargo.toml:9:35</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ members = ["pkg-a", "pkg-b"]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ members = ["pkg-a", "pkg-b"]</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ [package.metadata.cargo-sync-rdme.unknown]</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ [package.metadata.cargo-sync-rdme.unknown]</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-red">      </tspan><tspan>    · </tspan><tspan class="fg-magenta bold">                                  ───────</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ foo = true</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-red">      </tspan><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ foo = true</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-red">      </tspan><tspan>    ╰────</tspan>
 </tspan>


### PR DESCRIPTION
## Summary
- remove explicit `readme = "README.md"` entries from the root crate, example crate, and test fixture manifests
- update snapshot fixtures whose diagnostics shifted by one line after removing the redundant manifest entry

## Background
`cargo::manual-readme` is enabled by default on nightly now. In practice, `cargo metadata` resolves the package `readme` to `README.md` even when the field is omitted, so these explicit entries are redundant for this repository and its fixtures.

## Validation
- `cargo test --test ui`
- `cargo test --test select_packages`
- `cargo test --test idempotency`

## Impact
No intended behavior change. This should only silence the lint and keep existing README handling intact.

## Risk
This change depends on Cargo metadata continuing to surface the implicit `README.md` value.