### PR TITLE
Remove workflow CARGO_TERM_COLOR overrides

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,9 +16,6 @@ concurrency:
 
 permissions: {}
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   issue-reporting:
     name: Audit (issue reporting)

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,9 +15,6 @@ concurrency:
 
 permissions: {}
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ concurrency:
 
 permissions: {}
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   set-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,9 +15,6 @@ permissions:
   pages: write
   id-token: write
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   build:
     name: "Build"

--- a/.github/workflows/renovate-post-update.yml
+++ b/.github/workflows/renovate-post-update.yml
@@ -12,9 +12,6 @@ permissions:
   contents: read
   pull-requests: write
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   renovate-post-update:
     if: github.actor == 'renovate[bot]'


### PR DESCRIPTION
## Summary
- remove workflow-level `CARGO_TERM_COLOR: always` from the GitHub Actions workflows
- rely on `dtolnay/rust-toolchain@v1` to set `CARGO_TERM_COLOR` in jobs that use that action
- keep the workflow behavior otherwise unchanged

## Notes
- `audit.yml`'s `issue-reporting` job does not use `dtolnay/rust-toolchain`, but it runs `actions-rust-lang/audit` via `cargo audit --json`, so removing this env there should only affect log coloring, not the job behavior

## Validation
- `mise run ci:lint-workflow`