### PR TITLE
Demote sync progress logs to debug

### DIFF
--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -167,7 +167,7 @@ pub(crate) fn sync_all(cx: &PackageSyncContext<'_>) -> Result<(), Box<SyncError>
     ensure!(!loaders.is_empty(), NoTargetFilesFoundSnafu { package: cx });
 
     for loader in loaders {
-        tracing::info!("syncing markdown file: {}", loader.workspace_path());
+        tracing::debug!("syncing markdown file: {}", loader.workspace_path());
 
         let mut markdown = loader
             .load()
@@ -178,7 +178,7 @@ pub(crate) fn sync_all(cx: &PackageSyncContext<'_>) -> Result<(), Box<SyncError>
 
         let all_markers = marker::parse_markers(cx, &markdown)?;
 
-        tracing::info!(
+        tracing::debug!(
             "creating replacement contents for markdown file: {}",
             loader.workspace_path()
         );
@@ -188,10 +188,7 @@ pub(crate) fn sync_all(cx: &PackageSyncContext<'_>) -> Result<(), Box<SyncError>
 
         let changed = new_text.as_str() != markdown.text();
         if !changed {
-            tracing::info!(
-                "markdown file is already up to date: {}",
-                loader.workspace_path()
-            );
+            tracing::debug!("markdown file is up to date: {}", loader.workspace_path());
             continue;
         }
 

--- a/tests/fixtures/snapshots/check_output/pkg-a.stderr.term.svg
+++ b/tests/fixtures/snapshots/check_output/pkg-a.stderr.term.svg
@@ -1,8 +1,7 @@
-<svg width="740px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
-    .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
     .container {
@@ -21,17 +20,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: pkg-a/README.md</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-yellow"> WARN</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> markdown file is not up to date: pkg-a/README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: pkg-a/README.md</tspan>
+    <tspan x="10px" y="46px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> markdown file for package `pkg-a` is not up to date: pkg-a/README.md</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-yellow"> WARN</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> markdown file is not up to date: pkg-a/README.md</tspan>
+    <tspan x="10px" y="64px">
 </tspan>
-    <tspan x="10px" y="82px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> markdown file for package `pkg-a` is not up to date: pkg-a/README.md</tspan>
-</tspan>
-    <tspan x="10px" y="100px">
-</tspan>
-    <tspan x="10px" y="118px">
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/check_output/root.stderr.term.svg
+++ b/tests/fixtures/snapshots/check_output/root.stderr.term.svg
@@ -1,8 +1,7 @@
-<svg width="740px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
-    .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
     .container {
@@ -21,17 +20,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-yellow"> WARN</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> markdown file is not up to date: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
+    <tspan x="10px" y="46px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> markdown file for package `root` is not up to date: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-yellow"> WARN</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> markdown file is not up to date: README.md</tspan>
+    <tspan x="10px" y="64px">
 </tspan>
-    <tspan x="10px" y="82px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> markdown file for package `root` is not up to date: README.md</tspan>
-</tspan>
-    <tspan x="10px" y="100px">
-</tspan>
-    <tspan x="10px" y="118px">
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/marker_parse_error/pkg-a.extra.stderr.term.svg
+++ b/tests/fixtures/snapshots/marker_parse_error/pkg-a.extra.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="830px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="776px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -23,95 +23,89 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: pkg-a/README.md</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: pkg-a/README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: pkg-a/README.md</tspan>
+    <tspan x="10px" y="46px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse `&lt;!-- cargo-sync-rdme ... --&gt;` markers in markdown file</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: pkg-a/README.md</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> for package `pkg-a`: pkg-a/doc/extra.md</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: pkg-a/doc/extra.md</tspan>
+    <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse `&lt;!-- cargo-sync-rdme ... --&gt;` markers in markdown file</tspan>
+    <tspan x="10px" y="100px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> for package `pkg-a`: pkg-a/doc/extra.md</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unexpected end of marker, expected: marker kind or `]]`</tspan>
 </tspan>
-    <tspan x="10px" y="136px">
+    <tspan x="10px" y="136px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:8:21</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>Error: </tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unexpected end of marker, expected: marker kind or `]]`</tspan>
+    <tspan x="10px" y="172px"><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:8:21</tspan><tspan>]</tspan>
+    <tspan x="10px" y="190px"><tspan>   · </tspan><tspan class="fg-magenta bold">                    ▲</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
+    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed">9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="226px"><tspan>   ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>   · </tspan><tspan class="fg-magenta bold">                    ▲</tspan>
+    <tspan x="10px" y="244px">
 </tspan>
-    <tspan x="10px" y="262px"><tspan> </tspan><tspan class="dimmed">9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="262px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>   ╰────</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
 </tspan>
-    <tspan x="10px" y="298px">
+    <tspan x="10px" y="298px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:9:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>Error: </tspan>
+    <tspan x="10px" y="316px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
+    <tspan x="10px" y="334px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:9:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="352px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="370px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="388px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+    <tspan x="10px" y="424px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
 </tspan>
-    <tspan x="10px" y="460px">
+    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>Error: </tspan>
+    <tspan x="10px" y="478px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:12:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
+    <tspan x="10px" y="496px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
+    <tspan x="10px" y="514px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:12:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="532px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
+    <tspan x="10px" y="550px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="568px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
+    <tspan x="10px" y="586px">
 </tspan>
-    <tspan x="10px" y="604px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="604px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="622px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
 </tspan>
-    <tspan x="10px" y="640px">
+    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>Error: </tspan>
+    <tspan x="10px" y="658px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:13:28</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
+    <tspan x="10px" y="676px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
+    <tspan x="10px" y="694px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/doc/extra.md:13:28</tspan><tspan>]</tspan>
+    <tspan x="10px" y="712px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="730px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="748px">
 </tspan>
-    <tspan x="10px" y="766px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
-</tspan>
-    <tspan x="10px" y="784px"><tspan>    ╰────</tspan>
-</tspan>
-    <tspan x="10px" y="802px">
-</tspan>
-    <tspan x="10px" y="820px">
+    <tspan x="10px" y="766px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/marker_parse_error/pkg-a.readme.stderr.term.svg
+++ b/tests/fixtures/snapshots/marker_parse_error/pkg-a.readme.stderr.term.svg
@@ -1,9 +1,8 @@
-<svg width="740px" height="776px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="758px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .fg-magenta { fill: #AA00AA }
     .fg-red { fill: #AA0000 }
     .container {
@@ -23,89 +22,87 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: pkg-a/README.md</tspan>
+    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse `&lt;!-- cargo-sync-rdme ... --&gt;` markers in markdown file</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse `&lt;!-- cargo-sync-rdme ... --&gt;` markers in markdown file</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> for package `pkg-a`: pkg-a/README.md</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> for package `pkg-a`: pkg-a/README.md</tspan>
+    <tspan x="10px" y="64px">
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Error: </tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unexpected end of marker, expected: marker kind or `]]`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unexpected end of marker, expected: marker kind or `]]`</tspan>
+    <tspan x="10px" y="118px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:8:21</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:8:21</tspan><tspan>]</tspan>
+    <tspan x="10px" y="136px"><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="172px"><tspan>   · </tspan><tspan class="fg-magenta bold">                    ▲</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>   · </tspan><tspan class="fg-magenta bold">                    ▲</tspan>
+    <tspan x="10px" y="190px"><tspan> </tspan><tspan class="dimmed">9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed">9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="208px"><tspan>   ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>   ╰────</tspan>
+    <tspan x="10px" y="226px">
 </tspan>
-    <tspan x="10px" y="244px">
+    <tspan x="10px" y="244px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>Error: </tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
+    <tspan x="10px" y="280px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:9:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:9:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="298px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="316px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="334px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
+    <tspan x="10px" y="352px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+    <tspan x="10px" y="370px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px">
+    <tspan x="10px" y="406px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>Error: </tspan>
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
+    <tspan x="10px" y="460px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:12:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:12:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="478px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
+    <tspan x="10px" y="496px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="514px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
+    <tspan x="10px" y="532px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="550px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px">
+    <tspan x="10px" y="586px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>Error: </tspan>
+    <tspan x="10px" y="604px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
+    <tspan x="10px" y="622px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
+    <tspan x="10px" y="640px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:13:28</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">pkg-a/README.md:13:28</tspan><tspan>]</tspan>
+    <tspan x="10px" y="658px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="676px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="694px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
+    <tspan x="10px" y="712px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="730px">
 </tspan>
     <tspan x="10px" y="748px">
-</tspan>
-    <tspan x="10px" y="766px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/marker_parse_error/root.extra.stderr.term.svg
+++ b/tests/fixtures/snapshots/marker_parse_error/root.extra.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="830px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="776px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -23,95 +23,89 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
+    <tspan x="10px" y="46px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse `&lt;!-- cargo-sync-rdme ... --&gt;` markers in markdown file</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> for package `root`: doc/extra.md</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: doc/extra.md</tspan>
+    <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse `&lt;!-- cargo-sync-rdme ... --&gt;` markers in markdown file</tspan>
+    <tspan x="10px" y="100px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> for package `root`: doc/extra.md</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unexpected end of marker, expected: marker kind or `]]`</tspan>
 </tspan>
-    <tspan x="10px" y="136px">
+    <tspan x="10px" y="136px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:8:21</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>Error: </tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unexpected end of marker, expected: marker kind or `]]`</tspan>
+    <tspan x="10px" y="172px"><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:8:21</tspan><tspan>]</tspan>
+    <tspan x="10px" y="190px"><tspan>   · </tspan><tspan class="fg-magenta bold">                    ▲</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
+    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed">9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="226px"><tspan>   ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>   · </tspan><tspan class="fg-magenta bold">                    ▲</tspan>
+    <tspan x="10px" y="244px">
 </tspan>
-    <tspan x="10px" y="262px"><tspan> </tspan><tspan class="dimmed">9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="262px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>   ╰────</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
 </tspan>
-    <tspan x="10px" y="298px">
+    <tspan x="10px" y="298px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:9:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>Error: </tspan>
+    <tspan x="10px" y="316px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
+    <tspan x="10px" y="334px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:9:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="352px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="370px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="388px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+    <tspan x="10px" y="424px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
 </tspan>
-    <tspan x="10px" y="460px">
+    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>Error: </tspan>
+    <tspan x="10px" y="478px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:12:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
+    <tspan x="10px" y="496px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
+    <tspan x="10px" y="514px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:12:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="532px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
+    <tspan x="10px" y="550px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="568px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
+    <tspan x="10px" y="586px">
 </tspan>
-    <tspan x="10px" y="604px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="604px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="622px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
 </tspan>
-    <tspan x="10px" y="640px">
+    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>Error: </tspan>
+    <tspan x="10px" y="658px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:13:28</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
+    <tspan x="10px" y="676px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
+    <tspan x="10px" y="694px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">doc/extra.md:13:28</tspan><tspan>]</tspan>
+    <tspan x="10px" y="712px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="730px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="748px">
 </tspan>
-    <tspan x="10px" y="766px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
-</tspan>
-    <tspan x="10px" y="784px"><tspan>    ╰────</tspan>
-</tspan>
-    <tspan x="10px" y="802px">
-</tspan>
-    <tspan x="10px" y="820px">
+    <tspan x="10px" y="766px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/marker_parse_error/root.readme.stderr.term.svg
+++ b/tests/fixtures/snapshots/marker_parse_error/root.readme.stderr.term.svg
@@ -1,9 +1,8 @@
-<svg width="740px" height="776px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="758px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .fg-magenta { fill: #AA00AA }
     .fg-red { fill: #AA0000 }
     .container {
@@ -23,89 +22,87 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
+    <tspan x="10px" y="28px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse `&lt;!-- cargo-sync-rdme ... --&gt;` markers in markdown file</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>Error:   </tspan><tspan class="fg-red">×</tspan><tspan> failed to parse `&lt;!-- cargo-sync-rdme ... --&gt;` markers in markdown file</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> for package `root`: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> for package `root`: README.md</tspan>
+    <tspan x="10px" y="64px">
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Error: </tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unexpected end of marker, expected: marker kind or `]]`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unexpected end of marker, expected: marker kind or `]]`</tspan>
+    <tspan x="10px" y="118px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:8:21</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>   ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:8:21</tspan><tspan>]</tspan>
+    <tspan x="10px" y="136px"><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">7</tspan><tspan> │ &lt;!-- cargo-sync-rdme ]] --&gt;</tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan> </tspan><tspan class="dimmed">8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="172px"><tspan>   · </tspan><tspan class="fg-magenta bold">                    ▲</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>   · </tspan><tspan class="fg-magenta bold">                    ▲</tspan>
+    <tspan x="10px" y="190px"><tspan> </tspan><tspan class="dimmed">9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan> </tspan><tspan class="dimmed">9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="208px"><tspan>   ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>   ╰────</tspan>
+    <tspan x="10px" y="226px">
 </tspan>
-    <tspan x="10px" y="244px">
+    <tspan x="10px" y="244px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>Error: </tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> unknown marker kind: unknown-specifier</tspan>
+    <tspan x="10px" y="280px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:9:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:9:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="298px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan> </tspan><tspan class="dimmed"> 8</tspan><tspan> │ &lt;!-- cargo-sync-rdme --&gt;</tspan>
+    <tspan x="10px" y="316px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan> </tspan><tspan class="dimmed"> 9</tspan><tspan> │ &lt;!-- cargo-sync-rdme unknown-specifier --&gt;</tspan>
+    <tspan x="10px" y="334px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────────────────</tspan>
+    <tspan x="10px" y="352px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan> </tspan><tspan class="dimmed">10</tspan><tspan> │ &lt;!-- cargo-sync-rdme title --&gt;</tspan>
+    <tspan x="10px" y="370px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px">
+    <tspan x="10px" y="406px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>Error: </tspan>
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> default badge group is not configured in the package manifest:</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> package.metadata.cargo-sync-rdme.badge.badges</tspan>
+    <tspan x="10px" y="460px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:12:22</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:12:22</tspan><tspan>]</tspan>
+    <tspan x="10px" y="478px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan> </tspan><tspan class="dimmed">11</tspan><tspan> │ &lt;!-- cargo-sync-rdme rustdoc --&gt;</tspan>
+    <tspan x="10px" y="496px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="514px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    · </tspan><tspan class="fg-magenta bold">                     ─────</tspan>
+    <tspan x="10px" y="532px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="550px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px">
+    <tspan x="10px" y="586px"><tspan>Error: </tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>Error: </tspan>
+    <tspan x="10px" y="604px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> badge group not found in the package manifest: package.metadata.cargo-</tspan>
+    <tspan x="10px" y="622px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> sync-rdme.badge.badges-invalid-group</tspan>
+    <tspan x="10px" y="640px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:13:28</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>    ╭─[</tspan><tspan class="fg-cyan underline bold">README.md:13:28</tspan><tspan>]</tspan>
+    <tspan x="10px" y="658px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan> </tspan><tspan class="dimmed">12</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge --&gt;</tspan>
+    <tspan x="10px" y="676px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan> </tspan><tspan class="dimmed">13</tspan><tspan> │ &lt;!-- cargo-sync-rdme badge:invalid-group --&gt;</tspan>
+    <tspan x="10px" y="694px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>    · </tspan><tspan class="fg-magenta bold">                           ─────────────</tspan>
+    <tspan x="10px" y="712px"><tspan>    ╰────</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>    ╰────</tspan>
+    <tspan x="10px" y="730px">
 </tspan>
     <tspan x="10px" y="748px">
-</tspan>
-    <tspan x="10px" y="766px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/sync_output/pkg-a.stderr.term.svg
+++ b/tests/fixtures/snapshots/sync_output/pkg-a.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="743px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -19,19 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: pkg-a/README.md</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: pkg-a/README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: pkg-a/README.md</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: pkg-a/doc/extra.md</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: pkg-a/README.md</tspan>
-</tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: pkg-a/doc/extra.md</tspan>
-</tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: pkg-a/doc/extra.md</tspan>
-</tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>pkg-a</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: pkg-a/doc/extra.md</tspan>
-</tspan>
-    <tspan x="10px" y="136px">
+    <tspan x="10px" y="64px">
 </tspan>
   </text>
 

--- a/tests/fixtures/snapshots/sync_output/root.stderr.term.svg
+++ b/tests/fixtures/snapshots/sync_output/root.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -19,19 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: README.md</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: README.md</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: doc/extra.md</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: README.md</tspan>
-</tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> syncing markdown file: doc/extra.md</tspan>
-</tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> creating replacement contents for markdown file: doc/extra.md</tspan>
-</tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green"> INFO</tspan><tspan> </tspan><tspan class="bold">sync</tspan><tspan class="bold">{</tspan><tspan>root</tspan><tspan class="bold">}</tspan><tspan class="dimmed">:</tspan><tspan> updated markdown file: doc/extra.md</tspan>
-</tspan>
-    <tspan x="10px" y="136px">
+    <tspan x="10px" y="64px">
 </tspan>
   </text>
 


### PR DESCRIPTION
## Summary
- demote per-file sync progress logs from `INFO` to `DEBUG`
- keep user-visible `INFO` output focused on actual file updates
- refresh CLI output snapshots to match the new log levels

## Motivation
The previous output logged intermediate per-file steps at `INFO`, which made normal runs noisier than necessary. This change keeps `INFO` for meaningful outcomes while preserving the detailed trace at higher verbosity.

## Validation
- `cargo test --test ui`

## User-visible impact
- normal output is shorter during sync and check flows
- detailed per-file progress remains available with `-v`

## Risk
Low. This change only adjusts log levels and the corresponding snapshot expectations.