### PR TITLE
Move CI Rust toolchain setup from mise to rust-toolchain

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,10 +18,6 @@ permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
-  # Disable implicit auto-install to prevent `mise` commands,
-  # especially `mise run`, from accidentally installing the
-  # default `rust = "stable"` toolchain from `mise.toml`.
-  MISE_AUTO_INSTALL: false
 
 jobs:
   issue-reporting:
@@ -39,6 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
       - run: mise run audit:advisories
@@ -49,6 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
       - run: mise run audit:policy

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,10 +17,6 @@ permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
-  # Disable implicit auto-install to prevent `mise` commands,
-  # especially `mise run`, from accidentally installing the
-  # default `rust = "stable"` toolchain from `mise.toml`.
-  MISE_AUTO_INSTALL: false
 
 jobs:
   build:
@@ -41,10 +37,11 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: windows-11-arm
             target: aarch64-pc-windows-msvc
-    env:
-      MISE_RUST_VERSION: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,6 @@ permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
-  # Disable implicit auto-install to prevent `mise` commands,
-  # especially `mise run`, from accidentally installing the
-  # default `rust = "stable"` toolchain from `mise.toml`.
-  MISE_AUTO_INSTALL: false
 
 jobs:
   set-matrix:
@@ -28,6 +24,9 @@ jobs:
       os: ${{ steps.set-values.outputs.os }}
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
       - name: Set matrix values
@@ -56,10 +55,11 @@ jobs:
         rust: ${{ fromJSON(needs.set-matrix.outputs.rust) }}
         os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
     runs-on: ${{ matrix.os }}
-    env:
-      MISE_RUST_VERSION: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:check-rust
@@ -74,10 +74,11 @@ jobs:
         rust: [stable]
         os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
     runs-on: ${{ matrix.os }}
-    env:
-      MISE_RUST_VERSION: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:check-rustdoc
@@ -92,10 +93,11 @@ jobs:
         rust: [stable]
         os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
     runs-on: ${{ matrix.os }}
-    env:
-      MISE_RUST_VERSION: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:check-unused-deps
@@ -111,6 +113,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:lint-rustfmt
@@ -125,10 +130,11 @@ jobs:
         rust: [stable]
         os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
     runs-on: ${{ matrix.os }}
-    env:
-      MISE_RUST_VERSION: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:lint-rust
@@ -143,11 +149,14 @@ jobs:
         rust: ${{ fromJSON(needs.set-matrix.outputs.rust) }}
         os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
     runs-on: ${{ matrix.os }}
-    env:
-      MISE_RUST_VERSION: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
       - uses: jdx/mise-action@v4
+      - run: mise run install-toolchains-for-rust-test
+        shell: bash
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:test-rust
         shell: bash
@@ -161,11 +170,14 @@ jobs:
         rust: [stable]
         os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
     runs-on: ${{ matrix.os }}
-    env:
-      MISE_RUST_VERSION: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
       - uses: jdx/mise-action@v4
+      - run: mise run install-toolchains-for-rust-test
+        shell: bash
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:coverage-rust-test
         shell: bash
@@ -184,11 +196,14 @@ jobs:
         rust: [stable]
         os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
     runs-on: ${{ matrix.os }}
-    env:
-      MISE_RUST_VERSION: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
       - uses: jdx/mise-action@v4
+      - run: mise run install-toolchains-for-rust-run
+        shell: bash
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:coverage-rust-run
         shell: bash
@@ -206,10 +221,11 @@ jobs:
         rust: [stable]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    env:
-      MISE_RUST_VERSION: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
       - run: mise run check:release --skip-ci
@@ -251,11 +267,14 @@ jobs:
         rust: [stable]
         os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
     runs-on: ${{ matrix.os }}
-    env:
-      MISE_RUST_VERSION: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
       - uses: jdx/mise-action@v4
+      - run: mise run install-toolchains-for-sync-markdown
+        shell: bash
       - uses: Swatinem/rust-cache@v2
       - run: mise run ci:sync-markdown
         shell: bash

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,10 +17,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # Disable implicit auto-install to prevent `mise` commands,
-  # especially `mise run`, from accidentally installing the
-  # default `rust = "stable"` toolchain from `mise.toml`.
-  MISE_AUTO_INSTALL: false
 
 jobs:
   build:
@@ -28,6 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
       - uses: jdx/mise-action@v4
       - uses: Swatinem/rust-cache@v2
       - run: mise run pages:build

--- a/.github/workflows/renovate-post-update.yml
+++ b/.github/workflows/renovate-post-update.yml
@@ -14,10 +14,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # Disable implicit auto-install to prevent `mise` commands,
-  # especially `mise run`, from accidentally installing the
-  # default `rust = "stable"` toolchain from `mise.toml`.
-  MISE_AUTO_INSTALL: false
 
 jobs:
   renovate-post-update:
@@ -29,7 +25,12 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           persist-credentials: false
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
       - uses: jdx/mise-action@v4
+      - run: mise run install-toolchains-for-renovate-post-update
+        shell: bash
       - uses: Swatinem/rust-cache@v2
       - run: mise run renovate-post-update
         shell: bash

--- a/.mise/tasks/markdown.toml
+++ b/.mise/tasks/markdown.toml
@@ -1,10 +1,14 @@
+["install-toolchains-for-sync-markdown"]
+description = "Install Rust toolchain for synchronizing markdown"
+depends = ["install-nightly-toolchain"]
+
 ["sync:markdown"]
 description = "Synchronize Markdown files with Rust doc comments"
 usage = '''
 flag "--check" help="Run cargo-sync-rdme in check mode"
 flag "--allow-dirty" help="Sync Markdown files even if the target file is dirty"
 '''
-depends = ["install-toolchains-for-sync-rdme"]
+depends = ["install-toolchains-for-sync-markdown"]
 run = '''
 cargo run -- --workspace
   {{- ' --check' if usage.check else '' }}

--- a/.mise/tasks/pages.toml
+++ b/.mise/tasks/pages.toml
@@ -1,9 +1,8 @@
 ["pages:build"]
 description = "Build the documentation for GitHub Pages"
-depends = ["install-toolchains-for-sync-rdme"]
 run = [
   '''
-  cargo +nightly doc --workspace --all-features --no-deps
+  cargo doc --workspace --all-features --no-deps
   ''',
   '''
   echo '<meta http-equiv="refresh" content="0; url=./cargo_sync_rdme/">' > target/doc/index.html

--- a/.mise/tasks/renovate.toml
+++ b/.mise/tasks/renovate.toml
@@ -1,4 +1,8 @@
-["renovate-post-update"]
+[install-toolchains-for-renovate-post-update]
+description = "Install toolchains for Renovate post-update tasks"
+depends = ["install-toolchains-for-sync-markdown"]
+
+[renovate-post-update]
 description = "Run Renovate post-update tasks"
 depends = [
   "format:*",

--- a/.mise/tasks/rust.toml
+++ b/.mise/tasks/rust.toml
@@ -5,20 +5,9 @@ run = [
   "cargo -vV",
 ]
 
-["install-toolchains-for-rust-test"]
-description = "Install Rust toolchains for test"
-run = [
-  "rustup toolchain install nightly",
-  # toolchains used in `tests/toolchain_version.rs`
-  "rustup toolchain install beta",
-  "rustup toolchain install 1.90.0",
-]
-
-["install-toolchains-for-sync-rdme"]
-description = "Install Rust toolchain for running cargo-sync-rdme"
-run = [
-  "rustup toolchain install nightly",
-]
+[install-nightly-toolchain]
+description = "Install Rust nightly toolchain"
+run = "rustup toolchain install nightly"
 
 ["format:rust"]
 description = "Format Rust files"
@@ -66,6 +55,15 @@ description = "Run Rust tests across exhaustive feature combinations"
 depends = ["install-toolchains-for-rust-test"]
 run = "cargo hack --workspace --feature-powerset test"
 
+[install-toolchains-for-rust-test]
+description = "Install Rust toolchains for test"
+depends = ["install-nightly-toolchain"]
+run = [
+  # toolchains used in `tests/toolchain_version.rs`
+  "rustup toolchain install beta",
+  "rustup toolchain install 1.90.0",
+]
+
 ["coverage:rust-test"]
 description = "Run Rust tests with coverage"
 usage = '''
@@ -85,13 +83,17 @@ cargo llvm-cov --workspace --all-features
   {{- '' }} test
 '''
 
+[install-toolchains-for-rust-run]
+description = "Install Rust toolchains for running cargo-sync-rdme"
+depends = ["install-nightly-toolchain"]
+
 ["coverage:rust-run"]
 description = "Run Rust program with coverage"
 usage = '''
 flag "--codecov" help="Export coverage data in \"Codecov Custom Coverage\" format"
 flag "--output-path <output>" help="Specify a file to write coverage data into."
 '''
-depends = ["install-toolchains-for-sync-rdme"]
+depends = ["install-toolchains-for-rust-run"]
 # cargo-llvm-cov cleans its working directories at runtime, so test/run coverage
 # tasks must use separate directories when invoked from aggregate CI tasks.
 env = { CARGO_LLVM_COV_TARGET_DIR = "target/llvm-cov-target-run", CARGO_LLVM_COV_BUILD_DIR = "target/llvm-cov-target-run" }

--- a/mise.lock
+++ b/mise.lock
@@ -150,14 +150,6 @@ specifiers = ["44.69.6"]
 [tools."npm:renovate".options]
 trust_policy_excludes = '["@yarnpkg/libzip@3.2.2"]'
 
-[[tools.rust]]
-version = "stable"
-backend = "core:rust"
-specifiers = ["stable"]
-
-[tools.rust.options]
-components = "llvm-tools"
-
 [[tools.shellcheck]]
 version = "0.11.0"
 backend = "aqua:koalaman/shellcheck"

--- a/mise.toml
+++ b/mise.toml
@@ -22,7 +22,6 @@ cargo-binstall = "1.23.0"  # lets mise install cargo:* tools from binaries inste
 editorconfig-checker = "3.11.3"
 "npm:markdownlint-cli" = "0.49.1"
 "npm:renovate" = { version = "44.69.6", trust_policy_excludes = ["@yarnpkg/libzip@3.2.2"] }
-rust = { version = "stable", components = ["llvm-tools"] }
 shellcheck = "0.11.0"
 shfmt = "3.14.1"
 tombi = "1.5.3"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,2 @@
 [toolchain]
-channel = "stable"
-profile = "default"
-components = ["llvm-tools"]
+components = ["rustfmt", "clippy", "llvm-tools"]


### PR DESCRIPTION
## Summary
- move default Rust toolchain setup in CI from `mise` to `dtolnay/rust-toolchain`
- remove Rust from `mise.toml` and `mise.lock`
- update `rust-toolchain.toml` to declare shared Rust components without forcing all jobs to use `stable`
- keep `jdx/mise-action` for non-Rust tools and `mise run`
- install any additional Rust toolchains required by a job before `Swatinem/rust-cache`
- build Pages docs with the job's selected toolchain instead of forcing `nightly`

## Why
This repository previously let `mise` manage Rust in GitHub Actions.

[#837](https://github.com/gifnksm/cargo-sync-rdme/pull/837) disabled implicit `mise` auto-installs to avoid one specific failure mode. This PR addresses a different concern: CI was still relying on mise-managed `rust@stable` restored by `jdx/mise-action`.

When `rust@stable` came from the `mise` cache, the restored toolchain was not guaranteed to match the current Rust stable release. That meant a job could run with an older stable toolchain than intended.

This change moves the main CI Rust toolchain setup to `dtolnay/rust-toolchain` and `Swatinem/rust-cache`, so the toolchain selected by the workflow no longer depends on cached mise-managed Rust state.

Some jobs also need additional toolchains such as `nightly`, `beta`, or a pinned stable release. Those requirements remain attached to the tasks that need them, but the affected workflows now install those toolchains before `Swatinem/rust-cache` so the cache reflects the full set of toolchains used by the job.

## Rust requirements
`rust-toolchain.toml` still carries the repository's shared Rust requirements, but it no longer forces every command in the repository to use `stable`.

Removing `channel = "stable"` prevents plain `cargo` and `rustc` invocations in the repository from being pulled back to `stable` in jobs that intentionally selected a different toolchain, such as the MSRV.

The file now lists the shared components directly (`rustfmt`, `clippy`, and `llvm-tools`) instead of relying on `profile = "default"` plus an extra component.

Because Rust is no longer managed through `mise`, the workflows also no longer need the earlier Rust-specific `MISE_AUTO_INSTALL` safeguard.

## Scope
This change does not move all Rust-related configuration into workflow YAML.

- `rust-toolchain.toml` still declares repository-wide Rust requirements.
- Tasks still declare any extra toolchains they require so local `mise run` usage remains self-contained.

The goal of this PR is narrower: stop using `mise` as the default Rust toolchain manager for CI.

## Validation
- `mise run ci:lint-workflow`
- `mise run ci:lint-toml`
- `mise run pages:build`
- `git diff --check`
