### PR TITLE
Use --no-deps for CI MSRV lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,11 @@ jobs:
       - name: Set matrix values
         id: set-values
         run: |
-          root_package_id="$(cargo metadata --format-version 1 | jq -cr '.resolve.root')"
-          root_package="$(cargo metadata --format-version 1 | jq -c --arg pkgid "${root_package_id}" '.packages[] | select(.id == $pkgid)')"
-          echo "${root_package}" | jq -c '{ root_package: .name }'
-
-          msrv="$(echo "${root_package}" | jq '.rust_version')"
-          rust="$(echo "[\"stable\", ${msrv}]" | jq -c)"
+          msrv="$(./scripts/print-msrv)"
+          rust="$(jq -c <<< "[\"stable\", \"${msrv}\"]")"
           echo "rust=${rust}" >> "$GITHUB_OUTPUT"
 
-          os="$(echo '["ubuntu-latest", "macos-latest", "windows-latest"]' | jq -c)"
+          os="$(jq -c <<< '["ubuntu-latest", "macos-latest", "windows-latest"]')"
           echo "os=${os}" >> "$GITHUB_OUTPUT"
 
           jq -n --argjson rust "${rust}" --argjson os "${os}" '{ rust: $rust, os: $os }'

--- a/scripts/print-msrv
+++ b/scripts/print-msrv
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cargo_metadata="$(cargo metadata --no-deps --format-version 1)"
+workspace_root="$(jq -cr '.workspace_root' <<<"${cargo_metadata}")"
+root_package_manifest_path="${workspace_root}/Cargo.toml"
+root_package_id="$(jq -r --arg path "${root_package_manifest_path}" '.packages[] | select(.manifest_path == $path) | .id' <<<"${cargo_metadata}")"
+
+if [[ -z "${root_package_id}" ]]; then
+    echo "error: could not find root package for workspace: ${workspace_root}" >&2
+    exit 1
+fi
+
+root_package="$(jq -c --arg pkgid "${root_package_id}" '.packages[] | select(.id == $pkgid)' <<<"${cargo_metadata}")"
+
+# For debugging
+jq -c '{ root_package: { name: .name, rust_version: .rust_version } }' <<<"${root_package}" >&2
+
+msrv="$(jq -r '.rust_version' <<<"${root_package}")"
+if [[ "${msrv}" == "null" ]]; then
+    echo "error: rust-version field is not set in root package manifest: ${root_package_manifest_path}" >&2
+    exit 1
+fi
+
+echo "${msrv}"


### PR DESCRIPTION
## Summary
- move the MSRV lookup in `set-matrix` into `scripts/print-msrv`
- call `cargo metadata --no-deps --format-version 1` so CI does not need to download dependencies just to read `rust_version`
- fail with a clear error if the root package or its `rust-version` cannot be found

## Background
`cargo metadata --no-deps` still includes workspace member package metadata, which is enough to read the root package `rust_version`, while omitting the resolved dependency graph.

## Validation
- `./scripts/print-msrv`
- `bash -n scripts/print-msrv`
- `mise run ci:lint-workflow`
