### PR TITLE
Remove cargo-edit from mise config

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -77,11 +77,6 @@ version = "0.20.2"
 backend = "cargo:cargo-deny"
 specifiers = ["0.20.2"]
 
-[[tools."cargo:cargo-edit"]]
-version = "0.13.13"
-backend = "cargo:cargo-edit"
-specifiers = ["0.13.13"]
-
 [[tools."cargo:cargo-hack"]]
 version = "0.6.45"
 backend = "cargo:cargo-hack"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [settings]
 lockfile = true
-cargo.binstall_quickinstall = true  # cargo-edit binaries are only available via cargo-binstall quickinstall
+cargo.binstall_only = true
 lockfile_platforms = [
   "linux-x64",
   "linux-arm64",
@@ -13,7 +13,6 @@ lockfile_platforms = [
 actionlint = "1.7.12"
 cargo-binstall = "1.23.0"  # lets mise install cargo:* tools from binaries instead of compiling them
 "cargo:cargo-deny" = "0.20.2"
-"cargo:cargo-edit" = "0.13.13"
 "cargo:cargo-hack" = "0.6.45"
 "cargo:cargo-llvm-cov" = "0.9.1"
 "cargo:cargo-machete" = "0.9.2"


### PR DESCRIPTION
## Summary
- remove `cargo-edit` from `mise.toml` and `mise.lock`
- drop the old `cargo.binstall_quickinstall` override and its outdated comment
- set `cargo.binstall_only = true` so `cargo:*` tools do not fall back to source installs

## Motivation
`cargo-upgrade` is no longer used, so `cargo-edit` is no longer needed in the mise toolchain.
Keep the cargo install policy explicit by requiring binary installs for configured `cargo:*` tools.

## Validation
- `mise install --dry-run`
- `mise run ci:lint-toml`
