### PR TITLE
Route --check diffs to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Bump MSRV from 1.96.0 to 1.98.0
 * Use the same styling for `--help` output as Cargo.
 * When `--color` is not specified, colored output now follows whether stderr is connected to a terminal and respects the `NO_COLOR` and `FORCE_COLOR` environment variables.
+* In `--check` mode, emit the generated diff on stdout instead of stderr. Diagnostics and log output continue to go to stderr.
 * Respect the `CARGO` environment variable when invoking Cargo to build rustdoc output, except when `--toolchain` is specified.
 * When neither `--package` nor `--workspace` is specified, select Cargo's default workspace packages instead of always syncing only the workspace root package.
 * Remove timestamps from messages shown during synchronization.

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -3,6 +3,8 @@ use std::{fmt, io};
 use similar::{ChangeTag, TextDiff};
 use supports_color::Stream;
 
+use crate::terminal::StreamInfo;
+
 #[derive(Debug)]
 struct Line(Option<usize>);
 
@@ -17,17 +19,17 @@ impl fmt::Display for Line {
 
 #[derive(Debug)]
 struct DiffStyler {
-    stream: Stream,
+    stream: StreamInfo,
 }
 
 impl DiffStyler {
-    fn new(stream: Stream) -> Self {
+    fn new(stream: StreamInfo) -> Self {
         Self { stream }
     }
 
     fn style(&self) -> console::Style {
         let s = console::Style::new();
-        match self.stream {
+        match self.stream.kind() {
             Stream::Stdout => s.for_stdout(),
             Stream::Stderr => s.for_stderr(),
         }
@@ -35,18 +37,18 @@ impl DiffStyler {
 
     fn styled<D>(&self, val: D) -> console::StyledObject<D> {
         let s = console::style(val);
-        match self.stream {
+        match self.stream.kind() {
             Stream::Stdout => s.for_stdout(),
             Stream::Stderr => s.for_stderr(),
         }
     }
 }
 
-pub(crate) fn write_pretty_diff(stream: Stream, old: &str, new: &str) -> Result<(), io::Error> {
+pub(crate) fn write_pretty_diff(stream: StreamInfo, old: &str, new: &str) -> Result<(), io::Error> {
     let styling = DiffStyler::new(stream);
     let diff = TextDiff::from_lines(old, new);
 
-    let mut output: &mut dyn io::Write = match stream {
+    let mut output: &mut dyn io::Write = match stream.kind() {
         Stream::Stdout => &mut io::stdout().lock(),
         Stream::Stderr => &mut io::stderr().lock(),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@
 use std::{assert_matches, env, io, process};
 
 use cargo_metadata::{Metadata, Package};
-use clap::{ColorChoice, CommandFactory as _};
+use clap::CommandFactory as _;
 use clap_complete::{Generator, Shell};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 use miette::MietteHandlerOpts;
@@ -27,6 +27,7 @@ use crate::{
     config::{Config, ConfigLoader},
     manifest::ManifestLoader,
     sync::PackageSyncContext,
+    terminal::Terminal,
 };
 
 mod args;
@@ -37,6 +38,7 @@ mod manifest;
 mod parse;
 mod source;
 mod sync;
+mod terminal;
 #[cfg(test)]
 mod testing;
 mod traits;
@@ -55,12 +57,9 @@ fn main() -> miette::Result<()> {
     }
 
     let args = args::parse();
-    let output_stream = Stream::Stderr;
-    let diff_stream = output_stream;
-    let use_color = should_use_color(args.color, output_stream);
-    set_console_color(use_color, output_stream);
-    set_miette_hook(use_color, output_stream);
-    install_logger(args.verbosity, use_color, output_stream);
+    let terminal = Terminal::init(args.color);
+    set_miette_hook(&terminal);
+    install_logger(&terminal, args.verbosity);
 
     let workspace = cargo::metadata(&args.manifest)?;
     let mut manifest_loader = ManifestLoader::new(&workspace);
@@ -71,7 +70,7 @@ fn main() -> miette::Result<()> {
             build_package_context(
                 &mut manifest_loader,
                 &mut config_loader,
-                diff_stream,
+                &terminal,
                 &args,
                 &workspace,
                 package,
@@ -85,34 +84,25 @@ fn main() -> miette::Result<()> {
     Ok(())
 }
 
-fn should_use_color(choice: ColorChoice, stream: Stream) -> bool {
-    match choice {
-        ColorChoice::Always => true,
-        ColorChoice::Auto => supports_color::on(stream).is_some(),
-        ColorChoice::Never => false,
-    }
-}
+fn set_miette_hook(terminal: &Terminal) {
+    let stream = terminal.diagnostic_stream();
 
-fn set_console_color(use_color: bool, stream: Stream) {
-    match stream {
-        Stream::Stdout => console::set_colors_enabled(use_color),
-        Stream::Stderr => console::set_colors_enabled_stderr(use_color),
-    }
-}
-
-fn set_miette_hook(use_color: bool, stream: Stream) {
     // Keep the same `Stream`-based interface as the other setup functions, but
     // errors returned from `main` are always printed to stderr, so only
     // `Stream::Stderr` is valid here.
-    assert_matches!(stream, Stream::Stderr);
+    assert_matches!(stream.kind(), Stream::Stderr);
 
     miette::set_hook(Box::new(move |_| {
-        Box::new(MietteHandlerOpts::new().color(use_color).build())
+        Box::new(
+            MietteHandlerOpts::new()
+                .color(stream.should_use_color())
+                .build(),
+        )
     }))
     .unwrap();
 }
 
-fn install_logger(verbosity: Verbosity<InfoLevel>, use_color: bool, stream: Stream) {
+fn install_logger(terminal: &Terminal, verbosity: Verbosity<InfoLevel>) {
     let env_filter = if !verbosity.is_present() && env::var_os("RUST_LOG").is_some() {
         EnvFilter::from_default_env()
     } else {
@@ -128,14 +118,15 @@ fn install_logger(verbosity: Verbosity<InfoLevel>, use_color: bool, stream: Stre
             .with_default_directive(default_level.into())
             .from_env_lossy()
     };
-    let writer = match stream {
+    let stream = terminal.log_stream();
+    let writer = match stream.kind() {
         Stream::Stdout => BoxMakeWriter::new(io::stdout),
         Stream::Stderr => BoxMakeWriter::new(io::stderr),
     };
 
     tracing_subscriber::fmt()
         .with_env_filter(env_filter)
-        .with_ansi(use_color)
+        .with_ansi(stream.should_use_color())
         .with_writer(writer)
         .with_target(false)
         .without_time()
@@ -169,7 +160,7 @@ fn generate_man(output_dir: &str) {
 fn build_package_context<'a>(
     manifest_loader: &mut ManifestLoader<'_>,
     config_loader: &mut ConfigLoader,
-    diff_stream: Stream,
+    terminal: &'a Terminal,
     args: &'a Args,
     workspace: &'a Metadata,
     package: &'a Package,
@@ -179,11 +170,6 @@ fn build_package_context<'a>(
         .map_err(|source| miette::Report::new_boxed(source))?;
     let config = Config::load(manifest_loader, config_loader, args, package)?;
     Ok(PackageSyncContext::new(
-        diff_stream,
-        args,
-        workspace,
-        package,
-        manifest,
-        config,
+        terminal, args, workspace, package, manifest, config,
     ))
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -2,7 +2,6 @@ use std::{io, sync::Arc};
 
 use cargo_metadata::{Metadata, Package, PackageName};
 use snafu::{ResultExt as _, Snafu, ensure};
-use supports_color::Stream;
 use tracing::Level;
 use vcs_modify_guard::{AllowOptions, ModificationSafety, UnsafeModificationReason};
 
@@ -13,6 +12,7 @@ use crate::{
     manifest::Manifest,
     source::{SourceFile, SourceFileLoader, SourceFilePath},
     sync::{contents::CreateAllContentsError, marker::ParseMarkersError},
+    terminal::Terminal,
 };
 
 mod contents;
@@ -119,7 +119,7 @@ impl From<CreateAllContentsError> for Box<SyncError> {
 pub(crate) struct PackageSyncContext<'a> {
     mode: Mode,
     verbosity: Option<Level>,
-    diff_stream: Stream,
+    terminal: &'a Terminal,
     fix: &'a FixArgs,
     install_toolchain: bool,
     feature: &'a FeatureSelection,
@@ -131,7 +131,7 @@ pub(crate) struct PackageSyncContext<'a> {
 
 impl<'a> PackageSyncContext<'a> {
     pub(crate) fn new(
-        diff_stream: Stream,
+        terminal: &'a Terminal,
         args: &'a Args,
         workspace: &'a Metadata,
         package: &'a Package,
@@ -139,7 +139,7 @@ impl<'a> PackageSyncContext<'a> {
         config: Config,
     ) -> Self {
         Self {
-            diff_stream,
+            terminal,
             mode: args.mode.mode(),
             verbosity: args.verbosity.into(),
             fix: &args.fix,
@@ -201,7 +201,7 @@ pub(crate) fn sync_all(cx: &PackageSyncContext<'_>) -> Result<(), Box<SyncError>
                     "markdown file is not up to date: {}",
                     loader.workspace_path()
                 );
-                diff::write_pretty_diff(cx.diff_stream, markdown.text(), &new_text)
+                diff::write_pretty_diff(cx.terminal.output_stream(), markdown.text(), &new_text)
                     .context(WriteDiffSnafu)?;
                 return Err(CheckFailedSnafu {
                     package: cx.package.name.clone(),

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,0 +1,58 @@
+use clap::ColorChoice;
+use supports_color::Stream;
+
+#[derive(Debug)]
+pub(crate) struct Terminal {
+    stdout: StreamInfo,
+    stderr: StreamInfo,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StreamInfo {
+    kind: Stream,
+    should_use_color: bool,
+}
+
+impl Terminal {
+    pub(crate) fn init(choice: ColorChoice) -> Self {
+        let stdout = StreamInfo::new(Stream::Stdout, choice);
+        let stderr = StreamInfo::new(Stream::Stderr, choice);
+        console::set_colors_enabled(stdout.should_use_color);
+        console::set_colors_enabled_stderr(stderr.should_use_color);
+        Self { stdout, stderr }
+    }
+
+    pub(crate) fn diagnostic_stream(&self) -> StreamInfo {
+        self.stderr
+    }
+
+    pub(crate) fn log_stream(&self) -> StreamInfo {
+        self.stderr
+    }
+
+    pub(crate) fn output_stream(&self) -> StreamInfo {
+        self.stdout
+    }
+}
+
+impl StreamInfo {
+    pub(crate) fn new(kind: Stream, choice: ColorChoice) -> Self {
+        let should_use_color = match choice {
+            ColorChoice::Always => true,
+            ColorChoice::Auto => supports_color::on(kind).is_some(),
+            ColorChoice::Never => false,
+        };
+        Self {
+            kind,
+            should_use_color,
+        }
+    }
+
+    pub(crate) fn kind(self) -> Stream {
+        self.kind
+    }
+
+    pub(crate) fn should_use_color(self) -> bool {
+        self.should_use_color
+    }
+}

--- a/tests/fixtures/snapshots/check_output/pkg-a.stderr.term.svg
+++ b/tests/fixtures/snapshots/check_output/pkg-a.stderr.term.svg
@@ -1,8 +1,7 @@
-<svg width="740px" height="290px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
-    .bg-black { stroke: #000000; fill: #000000; user-select: none;  }
     .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
@@ -11,7 +10,6 @@
       line-height: 18px;
     }
     .bold { font-weight: bold; }
-    .underline { text-decoration-line: underline; }
     .dimmed { opacity: 0.4; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
@@ -29,33 +27,11 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-yellow"> WARN</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> markdown file is not up to date: pkg-a/README.md</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="dimmed">   2</tspan><tspan class="dimmed">   2</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan>
+    <tspan x="10px" y="82px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> markdown file for package `pkg-a` is not up to date: pkg-a/README.md</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="dimmed">   3</tspan><tspan class="dimmed">   3</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- cargo-sync-rdme rustdoc [[ --&gt;</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="dimmed">   4</tspan><tspan class="dimmed">   4</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- SYNC_RDME_INTEGRATION_TEST::SPAN_START --&gt;</tspan>
-</tspan>
-    <tspan x="10px" y="136px"><tspan>    </tspan><tspan>    </tspan><tspan>  </tspan><tspan> </tspan><tspan>  </tspan><tspan class="bg-black">███████████</tspan>
-</tspan>
-    <tspan x="10px" y="136px"><tspan class="dimmed">   5</tspan><tspan class="dimmed">    </tspan><tspan> │</tspan><tspan class="fg-red bold">-</tspan><tspan class="fg-red">* </tspan><tspan class="fg-red underline">NOT_UPDATED</tspan>
-</tspan>
-    <tspan x="10px" y="154px"><tspan class="dimmed">    </tspan><tspan class="dimmed">   5</tspan><tspan> │</tspan><tspan class="fg-green bold">+</tspan>
-</tspan>
-    <tspan x="10px" y="172px"><tspan>    </tspan><tspan>    </tspan><tspan>  </tspan><tspan> </tspan><tspan>  </tspan><tspan class="bg-black">███████</tspan>
-</tspan>
-    <tspan x="10px" y="172px"><tspan class="dimmed">    </tspan><tspan class="dimmed">   6</tspan><tspan> │</tspan><tspan class="fg-green bold">+</tspan><tspan class="fg-green">* </tspan><tspan class="fg-green underline">UPDATED</tspan>
-</tspan>
-    <tspan x="10px" y="190px"><tspan class="dimmed">    </tspan><tspan class="dimmed">   7</tspan><tspan> │</tspan><tspan class="fg-green bold">+</tspan>
-</tspan>
-    <tspan x="10px" y="208px"><tspan class="dimmed">   6</tspan><tspan class="dimmed">   8</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- SYNC_RDME_INTEGRATION_TEST::SPAN_END --&gt;</tspan>
-</tspan>
-    <tspan x="10px" y="226px"><tspan class="dimmed">   7</tspan><tspan class="dimmed">   9</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
-</tspan>
-    <tspan x="10px" y="244px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> markdown file for package `pkg-a` is not up to date: pkg-a/README.md</tspan>
-</tspan>
-    <tspan x="10px" y="262px">
-</tspan>
-    <tspan x="10px" y="280px">
+    <tspan x="10px" y="118px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/check_output/pkg-a.stdout.term.svg
+++ b/tests/fixtures/snapshots/check_output/pkg-a.stdout.term.svg
@@ -1,0 +1,51 @@
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .bg-black { stroke: #000000; fill: #000000; user-select: none;  }
+    .fg-green { fill: #00AA00 }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    .dimmed { opacity: 0.4; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="dimmed">   2</tspan><tspan class="dimmed">   2</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="dimmed">   3</tspan><tspan class="dimmed">   3</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- cargo-sync-rdme rustdoc [[ --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="dimmed">   4</tspan><tspan class="dimmed">   4</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- SYNC_RDME_INTEGRATION_TEST::SPAN_START --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>    </tspan><tspan>    </tspan><tspan>  </tspan><tspan> </tspan><tspan>  </tspan><tspan class="bg-black">███████████</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="dimmed">   5</tspan><tspan class="dimmed">    </tspan><tspan> │</tspan><tspan class="fg-red bold">-</tspan><tspan class="fg-red">* </tspan><tspan class="fg-red underline">NOT_UPDATED</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="dimmed">    </tspan><tspan class="dimmed">   5</tspan><tspan> │</tspan><tspan class="fg-green bold">+</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>    </tspan><tspan>    </tspan><tspan>  </tspan><tspan> </tspan><tspan>  </tspan><tspan class="bg-black">███████</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="dimmed">    </tspan><tspan class="dimmed">   6</tspan><tspan> │</tspan><tspan class="fg-green bold">+</tspan><tspan class="fg-green">* </tspan><tspan class="fg-green underline">UPDATED</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="dimmed">    </tspan><tspan class="dimmed">   7</tspan><tspan> │</tspan><tspan class="fg-green bold">+</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="dimmed">   6</tspan><tspan class="dimmed">   8</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- SYNC_RDME_INTEGRATION_TEST::SPAN_END --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="dimmed">   7</tspan><tspan class="dimmed">   9</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/fixtures/snapshots/check_output/root.stderr.term.svg
+++ b/tests/fixtures/snapshots/check_output/root.stderr.term.svg
@@ -1,8 +1,7 @@
-<svg width="740px" height="290px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
-    .bg-black { stroke: #000000; fill: #000000; user-select: none;  }
     .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
@@ -11,7 +10,6 @@
       line-height: 18px;
     }
     .bold { font-weight: bold; }
-    .underline { text-decoration-line: underline; }
     .dimmed { opacity: 0.4; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
@@ -29,33 +27,11 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-yellow"> WARN</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> markdown file is not up to date: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="dimmed">   2</tspan><tspan class="dimmed">   2</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan>
+    <tspan x="10px" y="82px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> markdown file for package `root` is not up to date: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="dimmed">   3</tspan><tspan class="dimmed">   3</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- cargo-sync-rdme rustdoc [[ --&gt;</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="dimmed">   4</tspan><tspan class="dimmed">   4</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- SYNC_RDME_INTEGRATION_TEST::SPAN_START --&gt;</tspan>
-</tspan>
-    <tspan x="10px" y="136px"><tspan>    </tspan><tspan>    </tspan><tspan>  </tspan><tspan> </tspan><tspan>  </tspan><tspan class="bg-black">███████████</tspan>
-</tspan>
-    <tspan x="10px" y="136px"><tspan class="dimmed">   5</tspan><tspan class="dimmed">    </tspan><tspan> │</tspan><tspan class="fg-red bold">-</tspan><tspan class="fg-red">* </tspan><tspan class="fg-red underline">NOT_UPDATED</tspan>
-</tspan>
-    <tspan x="10px" y="154px"><tspan class="dimmed">    </tspan><tspan class="dimmed">   5</tspan><tspan> │</tspan><tspan class="fg-green bold">+</tspan>
-</tspan>
-    <tspan x="10px" y="172px"><tspan>    </tspan><tspan>    </tspan><tspan>  </tspan><tspan> </tspan><tspan>  </tspan><tspan class="bg-black">███████</tspan>
-</tspan>
-    <tspan x="10px" y="172px"><tspan class="dimmed">    </tspan><tspan class="dimmed">   6</tspan><tspan> │</tspan><tspan class="fg-green bold">+</tspan><tspan class="fg-green">* </tspan><tspan class="fg-green underline">UPDATED</tspan>
-</tspan>
-    <tspan x="10px" y="190px"><tspan class="dimmed">    </tspan><tspan class="dimmed">   7</tspan><tspan> │</tspan><tspan class="fg-green bold">+</tspan>
-</tspan>
-    <tspan x="10px" y="208px"><tspan class="dimmed">   6</tspan><tspan class="dimmed">   8</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- SYNC_RDME_INTEGRATION_TEST::SPAN_END --&gt;</tspan>
-</tspan>
-    <tspan x="10px" y="226px"><tspan class="dimmed">   7</tspan><tspan class="dimmed">   9</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
-</tspan>
-    <tspan x="10px" y="244px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> markdown file for package `root` is not up to date: README.md</tspan>
-</tspan>
-    <tspan x="10px" y="262px">
-</tspan>
-    <tspan x="10px" y="280px">
+    <tspan x="10px" y="118px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/check_output/root.stdout.term.svg
+++ b/tests/fixtures/snapshots/check_output/root.stdout.term.svg
@@ -1,0 +1,51 @@
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .bg-black { stroke: #000000; fill: #000000; user-select: none;  }
+    .fg-green { fill: #00AA00 }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    .dimmed { opacity: 0.4; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="dimmed">   2</tspan><tspan class="dimmed">   2</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="dimmed">   3</tspan><tspan class="dimmed">   3</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- cargo-sync-rdme rustdoc [[ --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="dimmed">   4</tspan><tspan class="dimmed">   4</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- SYNC_RDME_INTEGRATION_TEST::SPAN_START --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>    </tspan><tspan>    </tspan><tspan>  </tspan><tspan> </tspan><tspan>  </tspan><tspan class="bg-black">███████████</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="dimmed">   5</tspan><tspan class="dimmed">    </tspan><tspan> │</tspan><tspan class="fg-red bold">-</tspan><tspan class="fg-red">* </tspan><tspan class="fg-red underline">NOT_UPDATED</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="dimmed">    </tspan><tspan class="dimmed">   5</tspan><tspan> │</tspan><tspan class="fg-green bold">+</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>    </tspan><tspan>    </tspan><tspan>  </tspan><tspan> </tspan><tspan>  </tspan><tspan class="bg-black">███████</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="dimmed">    </tspan><tspan class="dimmed">   6</tspan><tspan> │</tspan><tspan class="fg-green bold">+</tspan><tspan class="fg-green">* </tspan><tspan class="fg-green underline">UPDATED</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="dimmed">    </tspan><tspan class="dimmed">   7</tspan><tspan> │</tspan><tspan class="fg-green bold">+</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="dimmed">   6</tspan><tspan class="dimmed">   8</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- SYNC_RDME_INTEGRATION_TEST::SPAN_END --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="dimmed">   7</tspan><tspan class="dimmed">   9</tspan><tspan> │</tspan><tspan class="bold dimmed"> </tspan><tspan class="dimmed">&lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -76,7 +76,7 @@ fn check_output_matches_snapshot(#[case] package_name: &str) {
         .args(["-p", package_name, "--check"])
         .assert()
         .failure()
-        .stdout_eq("")
+        .stdout_eq(expected("check_output", &format!("{package_name}.stdout")))
         .stderr_eq(expected("check_output", &format!("{package_name}.stderr")));
 }
 


### PR DESCRIPTION
## Summary
- centralize stream and color handling in `src/terminal.rs`
- emit `--check` diffs on stdout instead of stderr
- keep diagnostics and log output on stderr
- update UI snapshots and changelog for the new stream layout

## Motivation
Diff output is the primary command result in `--check` mode, so sending it to stdout aligns the command with common CLI conventions and makes redirection/piping easier.

## Validation
- `cargo test --test ui`
- author reported `cargo test` passes
- author reported `cargo clippy` has zero findings

## User-visible impact
Users who consumed `--check` diffs from stderr will need to read stdout instead. Error diagnostics and log output remain on stderr.