### PR TITLE
Refactor badge config for item merging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "clap_complete_nushell",
  "clap_mangen",
  "console",
+ "indexmap",
  "indoc",
  "miette",
  "pulldown-cmark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ clap_complete_nushell = "4.6.2"
 clap_mangen = "0.3.3"
 clap-verbosity-flag = { version = "3.0.4", default-features = false, features = ["tracing"] }
 console = "0.16.4"
+indexmap = "2.14.1"
 indoc = "2.0.7"
 miette = { version = "7.6.0", features = ["fancy"] }
 pulldown-cmark = { version = "0.13.4", default-features = false }
@@ -134,6 +135,7 @@ clap_complete_nushell.workspace = true
 clap_mangen.workspace = true
 clap-verbosity-flag.workspace = true
 console.workspace = true
+indexmap.workspace = true
 miette.workspace = true
 pulldown-cmark.workspace = true
 pulldown-cmark-to-cmark.workspace = true

--- a/src/config/badge/item.rs
+++ b/src/config/badge/item.rs
@@ -1,12 +1,13 @@
-use std::{fmt, str::FromStr, sync::Arc};
+use std::{fmt, str::FromStr};
 
+use indexmap::IndexMap;
 use serde::{
     Deserialize,
     de::{DeserializeSeed, Error as _, Visitor},
 };
 use void::Void;
 
-use crate::config::de;
+use crate::config::{badge::BadgeMap, de};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum BadgeItem {
@@ -19,18 +20,18 @@ pub(crate) enum BadgeItem {
     Codecov(Codecov),
 }
 
-#[derive(Debug, Clone)]
-enum BadgeItemKind {
-    Maintenance,
-    License,
-    CratesIo,
-    DocsRs,
-    RustVersion,
-    GithubActions,
-    Codecov,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) enum BadgeItemKey {
+    Maintenance(Option<String>),
+    License(Option<String>),
+    CratesIo(Option<String>),
+    DocsRs(Option<String>),
+    RustVersion(Option<String>),
+    GithubActions(Option<String>),
+    Codecov(Option<String>),
 }
 
-impl BadgeItemKind {
+impl BadgeItemKey {
     fn expected() -> &'static [&'static str] {
         &[
             "maintenance",
@@ -51,14 +52,14 @@ impl BadgeItemKind {
     }
 }
 
-pub(super) fn deserialize_badge_list<'de, D>(deserializer: D) -> Result<Arc<[BadgeItem]>, D::Error>
+pub(super) fn deserialize_badge_map<'de, D>(deserializer: D) -> Result<BadgeMap, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     struct BadgeList;
 
     impl<'de> Visitor<'de> for BadgeList {
-        type Value = Arc<[BadgeItem]>;
+        type Value = BadgeMap;
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             formatter.write_str("map")
@@ -68,50 +69,49 @@ where
         where
             M: serde::de::MapAccess<'de>,
         {
-            let mut data = vec![];
-            while let Some(kind) = map.next_key::<BadgeItemKind>()? {
-                if let Some(item) = map.next_value_seed(kind)? {
-                    data.push(item);
-                }
+            let mut data = IndexMap::new();
+            while let Some(kind) = map.next_key::<BadgeItemKey>()? {
+                let (key, item) = map.next_value_seed(kind)?;
+                data.insert(key, item);
             }
-            Ok(data.into())
+            Ok(data)
         }
     }
 
     deserializer.deserialize_any(BadgeList)
 }
 
-impl<'de> Deserialize<'de> for BadgeItemKind {
+impl<'de> Deserialize<'de> for BadgeItemKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         let s = <&str>::deserialize(deserializer)?;
         let kind = match s {
-            "maintenance" => Self::Maintenance,
-            "license" => Self::License,
-            "crates-io" => Self::CratesIo,
-            "docs-rs" => Self::DocsRs,
-            "rust-version" => Self::RustVersion,
-            "github-actions" => Self::GithubActions,
-            "codecov" => Self::Codecov,
+            "maintenance" => Self::Maintenance(None),
+            "license" => Self::License(None),
+            "crates-io" => Self::CratesIo(None),
+            "docs-rs" => Self::DocsRs(None),
+            "rust-version" => Self::RustVersion(None),
+            "github-actions" => Self::GithubActions(None),
+            "codecov" => Self::Codecov(None),
             _ => {
-                if s.starts_with("maintenance-") {
-                    Self::Maintenance
-                } else if s.starts_with("license-") {
-                    Self::License
-                } else if s.starts_with("crates-io-") {
-                    Self::CratesIo
-                } else if s.starts_with("docs-rs-") {
-                    Self::DocsRs
-                } else if s.starts_with("rust-version-") {
-                    Self::RustVersion
-                } else if s.starts_with("github-actions-") {
-                    Self::GithubActions
-                } else if s.starts_with("codecov-") {
-                    Self::Codecov
+                if let Some(suffix) = s.strip_prefix("maintenance-") {
+                    Self::Maintenance(Some(suffix.to_owned()))
+                } else if let Some(suffix) = s.strip_prefix("license-") {
+                    Self::License(Some(suffix.to_owned()))
+                } else if let Some(suffix) = s.strip_prefix("crates-io-") {
+                    Self::CratesIo(Some(suffix.to_owned()))
+                } else if let Some(suffix) = s.strip_prefix("docs-rs-") {
+                    Self::DocsRs(Some(suffix.to_owned()))
+                } else if let Some(suffix) = s.strip_prefix("rust-version-") {
+                    Self::RustVersion(Some(suffix.to_owned()))
+                } else if let Some(suffix) = s.strip_prefix("github-actions-") {
+                    Self::GithubActions(Some(suffix.to_owned()))
+                } else if let Some(suffix) = s.strip_prefix("codecov-") {
+                    Self::Codecov(Some(suffix.to_owned()))
                 } else {
-                    return Err(D::Error::unknown_field(s, BadgeItemKind::expected()));
+                    return Err(D::Error::unknown_field(s, BadgeItemKey::expected()));
                 }
             }
         };
@@ -119,8 +119,8 @@ impl<'de> Deserialize<'de> for BadgeItemKind {
     }
 }
 
-impl<'de> DeserializeSeed<'de> for BadgeItemKind {
-    type Value = Option<BadgeItem>;
+impl<'de> DeserializeSeed<'de> for BadgeItemKey {
+    type Value = (BadgeItemKey, Option<BadgeItem>);
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
@@ -131,27 +131,25 @@ impl<'de> DeserializeSeed<'de> for BadgeItemKind {
         struct BoolOrMap<T>(#[serde(deserialize_with = "de::bool_or_map")] Option<T>);
 
         let item = match self {
-            BadgeItemKind::Maintenance => {
+            Self::Maintenance(_) => {
                 bool::deserialize(deserializer)?.then_some(BadgeItem::Maintenance)
             }
-            BadgeItemKind::License => <BoolOrMap<License>>::deserialize(deserializer)?
+            Self::License(_) => <BoolOrMap<License>>::deserialize(deserializer)?
                 .0
                 .map(BadgeItem::License),
-            BadgeItemKind::CratesIo => {
-                bool::deserialize(deserializer)?.then_some(BadgeItem::CratesIo)
-            }
-            BadgeItemKind::DocsRs => bool::deserialize(deserializer)?.then_some(BadgeItem::DocsRs),
-            BadgeItemKind::RustVersion => {
+            Self::CratesIo(_) => bool::deserialize(deserializer)?.then_some(BadgeItem::CratesIo),
+            Self::DocsRs(_) => bool::deserialize(deserializer)?.then_some(BadgeItem::DocsRs),
+            Self::RustVersion(_) => {
                 bool::deserialize(deserializer)?.then_some(BadgeItem::RustVersion)
             }
-            BadgeItemKind::GithubActions => <BoolOrMap<GithubActions>>::deserialize(deserializer)?
+            Self::GithubActions(_) => <BoolOrMap<GithubActions>>::deserialize(deserializer)?
                 .0
                 .map(BadgeItem::GithubActions),
-            BadgeItemKind::Codecov => <BoolOrMap<Codecov>>::deserialize(deserializer)?
+            Self::Codecov(_) => <BoolOrMap<Codecov>>::deserialize(deserializer)?
                 .0
                 .map(BadgeItem::Codecov),
         };
-        Ok(item)
+        Ok((self, item))
     }
 }
 
@@ -207,7 +205,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn deserialize_badge_list_preserves_badges_order() {
+    fn deserialize_badge_map_preserves_badges_order() {
         let source = testing::badge_manifest(indoc! {"
             badges = {
               license = true,
@@ -221,19 +219,33 @@ mod tests {
         "});
         let badge = testing::parse_badge(&source);
         assert_eq!(
-            badge.default.as_deref().unwrap(),
+            badge.default.unwrap().into_iter().collect::<Vec<_>>(),
             [
-                BadgeItem::License(License::default()),
-                BadgeItem::Maintenance,
-                BadgeItem::CratesIo,
-                BadgeItem::Codecov(Codecov::default()),
-                BadgeItem::RustVersion
+                (
+                    BadgeItemKey::License(None),
+                    Some(BadgeItem::License(License::default()))
+                ),
+                (
+                    BadgeItemKey::Maintenance(None),
+                    Some(BadgeItem::Maintenance)
+                ),
+                (BadgeItemKey::GithubActions(None), None),
+                (BadgeItemKey::CratesIo(None), Some(BadgeItem::CratesIo)),
+                (
+                    BadgeItemKey::Codecov(None),
+                    Some(BadgeItem::Codecov(Codecov::default()))
+                ),
+                (BadgeItemKey::DocsRs(None), None),
+                (
+                    BadgeItemKey::RustVersion(None),
+                    Some(BadgeItem::RustVersion)
+                ),
             ]
         );
     }
 
     #[test]
-    fn deserialize_badge_list_preserves_multiple_badges_with_same_kind() {
+    fn deserialize_badge_map_preserves_multiple_badges_with_same_kind() {
         let source = testing::badge_manifest(indoc! {"
             badges = {
               license = true,
@@ -244,18 +256,30 @@ mod tests {
         "});
         let badge = testing::parse_badge(&source);
         assert_eq!(
-            badge.default.as_deref().unwrap(),
+            badge.default.unwrap().into_iter().collect::<Vec<_>>(),
             [
-                BadgeItem::License(License::default()),
-                BadgeItem::License(License::default()),
-                BadgeItem::Maintenance,
-                BadgeItem::License(License::default()),
+                (
+                    BadgeItemKey::License(None),
+                    Some(BadgeItem::License(License::default()))
+                ),
+                (
+                    BadgeItemKey::License(Some("x".to_owned())),
+                    Some(BadgeItem::License(License::default()))
+                ),
+                (
+                    BadgeItemKey::Maintenance(None),
+                    Some(BadgeItem::Maintenance)
+                ),
+                (
+                    BadgeItemKey::License(Some("z".to_owned())),
+                    Some(BadgeItem::License(License::default()))
+                ),
             ]
         );
     }
 
     #[test]
-    fn deserialize_badge_item_kind_rejects_unknown_field() {
+    fn deserialize_badge_item_key_rejects_unknown_field() {
         let source = testing::badge_manifest(indoc! {r"
             badges = {
               unknown = true,
@@ -266,19 +290,36 @@ mod tests {
 
     #[test]
     fn deserialize_badge_item_parses_bool_values() {
-        let fields = [
-            ("maintenance", BadgeItem::Maintenance),
-            ("license", BadgeItem::License(License::default())),
-            ("crates-io", BadgeItem::CratesIo),
-            ("docs-rs", BadgeItem::DocsRs),
-            ("rust-version", BadgeItem::RustVersion),
+        let fields: [(_, fn(_) -> _, _); _] = [
+            (
+                "maintenance",
+                BadgeItemKey::Maintenance,
+                BadgeItem::Maintenance,
+            ),
+            (
+                "license",
+                BadgeItemKey::License,
+                BadgeItem::License(License::default()),
+            ),
+            ("crates-io", BadgeItemKey::CratesIo, BadgeItem::CratesIo),
+            ("docs-rs", BadgeItemKey::DocsRs, BadgeItem::DocsRs),
+            (
+                "rust-version",
+                BadgeItemKey::RustVersion,
+                BadgeItem::RustVersion,
+            ),
             (
                 "github-actions",
+                BadgeItemKey::GithubActions,
                 BadgeItem::GithubActions(GithubActions::default()),
             ),
-            ("codecov", BadgeItem::Codecov(Codecov::default())),
+            (
+                "codecov",
+                BadgeItemKey::Codecov,
+                BadgeItem::Codecov(Codecov::default()),
+            ),
         ];
-        for (field, item) in fields {
+        for (field, key, item) in fields {
             let source = testing::badge_manifest(&formatdoc! {r"
                 badges = {{
                   {field} = true,
@@ -287,8 +328,11 @@ mod tests {
             "});
             let badge = testing::parse_badge(&source);
             assert_eq!(
-                badge.default.as_deref().unwrap(),
-                [item.clone(), item.clone()]
+                badge.default.unwrap().into_iter().collect::<Vec<_>>(),
+                [
+                    (key(None), Some(item.clone())),
+                    (key(Some("x".to_owned())), Some(item.clone())),
+                ]
             );
 
             let source = testing::badge_manifest(&formatdoc! {r"
@@ -298,7 +342,10 @@ mod tests {
                 }}
             "});
             let badge = testing::parse_badge(&source);
-            assert_eq!(badge.default.as_deref().unwrap(), []);
+            assert_eq!(
+                badge.default.unwrap().into_iter().collect::<Vec<_>>(),
+                [(key(None), None), (key(Some("x".to_owned())), None),]
+            );
         }
     }
 
@@ -334,15 +381,24 @@ mod tests {
         "#});
         let badge = testing::parse_badge(&source);
         assert_eq!(
-            badge.default.as_deref().unwrap(),
+            badge.default.unwrap().into_iter().collect::<Vec<_>>(),
             [
-                BadgeItem::License(License { link: None }),
-                BadgeItem::License(License {
-                    link: Some("https://example.com".to_string()),
-                }),
-                BadgeItem::License(License {
-                    link: Some("https://example.com/x".to_string()),
-                })
+                (
+                    BadgeItemKey::License(None),
+                    Some(BadgeItem::License(License { link: None }))
+                ),
+                (
+                    BadgeItemKey::License(Some("x".to_owned())),
+                    Some(BadgeItem::License(License {
+                        link: Some("https://example.com".to_string()),
+                    }))
+                ),
+                (
+                    BadgeItemKey::License(Some("y".to_owned())),
+                    Some(BadgeItem::License(License {
+                        link: Some("https://example.com/x".to_string()),
+                    }))
+                ),
             ]
         );
     }
@@ -376,33 +432,47 @@ mod tests {
         "#});
         let badge = testing::parse_badge(&source);
         assert_eq!(
-            badge.default.as_deref().unwrap(),
+            badge.default.unwrap().into_iter().collect::<Vec<_>>(),
             [
-                BadgeItem::GithubActions(GithubActions { workflows: vec![] }),
-                BadgeItem::GithubActions(GithubActions {
-                    workflows: vec![GithubActionsWorkflow {
-                        name: None,
-                        file: "x.yaml".into()
-                    }]
-                }),
-                BadgeItem::GithubActions(GithubActions {
-                    workflows: vec![GithubActionsWorkflow {
-                        name: None,
-                        file: "y.yaml".into()
-                    }]
-                }),
-                BadgeItem::GithubActions(GithubActions {
-                    workflows: vec![
-                        GithubActionsWorkflow {
+                (
+                    BadgeItemKey::GithubActions(None),
+                    Some(BadgeItem::GithubActions(GithubActions {
+                        workflows: vec![]
+                    }))
+                ),
+                (
+                    BadgeItemKey::GithubActions(Some("x".to_owned())),
+                    Some(BadgeItem::GithubActions(GithubActions {
+                        workflows: vec![GithubActionsWorkflow {
                             name: None,
                             file: "x.yaml".into()
-                        },
-                        GithubActionsWorkflow {
+                        }]
+                    }))
+                ),
+                (
+                    BadgeItemKey::GithubActions(Some("y".to_owned())),
+                    Some(BadgeItem::GithubActions(GithubActions {
+                        workflows: vec![GithubActionsWorkflow {
                             name: None,
                             file: "y.yaml".into()
-                        },
-                    ]
-                }),
+                        }]
+                    }))
+                ),
+                (
+                    BadgeItemKey::GithubActions(Some("xyz".to_owned())),
+                    Some(BadgeItem::GithubActions(GithubActions {
+                        workflows: vec![
+                            GithubActionsWorkflow {
+                                name: None,
+                                file: "x.yaml".into()
+                            },
+                            GithubActionsWorkflow {
+                                name: None,
+                                file: "y.yaml".into()
+                            },
+                        ]
+                    }))
+                ),
             ]
         );
     }
@@ -434,13 +504,19 @@ mod tests {
         "#});
         let badge = testing::parse_badge(&source);
         assert_eq!(
-            badge.default.as_deref().unwrap(),
+            badge.default.unwrap().into_iter().collect::<Vec<_>>(),
             [
-                BadgeItem::Codecov(Codecov::default()),
-                BadgeItem::Codecov(Codecov {
-                    component: Some("core".into()),
-                    flag: None
-                }),
+                (
+                    BadgeItemKey::Codecov(None),
+                    Some(BadgeItem::Codecov(Codecov::default()))
+                ),
+                (
+                    BadgeItemKey::Codecov(Some("x".to_owned())),
+                    Some(BadgeItem::Codecov(Codecov {
+                        component: Some("core".into()),
+                        flag: None
+                    }))
+                ),
             ]
         );
     }

--- a/src/config/badge/mod.rs
+++ b/src/config/badge/mod.rs
@@ -1,23 +1,28 @@
 use std::{
     collections::HashMap,
     fmt::{self, Display},
-    sync::Arc,
 };
 
+use indexmap::IndexMap;
 use serde::{
     Deserialize,
     de::{Error as _, Visitor},
 };
 
-use crate::{config::badge::item::BadgeItem, parse};
+use crate::{
+    config::badge::item::{BadgeItem, BadgeItemKey},
+    parse,
+};
 
 pub(crate) mod item;
+
+pub(crate) type BadgeMap = IndexMap<BadgeItemKey, Option<BadgeItem>>;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct Badge {
     pub(crate) style: Option<BadgeStyle>,
-    pub(crate) default: Option<Arc<[BadgeItem]>>,
-    pub(crate) groups: HashMap<Arc<str>, Arc<[BadgeItem]>>,
+    pub(crate) default: Option<BadgeMap>,
+    pub(crate) groups: HashMap<String, BadgeMap>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
@@ -104,7 +109,7 @@ impl<'de> Deserialize<'de> for Badge {
             {
                 #[derive(Deserialize)]
                 struct BadgeList(
-                    #[serde(deserialize_with = "item::deserialize_badge_list")] Arc<[BadgeItem]>,
+                    #[serde(deserialize_with = "item::deserialize_badge_map")] BadgeMap,
                 );
 
                 let mut data = Badge::default();
@@ -121,7 +126,7 @@ impl<'de> Deserialize<'de> for Badge {
                         BadgeFieldKey::BadgesGroup(group) => {
                             let group = group.to_owned();
                             let value = map.next_value::<BadgeList>()?;
-                            data.groups.entry(group.into()).or_insert(value.0);
+                            data.groups.entry(group).or_insert(value.0);
                         }
                     }
                 }
@@ -157,17 +162,32 @@ mod tests {
         "});
         let badge = testing::parse_badge(&source);
         assert_eq!(
-            badge.default.as_deref().unwrap(),
+            badge.default.unwrap().into_iter().collect::<Vec<_>>(),
             [
-                BadgeItem::License(License::default()),
-                BadgeItem::Maintenance,
+                (
+                    BadgeItemKey::License(None),
+                    Some(BadgeItem::License(License::default()))
+                ),
+                (
+                    BadgeItemKey::Maintenance(None),
+                    Some(BadgeItem::Maintenance)
+                ),
             ]
         );
         assert_eq!(
-            *badge.groups["group1"],
+            badge.groups["group1"]
+                .clone()
+                .into_iter()
+                .collect::<Vec<_>>(),
             [
-                BadgeItem::License(License::default()),
-                BadgeItem::Maintenance,
+                (
+                    BadgeItemKey::License(None),
+                    Some(BadgeItem::License(License::default()))
+                ),
+                (
+                    BadgeItemKey::Maintenance(None),
+                    Some(BadgeItem::Maintenance)
+                ),
             ]
         );
     }
@@ -190,12 +210,39 @@ mod tests {
         "});
         let badge = testing::parse_badge(&source);
         assert_eq!(
-            *badge.groups["group1"],
-            [BadgeItem::License(License::default())]
+            badge.groups["group1"]
+                .clone()
+                .into_iter()
+                .collect::<Vec<_>>(),
+            [(
+                BadgeItemKey::License(None),
+                Some(BadgeItem::License(License::default()))
+            )]
         );
-        assert_eq!(*badge.groups["group_2"], [BadgeItem::Maintenance]);
-        assert_eq!(*badge.groups["Group3"], [BadgeItem::CratesIo]);
-        assert_eq!(*badge.groups["group_4-foo"], [BadgeItem::DocsRs]);
+        assert_eq!(
+            badge.groups["group_2"]
+                .clone()
+                .into_iter()
+                .collect::<Vec<_>>(),
+            [(
+                BadgeItemKey::Maintenance(None),
+                Some(BadgeItem::Maintenance),
+            )]
+        );
+        assert_eq!(
+            badge.groups["Group3"]
+                .clone()
+                .into_iter()
+                .collect::<Vec<_>>(),
+            [(BadgeItemKey::CratesIo(None), Some(BadgeItem::CratesIo)),]
+        );
+        assert_eq!(
+            badge.groups["group_4-foo"]
+                .clone()
+                .into_iter()
+                .collect::<Vec<_>>(),
+            [(BadgeItemKey::DocsRs(None), Some(BadgeItem::DocsRs)),]
+        );
     }
 
     #[test]
@@ -278,10 +325,16 @@ mod tests {
         "#};
         let badge = testing::parse_badge(source);
         assert_eq!(
-            badge.default.as_deref().unwrap(),
+            badge.default.unwrap().into_iter().collect::<Vec<_>>(),
             [
-                BadgeItem::License(License::default()),
-                BadgeItem::Maintenance,
+                (
+                    BadgeItemKey::License(None),
+                    Some(BadgeItem::License(License::default()))
+                ),
+                (
+                    BadgeItemKey::Maintenance(None),
+                    Some(BadgeItem::Maintenance)
+                ),
             ]
         );
     }

--- a/src/sync/contents/badge.rs
+++ b/src/sync/contents/badge.rs
@@ -12,7 +12,10 @@ use url::Url;
 
 use super::Escape;
 use crate::{
-    config::badge::item::{BadgeItem, Codecov, GithubActions, GithubActionsWorkflow, License},
+    config::badge::{
+        BadgeMap,
+        item::{BadgeItem, Codecov, GithubActions, GithubActionsWorkflow, License},
+    },
     manifest::{MaintenanceStatus, ManifestError},
     sync::PackageSyncContext,
 };
@@ -21,13 +24,13 @@ type CreateResult<T> = Result<T, Box<CreateBadgeError>>;
 
 pub(super) fn create_all(
     cx: &PackageSyncContext<'_>,
-    badges: &[BadgeItem],
+    badges: &BadgeMap,
 ) -> Result<String, CreateAllBadgesError> {
     let mut output = String::new();
 
     let mut errors = vec![];
 
-    for badge in badges {
+    for badge in badges.values().flatten() {
         match BadgeLinkSet::from_config(cx, badge) {
             Ok(BadgeLinkSet::None) => {}
             Ok(BadgeLinkSet::One(badge)) => writeln!(&mut output, "{badge}").unwrap(),

--- a/src/sync/contents/mod.rs
+++ b/src/sync/contents/mod.rs
@@ -10,10 +10,10 @@ mod badge;
 mod rustdoc;
 mod title;
 
-pub(super) fn create_all(
+pub(super) fn create_all<'a>(
     cx: &PackageSyncContext<'_>,
-    specifiers: Vec<Spanned<ResolvedReplaceSpecifier>>,
-) -> Result<Vec<Contents>, CreateAllContentsError> {
+    specifiers: Vec<Spanned<ResolvedReplaceSpecifier<'a>>>,
+) -> Result<Vec<Contents<'a>>, CreateAllContentsError> {
     let mut contents = vec![];
     let mut errors = vec![];
     for specifier in specifiers {
@@ -55,16 +55,16 @@ pub(super) enum CreateContentsError {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct Contents {
-    specifier: Spanned<ResolvedReplaceSpecifier>,
+pub(super) struct Contents<'a> {
+    specifier: Spanned<ResolvedReplaceSpecifier<'a>>,
     text: String,
 }
 
-fn create_content(
+fn create_content<'a>(
     cx: &PackageSyncContext<'_>,
-    specifier: Spanned<ResolvedReplaceSpecifier>,
-) -> Result<Contents, CreateContentsError> {
-    let text = match &specifier.value {
+    specifier: Spanned<ResolvedReplaceSpecifier<'a>>,
+) -> Result<Contents<'a>, CreateContentsError> {
+    let text = match specifier.value {
         ResolvedReplaceSpecifier::Title => title::create(cx),
         ResolvedReplaceSpecifier::Badge { group: _, badges } => badge::create_all(cx, badges)?,
         ResolvedReplaceSpecifier::Rustdoc => rustdoc::create(cx)?,
@@ -75,8 +75,8 @@ fn create_content(
     Ok(Contents { specifier, text })
 }
 
-impl Contents {
-    pub(super) fn specifier(&self) -> &Spanned<ResolvedReplaceSpecifier> {
+impl Contents<'_> {
+    pub(super) fn specifier(&self) -> &Spanned<ResolvedReplaceSpecifier<'_>> {
         &self.specifier
     }
 

--- a/src/sync/marker/mod.rs
+++ b/src/sync/marker/mod.rs
@@ -6,7 +6,7 @@ use pulldown_cmark::Event;
 use snafu::{Snafu, ensure};
 
 use crate::{
-    config::badge::item::BadgeItem,
+    config::badge::BadgeMap,
     source::{SourceFile, SourceFilePath, Spanned},
     sync::{
         PackageSyncContext,
@@ -36,16 +36,16 @@ pub(crate) struct ParseMarkersError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum ResolvedReplaceSpecifier {
+pub(super) enum ResolvedReplaceSpecifier<'a> {
     Title,
     Badge {
-        group: Option<Arc<str>>,
-        badges: Arc<[BadgeItem]>,
+        group: Option<&'a str>,
+        badges: &'a BadgeMap,
     },
     Rustdoc,
 }
 
-impl fmt::Display for ResolvedReplaceSpecifier {
+impl fmt::Display for ResolvedReplaceSpecifier<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Title => write!(f, "title"),
@@ -61,10 +61,10 @@ impl fmt::Display for ResolvedReplaceSpecifier {
     }
 }
 
-pub(super) fn parse_markers(
-    cx: &PackageSyncContext<'_>,
+pub(super) fn parse_markers<'cx>(
+    cx: &'cx PackageSyncContext<'_>,
     markdown: &SourceFile,
-) -> Result<Vec<Spanned<ResolvedReplaceSpecifier>>, Box<ParseMarkersError>> {
+) -> Result<Vec<Spanned<ResolvedReplaceSpecifier<'cx>>>, Box<ParseMarkersError>> {
     let mut resolver = Resolver::new(cx, markdown.text());
     let mut specifiers = vec![];
     let mut errors = vec![];
@@ -89,7 +89,7 @@ pub(super) fn parse_markers(
     Ok(specifiers)
 }
 
-pub(super) fn make_marked_contents(contents: &Contents) -> String {
+pub(super) fn make_marked_contents(contents: &Contents<'_>) -> String {
     let specifier = contents.specifier();
     let text = contents.text();
     if text.is_empty() {

--- a/src/sync/marker/resolve.rs
+++ b/src/sync/marker/resolve.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use miette::{Diagnostic, SourceSpan};
 use snafu::Snafu;
 
@@ -71,7 +69,7 @@ impl<'cx, 'markdown> Resolver<'cx, 'markdown> {
 
     pub(super) fn try_next(
         &mut self,
-    ) -> Result<Option<Spanned<ResolvedReplaceSpecifier>>, ResolveMarkerError> {
+    ) -> Result<Option<Spanned<ResolvedReplaceSpecifier<'cx>>>, ResolveMarkerError> {
         let Some(chunk) = self.scanner.try_next()? else {
             return Ok(None);
         };
@@ -80,10 +78,10 @@ impl<'cx, 'markdown> Resolver<'cx, 'markdown> {
     }
 }
 
-pub(super) fn resolve_specifier(
+pub(super) fn resolve_specifier<'a>(
     specifier: Spanned<ReplaceSpecifier<'_>>,
-    config: &Config,
-) -> Result<ResolvedReplaceSpecifier, ResolveMarkerError> {
+    config: &'a Config,
+) -> Result<ResolvedReplaceSpecifier<'a>, ResolveMarkerError> {
     let kind = specifier.value.kind;
     let group = specifier.value.group;
     match (kind.value, group) {
@@ -115,8 +113,8 @@ pub(super) fn resolve_specifier(
             .build()
         })?;
         Ok(ResolvedReplaceSpecifier::Badge {
-            group: Some(Arc::clone(group)),
-            badges: Arc::clone(badges),
+            group: Some(group),
+            badges,
         })
     } else {
         let badges = badge.default.as_ref().ok_or_else(|| {
@@ -127,22 +125,24 @@ pub(super) fn resolve_specifier(
         })?;
         Ok(ResolvedReplaceSpecifier::Badge {
             group: None,
-            badges: Arc::clone(badges),
+            badges,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::LazyLock;
+
     use similar_asserts::assert_eq;
 
     use crate::{
-        config::badge::item::BadgeItem, manifest::Manifest, source::SourceFile, sync::marker::parse,
+        config::badge::BadgeMap, manifest::Manifest, source::SourceFile, sync::marker::parse,
     };
 
     use super::*;
 
-    static CONFIG: &str = indoc::indoc! {r#"
+    static CONFIG_SOURCE: &str = indoc::indoc! {r#"
         [package]
         name = "foo"
         version = "0.1.0"
@@ -150,8 +150,13 @@ mod tests {
         [package.metadata.cargo-sync-rdme.badge.badges]
         [package.metadata.cargo-sync-rdme.badge.badges-foo]
     "#};
+    static CONFIG: LazyLock<Config> = LazyLock::new(|| {
+        let source_file = SourceFile::new_for_test("Cargo.toml", CONFIG_SOURCE);
+        let manifest = Manifest::new_for_test(&source_file).unwrap();
+        manifest.package_config().unwrap().unwrap()
+    });
 
-    impl ResolvedReplaceSpecifier {
+    impl<'a> ResolvedReplaceSpecifier<'a> {
         #[track_caller]
         pub(crate) fn into_title(self) {
             let Self::Title = self else {
@@ -167,7 +172,7 @@ mod tests {
         }
 
         #[track_caller]
-        pub(crate) fn into_badge(self) -> (Option<Arc<str>>, Arc<[BadgeItem]>) {
+        pub(crate) fn into_badge(self) -> (Option<&'a str>, &'a BadgeMap) {
             let Self::Badge { group, badges } = self else {
                 panic!("unexpected replace specifier: {self:?}");
             };
@@ -208,49 +213,46 @@ mod tests {
         }
     }
 
-    fn resolve(
+    fn resolve<'a>(
         source: Spanned<&str>,
-        config: &str,
-    ) -> Result<ResolvedReplaceSpecifier, ResolveMarkerError> {
-        let source_file = SourceFile::new_for_test("Cargo.toml", config);
-        let manifest = Manifest::new_for_test(&source_file).unwrap();
-        let config = manifest.package_config().unwrap().unwrap_or_default();
+        config: &'a Config,
+    ) -> Result<ResolvedReplaceSpecifier<'a>, ResolveMarkerError> {
         let (specifier, _rest) = parse::parse_specifier(source).unwrap().unwrap();
-        resolve_specifier(specifier, &config)
+        resolve_specifier(specifier, config)
     }
 
     #[test]
     fn resolve_marker_resolves_valid_markers() {
         let source = Spanned::from_str("title");
-        let resolved = resolve(source, CONFIG).unwrap();
+        let resolved = resolve(source, &CONFIG).unwrap();
         resolved.into_title();
 
         let source = Spanned::from_str("rustdoc");
-        let resolved = resolve(source, CONFIG).unwrap();
+        let resolved = resolve(source, &CONFIG).unwrap();
         resolved.into_rustdoc();
 
         let source = Spanned::from_str("badge");
-        let resolved = resolve(source, CONFIG).unwrap();
+        let resolved = resolve(source, &CONFIG).unwrap();
         let (group, _badges) = resolved.into_badge();
         assert!(group.is_none());
 
         let source = Spanned::from_str("badge:foo");
-        let resolved = resolve(source, CONFIG).unwrap();
+        let resolved = resolve(source, &CONFIG).unwrap();
         let (group, _badges) = resolved.into_badge();
-        assert_eq!(group.as_deref().unwrap(), "foo");
+        assert_eq!(group.unwrap(), "foo");
     }
 
     #[test]
     fn resolve_marker_rejects_invalid_markers() {
         let source = Spanned::from_str("unknown");
-        let (kind, span) = resolve(source, CONFIG)
+        let (kind, span) = resolve(source, &CONFIG)
             .unwrap_err()
             .into_unknown_marker_kind();
         assert_eq!(kind, "unknown");
         source.assert_source_span(span, "unknown");
 
         let source = Spanned::from_str("title:foo");
-        let (kind, group, span) = resolve(source, CONFIG)
+        let (kind, group, span) = resolve(source, &CONFIG)
             .unwrap_err()
             .into_unexpected_group_for_specifier();
         assert_eq!(kind, "title");
@@ -258,7 +260,7 @@ mod tests {
         source.assert_source_span(span, "title:foo");
 
         let source = Spanned::from_str("rustdoc:foo");
-        let (kind, group, span) = resolve(source, CONFIG)
+        let (kind, group, span) = resolve(source, &CONFIG)
             .unwrap_err()
             .into_unexpected_group_for_specifier();
         assert_eq!(kind, "rustdoc");
@@ -266,14 +268,14 @@ mod tests {
         source.assert_source_span(span, "rustdoc:foo");
 
         let source = Spanned::from_str("badge:bar");
-        let (group, span) = resolve(source, CONFIG)
+        let (group, span) = resolve(source, &CONFIG)
             .unwrap_err()
             .into_no_such_badge_group();
         assert_eq!(group, "bar");
         source.assert_source_span(span, "bar");
 
         let source = Spanned::from_str("badge");
-        let span = resolve(source, "")
+        let span = resolve(source, &Config::default())
             .unwrap_err()
             .into_no_default_badge_configured();
         source.assert_source_span(span, "badge");

--- a/src/sync/replace.rs
+++ b/src/sync/replace.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, iter, range::Range};
 
 use crate::sync::{contents::Contents, marker};
 
-pub(in super::super) fn replace_all(text: &str, contents: &[Contents]) -> String {
+pub(in super::super) fn replace_all(text: &str, contents: &[Contents<'_>]) -> String {
     let pairs = contents
         .iter()
         .map(|contents| (contents, contents.specifier().span));


### PR DESCRIPTION
## Summary
- change badge configuration storage from ordered lists to ordered maps keyed by badge item
- preserve explicit `false` entries so item-level config merges can disable inherited badge items later
- remove unnecessary `Arc` cloning from badge resolution/sync paths and borrow config data instead

## Motivation
This refactor prepares for `workspace.metadata` support where badge settings will be merged item by item while preserving declaration order and explicit disables.

## Validation
- `cargo test` (reported by author)
- `cargo check`