### PR TITLE
Disable implicit mise installs in GitHub Actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,10 +14,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
-
-permissions: {}
+  # Disable implicit auto-install to prevent `mise` commands,
+  # especially `mise run`, from accidentally installing the
+  # default `rust = "stable"` toolchain from `mise.toml`.
+  MISE_AUTO_INSTALL: false
 
 jobs:
   issue-reporting:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,10 +13,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
-
-permissions: {}
+  # Disable implicit auto-install to prevent `mise` commands,
+  # especially `mise run`, from accidentally installing the
+  # default `rust = "stable"` toolchain from `mise.toml`.
+  MISE_AUTO_INSTALL: false
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
-
-permissions: {}
+  # Disable implicit auto-install to prevent `mise` commands,
+  # especially `mise run`, from accidentally installing the
+  # default `rust = "stable"` toolchain from `mise.toml`.
+  MISE_AUTO_INSTALL: false
 
 jobs:
   set-matrix:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,14 +6,21 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pages: write
   id-token: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
+env:
+  CARGO_TERM_COLOR: always
+  # Disable implicit auto-install to prevent `mise` commands,
+  # especially `mise run`, from accidentally installing the
+  # default `rust = "stable"` toolchain from `mise.toml`.
+  MISE_AUTO_INSTALL: false
 
 jobs:
   build:

--- a/.github/workflows/renovate-post-update.yml
+++ b/.github/workflows/renovate-post-update.yml
@@ -4,13 +4,20 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.actor == 'renovate[bot]' }}
+
 permissions:
   contents: read
   pull-requests: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.actor == 'renovate[bot]' }}
+env:
+  CARGO_TERM_COLOR: always
+  # Disable implicit auto-install to prevent `mise` commands,
+  # especially `mise run`, from accidentally installing the
+  # default `rust = "stable"` toolchain from `mise.toml`.
+  MISE_AUTO_INSTALL: false
 
 jobs:
   renovate-post-update:


### PR DESCRIPTION
## Background

Some CI jobs set `MISE_RUST_VERSION`, but running `mise` in workflow steps could still implicitly install or update the `rust = "stable"` toolchain declared in `mise.toml`.

On Windows, that extra `rust@stable` update sometimes failed while `rustup` was replacing files in the toolchain directory, causing CI to fail.

## What changed

- set `MISE_AUTO_INSTALL: false` in workflows that run `mise`
- add an inline comment explaining why implicit auto-install is disabled
- normalize the top-level workflow key order as incidental cleanup

Affected workflows:

- `.github/workflows/audit.yml`
- `.github/workflows/cd.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/pages.yml`
- `.github/workflows/renovate-post-update.yml`

## Validation

- `mise run lint:workflow`

## Impact

Workflow steps that run `mise` will no longer trigger implicit tool installation from `mise.toml`.

Explicit installation in workflow setup steps is unchanged, and explicit `rustup toolchain install ...` commands inside `mise` tasks are unchanged.

This removes the redundant `rust@stable` install or update path in CI and should avoid the Windows failure mode seen when `rustup` replaces files in the stable toolchain directory.