### PR TITLE
Replace layered vector values

### DIFF
--- a/src/config/badge/item.rs
+++ b/src/config/badge/item.rs
@@ -212,8 +212,8 @@ impl ApplyLayer for License {
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct GithubActions {
-    #[serde(default, deserialize_with = "de::string_or_map_or_seq")]
-    pub(crate) workflows: Vec<GithubActionsWorkflow>,
+    #[serde(default, deserialize_with = "de::string_or_map_or_seq_opt")]
+    pub(crate) workflows: Option<Vec<GithubActionsWorkflow>>,
 }
 
 impl ApplyLayer for GithubActions {
@@ -287,7 +287,7 @@ mod tests {
         S: Into<Vec<GithubActionsWorkflow>>,
     {
         GithubActions {
-            workflows: workflows.into(),
+            workflows: Some(workflows.into()),
         }
     }
 
@@ -323,7 +323,7 @@ mod tests {
     }
 
     #[test]
-    fn github_actions_apply_layer_appends_workflows_in_order() {
+    fn github_actions_apply_layer_replaces_workflows_when_specified() {
         let mut target = github_actions([
             workflow(Some("target 1"), "target-1.yaml"),
             workflow(None, "target-2.yaml"),
@@ -338,12 +338,27 @@ mod tests {
         assert_eq!(
             target,
             github_actions([
-                workflow(Some("target 1"), "target-1.yaml"),
-                workflow(None, "target-2.yaml"),
                 workflow(None, "layer-1.yaml"),
                 workflow(Some("layer 2"), "layer-2.yaml"),
             ]),
         );
+    }
+
+    #[test]
+    fn github_actions_apply_layer_keeps_or_clears_workflows_based_on_layer_value() {
+        let mut target = github_actions([workflow(None, "target.yaml")]);
+        let layer = GithubActions { workflows: None };
+
+        target.apply_layer(&layer);
+
+        assert_eq!(target, github_actions([workflow(None, "target.yaml")]));
+
+        let mut target = github_actions([workflow(None, "target.yaml")]);
+        let layer = github_actions([]);
+
+        target.apply_layer(&layer);
+
+        assert_eq!(target, github_actions([]));
     }
 
     #[test]
@@ -370,7 +385,7 @@ mod tests {
     }
 
     #[test]
-    fn badge_item_apply_layer_merges_same_variant_values() {
+    fn badge_item_apply_layer_applies_nested_github_actions_layer() {
         let mut target = BadgeItem::GithubActions(github_actions([workflow(None, "target.yaml")]));
         let layer = BadgeItem::GithubActions(github_actions([workflow(None, "layer.yaml")]));
 
@@ -378,10 +393,7 @@ mod tests {
 
         assert_eq!(
             target,
-            BadgeItem::GithubActions(github_actions([
-                workflow(None, "target.yaml"),
-                workflow(None, "layer.yaml")
-            ])),
+            BadgeItem::GithubActions(github_actions([workflow(None, "layer.yaml")])),
         );
     }
 
@@ -623,7 +635,7 @@ mod tests {
             [
                 (
                     BadgeItemKey::GithubActions(None),
-                    Inheritable::Value(BadgeItem::GithubActions(github_actions([]))),
+                    Inheritable::Value(BadgeItem::GithubActions(GithubActions { workflows: None })),
                 ),
                 (
                     BadgeItemKey::GithubActions(Some("x".to_owned())),

--- a/src/config/de.rs
+++ b/src/config/de.rs
@@ -50,14 +50,17 @@ where
     Ok(map)
 }
 
-pub(in crate::config) fn string_or_seq<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+pub(in crate::config) fn string_or_seq_opt<'de, T, D>(
+    deserializer: D,
+) -> Result<Option<Vec<T>>, D::Error>
 where
     T: Deserialize<'de>,
     D: Deserializer<'de>,
 {
-    struct StringOrSeq<T>(PhantomData<T>);
+    struct StringOrSeq<T>(Vec<T>);
+    struct StringOrSeqVisitor<T>(PhantomData<T>);
 
-    impl<'de, T> Visitor<'de> for StringOrSeq<T>
+    impl<'de, T> Visitor<'de> for StringOrSeqVisitor<T>
     where
         T: Deserialize<'de>,
     {
@@ -86,20 +89,34 @@ where
         }
     }
 
-    let seq = deserializer.deserialize_any(StringOrSeq(PhantomData))?;
-    Ok(seq)
+    impl<'de, T> Deserialize<'de> for StringOrSeq<T>
+    where
+        T: Deserialize<'de>,
+    {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let values = deserializer.deserialize_any(StringOrSeqVisitor(PhantomData))?;
+            Ok(Self(values))
+        }
+    }
+
+    let map = <Option<StringOrSeq<T>>>::deserialize(deserializer)?;
+    Ok(map.map(|v| v.0))
 }
 
-pub(in crate::config) fn string_or_map_or_seq<'de, T, D>(
+pub(in crate::config) fn string_or_map_or_seq_opt<'de, T, D>(
     deserializer: D,
-) -> Result<Vec<T>, D::Error>
+) -> Result<Option<Vec<T>>, D::Error>
 where
     T: Deserialize<'de> + FromStr<Err = Void>,
     D: Deserializer<'de>,
 {
-    struct StringOrMapOrSeq<T>(PhantomData<T>);
+    struct StringOrMapOrSeqVisitor<T>(PhantomData<T>);
+    struct StringOrMapOrSeq<T>(Vec<T>);
 
-    impl<'de, T> Visitor<'de> for StringOrMapOrSeq<T>
+    impl<'de, T> Visitor<'de> for StringOrMapOrSeqVisitor<T>
     where
         T: Deserialize<'de> + FromStr<Err = Void>,
     {
@@ -149,8 +166,21 @@ where
         }
     }
 
-    let map = deserializer.deserialize_any(StringOrMapOrSeq(PhantomData))?;
-    Ok(map)
+    impl<'de, T> Deserialize<'de> for StringOrMapOrSeq<T>
+    where
+        T: Deserialize<'de> + FromStr<Err = Void>,
+    {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let values = deserializer.deserialize_any(StringOrMapOrSeqVisitor(PhantomData))?;
+            Ok(Self(values))
+        }
+    }
+
+    let map = <Option<StringOrMapOrSeq<T>>>::deserialize(deserializer)?;
+    Ok(map.map(|v| v.0))
 }
 
 pub(in crate::config) fn string_or_map<'de, T, D>(deserializer: D) -> Result<T, D::Error>
@@ -226,12 +256,12 @@ fn normalize_path(path: &Utf8Path) -> Utf8PathBuf {
     components.collect()
 }
 
-pub(crate) fn string_or_seq_of_path_from_source<'de, D>(
+pub(crate) fn string_or_seq_opt_of_path_from_source<'de, D>(
     deserializer: D,
-) -> Result<Vec<Utf8PathBuf>, D::Error>
+) -> Result<Option<Vec<Utf8PathBuf>>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let seq = string_or_seq::<PathFromSource, _>(deserializer)?;
-    Ok(seq.into_iter().map(|p| p.0).collect())
+    let seq = string_or_seq_opt::<PathFromSource, _>(deserializer)?;
+    Ok(seq.map(|v| v.into_iter().map(|p| p.0).collect()))
 }

--- a/src/config/layer.rs
+++ b/src/config/layer.rs
@@ -24,7 +24,7 @@ where
     T: Clone,
 {
     fn apply_layer(&mut self, layer: &Self) {
-        self.extend(layer.iter().cloned());
+        self.clone_from(layer);
     }
 }
 
@@ -91,8 +91,8 @@ mod tests {
 
     impl ApplyLayer for ScalarAndSequence {
         fn apply_layer(&mut self, layer: &Self) {
-            self.scalar.apply_layer(&layer.scalar);
-            self.sequence.apply_layer(&layer.sequence);
+            self.scalar.clone_from(&layer.scalar);
+            self.sequence.extend(&layer.sequence);
         }
     }
 
@@ -107,13 +107,13 @@ mod tests {
     }
 
     #[test]
-    fn vec_apply_layer_appends_items_in_order() {
+    fn vec_apply_layer_replaces_target_value() {
         let mut sequence = vec!["target-1", "target-2"];
         let layer_sequence = vec!["layer-1", "layer-2"];
 
         sequence.apply_layer(&layer_sequence);
 
-        assert_eq!(sequence, vec!["target-1", "target-2", "layer-1", "layer-2"]);
+        assert_eq!(sequence, vec!["layer-1", "layer-2"]);
     }
 
     #[test]
@@ -142,14 +142,17 @@ mod tests {
     #[test]
     fn index_map_apply_layer_updates_values_without_reordering_keys() {
         let mut target = IndexMap::from([
-            ("updated", ScalarAndSequence::new("from target", ["target"])),
+            (
+                "replaced",
+                ScalarAndSequence::new("from target", ["target"]),
+            ),
             (
                 "untouched",
                 ScalarAndSequence::new("keep target", ["keep target"]),
             ),
         ]);
         let layer = IndexMap::from([
-            ("updated", ScalarAndSequence::new("from layer", ["layer"])),
+            ("replaced", ScalarAndSequence::new("from layer", ["layer"])),
             (
                 "inserted",
                 ScalarAndSequence::new("only in layer", ["only in layer"]),
@@ -157,12 +160,11 @@ mod tests {
         ]);
 
         target.apply_layer(&layer);
-
         testing::assert_indexmap_eq(
             &target,
             [
                 (
-                    "updated",
+                    "replaced",
                     ScalarAndSequence::new("from layer", ["target", "layer"]),
                 ),
                 (

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -281,11 +281,8 @@ mod tests {
         } = config;
 
         assert_eq!(
-            extra_targets,
-            [
-                "/path/to/workspace/docs/workspace.md",
-                "/path/to/workspace/member/docs/package.md",
-            ]
+            extra_targets.unwrap(),
+            ["/path/to/workspace/member/docs/package.md"]
         );
         assert_eq!(badge.style, Some(BadgeStyle::FlatSquare));
         testing::assert_indexmap_eq(
@@ -351,11 +348,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            config.extra_targets,
-            [
-                "/path/to/workspace/docs/workspace.md",
-                "/path/to/workspace/docs/package.md"
-            ]
+            config.extra_targets.unwrap(),
+            ["/path/to/workspace/docs/package.md"]
         );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,8 +16,11 @@ mod testing;
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct Config {
-    #[serde(default, deserialize_with = "de::string_or_seq_of_path_from_source")]
-    pub(crate) extra_targets: Vec<Utf8PathBuf>,
+    #[serde(
+        default,
+        deserialize_with = "de::string_or_seq_opt_of_path_from_source"
+    )]
+    pub(crate) extra_targets: Option<Vec<Utf8PathBuf>>,
     #[serde(default)]
     pub(crate) badge: Badge,
     #[serde(default)]
@@ -104,13 +107,16 @@ mod tests {
         "#});
 
         let config = manifest.package_config().unwrap().unwrap();
-        assert_eq!(config.extra_targets, ["/path/to/workspace/docs/target.md"]);
+        assert_eq!(
+            config.extra_targets.unwrap(),
+            ["/path/to/workspace/docs/target.md"]
+        );
     }
 
     #[test]
     fn config_apply_layer_updates_extra_targets_badge_and_rustdoc() {
         let mut target = Config {
-            extra_targets: vec!["./docs/target.md".into()],
+            extra_targets: Some(vec!["./docs/target.md".into()]),
             badge: Badge {
                 style: Some(BadgeStyle::Flat),
                 ..Badge::default()
@@ -125,7 +131,7 @@ mod tests {
             },
         };
         let layer = Config {
-            extra_targets: vec!["./docs/layer.md".into()],
+            extra_targets: Some(vec!["./docs/layer.md".into()]),
             badge: Badge {
                 style: Some(BadgeStyle::FlatSquare),
                 ..Badge::default()
@@ -145,7 +151,7 @@ mod tests {
         assert_eq!(
             target,
             Config {
-                extra_targets: vec!["./docs/target.md".into(), "./docs/layer.md".into()],
+                extra_targets: Some(vec!["./docs/layer.md".into()]),
                 badge: Badge {
                     style: Some(BadgeStyle::FlatSquare),
                     default: None,
@@ -167,6 +173,22 @@ mod tests {
                 },
             }
         );
+    }
+
+    #[test]
+    fn config_apply_layer_replaces_extra_targets_with_empty_list() {
+        let mut target = Config {
+            extra_targets: Some(vec!["./docs/target.md".into()]),
+            ..Config::default()
+        };
+        let layer = Config {
+            extra_targets: Some(vec![]),
+            ..Config::default()
+        };
+
+        target.apply_layer(&layer);
+
+        assert_eq!(target.extra_targets, Some(vec![]));
     }
 
     #[test]

--- a/src/sync/contents/badge.rs
+++ b/src/sync/contents/badge.rs
@@ -396,10 +396,12 @@ impl BadgeLink {
             .strip_prefix("https://github.com/")
             .context(InvalidGithubRepositorySnafu)?;
 
-        let results = if github_actions.workflows.is_empty() {
-            Self::github_actions_from_directory(cx)?
+        let results = if let Some(workflows) = &github_actions.workflows
+            && !workflows.is_empty()
+        {
+            Self::github_actions_from_config(cx, workflows)
         } else {
-            Self::github_actions_from_config(cx, &github_actions.workflows)
+            Self::github_actions_from_directory(cx)?
         };
 
         let results = results

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -234,6 +234,7 @@ fn package_target_files(cx: &PackageSyncContext<'_>) -> Vec<SourceFileLoader> {
         cx.config
             .extra_targets
             .iter()
+            .flatten()
             .map(|path| SourceFileLoader::from_path(cx.workspace, path)),
     );
     paths

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use indexmap::IndexMap;
 use similar_asserts::assert_eq;
 
@@ -5,8 +7,8 @@ use similar_asserts::assert_eq;
 pub(crate) fn assert_indexmap_eq<K, V, I>(actual: &IndexMap<K, V>, expected: I)
 where
     I: IntoIterator<Item = (K, V)>,
-    K: Clone + PartialEq,
-    V: Clone + PartialEq,
+    K: Clone + PartialEq + Debug,
+    V: Clone + PartialEq + Debug,
 {
     let actual = actual
         .iter()

--- a/tests/workspace_metadata.rs
+++ b/tests/workspace_metadata.rs
@@ -21,7 +21,6 @@ fn workspace_metadata_applies_to_package_and_resolves_relative_extra_targets() {
     let fixture_dir = helper::package_fixtures_dir().join(fixture_name);
 
     for (relative_path, title) in [
-        ("docs/workspace.md", "workspace extra"),
         ("pkg-a/docs/package.md", "pkg-a extra"),
         ("pkg-a/README.md", "pkg-a"),
     ] {
@@ -33,14 +32,16 @@ fn workspace_metadata_applies_to_package_and_resolves_relative_extra_targets() {
                 <!-- cargo-sync-rdme badge [[ -->
                 [![crates.io](https://img.shields.io/crates/v/pkg-a.svg?logo=rust&style=for-the-badge)](https://crates.io/crates/pkg-a)
                 <!-- cargo-sync-rdme ]] -->
-            "}
+            "},
+            "content mismatch: {relative_path}",
         );
     }
 
-    for relative_path in ["pkg-b/README.md", "README.md"] {
+    for relative_path in ["docs/workspace.md", "pkg-b/README.md", "README.md"] {
         assert_eq!(
             fs::read_to_string(workspace_dir.join(relative_path)).unwrap(),
-            fs::read_to_string(fixture_dir.join(relative_path)).unwrap()
+            fs::read_to_string(fixture_dir.join(relative_path)).unwrap(),
+            "content mismatch: {relative_path}",
         );
     }
 }


### PR DESCRIPTION
## Summary
- change layered `Vec` application to replace the target value instead of appending
- represent layered vector-backed config fields as `Option<Vec<_>>` so unspecified values still inherit while explicit empty lists clear the inherited value
- update `extra-targets` and GitHub Actions badge workflow handling and adjust focused tests accordingly

## Motivation
Layered vector fields now follow the same override-oriented behavior as the rest of the configuration model. This also lets package-level config explicitly replace or clear workspace-level defaults when needed.

## Validation
- `cargo test --quiet`

## Notes
- `docs/configuration.md` and `CHANGELOG.md` were left unchanged intentionally because this is unreleased workspace-layering behavior and the fine-grained override semantics are considered implementation detail for now.