### PR TITLE
Enable Renovate GitHub Actions digest pinning

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
 
   // Allow Renovate to open or refresh dependency update branches on Mondays
   // without depending on an exact run time.


### PR DESCRIPTION
## Summary
- enable Renovate's `helpers:pinGitHubActionDigests` preset in `renovate.jsonc`
- allow Renovate to open PRs that pin GitHub Actions `uses:` references to full digests
- keep the existing Renovate schedule and package rules unchanged

## Validation
- `mise run lint:renovate`

## Impact
Renovate will start proposing digest-pinning updates for GitHub Actions workflow dependencies, such as converting version-tagged `uses:` references into digest-pinned references while preserving the source tag in a comment.